### PR TITLE
feat(mcp): 集成 Horizon MCP 服务并增强 AI 输出兼容性

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,19 @@ Horizon works great as a **GitHub Actions** cron job. See [`.github/workflows/da
 | **Telegram** | Public channel messages | — |
 | **GitHub** | User events & repo releases | — |
 
+## MCP Integration
+
+Horizon ships with a built-in [MCP](https://modelcontextprotocol.io/) server so AI assistants can drive the pipeline programmatically.
+
+```bash
+# Start the MCP server (stdio mode)
+uv run horizon-mcp
+```
+
+Available tools include `hz_validate_config`, `hz_fetch_items`, `hz_score_items`, `hz_filter_items`, `hz_enrich_items`, `hz_generate_summary`, and `hz_run_pipeline`.
+
+See [`src/mcp/README.md`](src/mcp/README.md) for the full tool reference and [`src/mcp/integration.md`](src/mcp/integration.md) for client setup.
+
 ## Roadmap
 
 - [x] Multi-source aggregation (HN, RSS, Reddit, Telegram, GitHub)

--- a/README_zh.md
+++ b/README_zh.md
@@ -199,6 +199,19 @@ Horizon 非常适合作为 **GitHub Actions** 定时任务运行。查看 [`.git
 | **Telegram** | 公开频道消息 | — |
 | **GitHub** | 用户动态 & 仓库 Release | — |
 
+## MCP 集成
+
+Horizon 内置了 [MCP](https://modelcontextprotocol.io/) Server，AI 助手可以直接通过它驱动抓取、打分、过滤、富化和摘要流程。
+
+```bash
+# 启动 MCP Server（stdio 模式）
+uv run horizon-mcp
+```
+
+可用工具包括 `hz_validate_config`、`hz_fetch_items`、`hz_score_items`、`hz_filter_items`、`hz_enrich_items`、`hz_generate_summary` 和 `hz_run_pipeline`。
+
+完整工具说明见 [`src/mcp/README.md`](src/mcp/README.md)，客户端接入见 [`src/mcp/integration.md`](src/mcp/integration.md)。
+
 ## 路线图
 
 - [x] 多源聚合（HN、RSS、Reddit、Telegram、GitHub）

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,18 @@ dependencies = [
     "ddgs>=7.0.0",
     "beautifulsoup4>=4.12.0",
     "markdown>=3.10.2",
+    "mcp>=1.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-cov>=5.0.0",
 ]
 
 [project.scripts]
 horizon = "src.main:main"
+horizon-mcp = "src.mcp.server:main"
 
 [build-system]
 requires = ["hatchling"]
@@ -29,3 +37,8 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+addopts = "-q"
+testpaths = ["tests"]

--- a/scripts/check_mcp.py
+++ b/scripts/check_mcp.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Local smoke check for Horizon MCP integration."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from src.mcp.horizon_adapter import resolve_horizon_path
+from src.mcp.server import hz_get_metrics
+from src.mcp.service import HorizonPipelineService
+
+
+async def _main() -> None:
+    horizon_path = resolve_horizon_path()
+    service = HorizonPipelineService()
+    validation = await service.validate_config(
+        horizon_path=str(horizon_path),
+        check_env=False,
+    )
+    metrics = hz_get_metrics()
+
+    payload = {
+        "ok": True,
+        "horizon_path": str(horizon_path),
+        "config_path": validation["config_path"],
+        "enabled_sources": validation["enabled_sources"],
+        "languages": validation["ai"]["languages"],
+        "metrics_ok": metrics["ok"],
+        "metrics_tool": metrics["tool"],
+    }
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/src/ai/analyzer.py
+++ b/src/ai/analyzer.py
@@ -1,7 +1,8 @@
 """Content analysis using AI."""
 
 import json
-from typing import List
+import re
+from typing import Any, List
 from tenacity import retry, stop_after_attempt, wait_exponential
 from rich.progress import Progress, SpinnerColumn, BarColumn, TextColumn, MofNCompleteColumn
 
@@ -119,22 +120,89 @@ class ContentAnalyzer:
             temperature=0.3
         )
 
-        # Parse JSON response
-        try:
-            result = json.loads(response)
-        except json.JSONDecodeError:
-            # Try to extract JSON from markdown code block
-            if "```json" in response:
-                json_str = response.split("```json")[1].split("```")[0].strip()
-                result = json.loads(json_str)
-            elif "```" in response:
-                json_str = response.split("```")[1].split("```")[0].strip()
-                result = json.loads(json_str)
-            else:
-                raise ValueError(f"Invalid JSON response: {response}")
+        result = self._parse_json_response(response)
 
         # Update item with analysis results
-        item.ai_score = float(result.get("score", 0))
-        item.ai_reason = result.get("reason", "")
-        item.ai_summary = result.get("summary", item.title)
-        item.ai_tags = result.get("tags", [])
+        item.ai_score = self._normalize_score(result.get("score", 0))
+        item.ai_reason = self._normalize_text(result.get("reason", ""))
+        item.ai_summary = self._normalize_text(result.get("summary", item.title)) or item.title
+        item.ai_tags = self._normalize_tags(result.get("tags", []))
+
+    @staticmethod
+    def _parse_json_response(response: str) -> dict[str, Any]:
+        """Extract a JSON object from raw model output."""
+
+        text = ContentAnalyzer._clean_response_text(response)
+        candidates: list[str] = []
+
+        if text:
+            candidates.append(text)
+
+        fenced_blocks = re.findall(r"```(?:json)?\s*(.*?)```", text, flags=re.IGNORECASE | re.DOTALL)
+        candidates.extend(block.strip() for block in fenced_blocks if block.strip())
+
+        start = text.find("{")
+        end = text.rfind("}")
+        if start != -1 and end != -1 and end > start:
+            candidates.append(text[start:end + 1].strip())
+
+        seen: set[str] = set()
+        for candidate in candidates:
+            if not candidate or candidate in seen:
+                continue
+            seen.add(candidate)
+            try:
+                payload = json.loads(candidate)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(payload, dict):
+                raise ValueError(f"Expected JSON object response, got {type(payload).__name__}.")
+            return payload
+
+        raise ValueError(f"Invalid JSON response: {text}")
+
+    @staticmethod
+    def _clean_response_text(response: str) -> str:
+        text = response.strip()
+        text = re.sub(r"<think>.*?</think>", "", text, flags=re.IGNORECASE | re.DOTALL)
+        return text.strip()
+
+    @staticmethod
+    def _normalize_score(score: Any) -> float:
+        if isinstance(score, (int, float)):
+            value = float(score)
+        elif isinstance(score, str):
+            match = re.search(r"-?\d+(?:\.\d+)?", score)
+            if not match:
+                raise ValueError(f"Invalid score value: {score}")
+            value = float(match.group(0))
+        else:
+            raise ValueError(f"Invalid score type: {type(score).__name__}")
+
+        return max(0.0, min(10.0, value))
+
+    @staticmethod
+    def _normalize_text(value: Any) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            return value.strip()
+        if isinstance(value, (int, float)):
+            return str(value)
+        return json.dumps(value, ensure_ascii=False)
+
+    @staticmethod
+    def _normalize_tags(tags: Any) -> list[str]:
+        if tags is None:
+            return []
+        if isinstance(tags, str):
+            parts = re.split(r"[,/\n]", tags)
+            return [part.strip() for part in parts if part.strip()]
+        if isinstance(tags, list):
+            normalized = []
+            for tag in tags:
+                text = ContentAnalyzer._normalize_text(tag)
+                if text:
+                    normalized.append(text)
+            return normalized
+        return [ContentAnalyzer._normalize_text(tags)] if tags else []

--- a/src/ai/client.py
+++ b/src/ai/client.py
@@ -2,7 +2,7 @@
 
 import os
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Any
 
 from anthropic import AsyncAnthropic
 from openai import AsyncOpenAI
@@ -10,6 +10,61 @@ from google import genai
 from google.genai import types
 
 from ..models import AIConfig, AIProvider
+
+
+def _coerce_text_content(content: Any) -> str:
+    """Extract plain text from provider-specific response payloads."""
+
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts = [_coerce_text_content(part) for part in content]
+        return "\n".join(part for part in parts if part).strip()
+    if isinstance(content, dict):
+        for key in ("text", "content", "output_text"):
+            if key in content:
+                return _coerce_text_content(content[key])
+        return ""
+
+    for attr in ("text", "content", "output_text"):
+        if hasattr(content, attr):
+            return _coerce_text_content(getattr(content, attr))
+
+    return str(content).strip()
+
+
+def _extract_openai_message_text(response: Any) -> str:
+    """Handle OpenAI-compatible responses that may return structured content."""
+
+    choices = getattr(response, "choices", None) or []
+    if not choices:
+        text = _coerce_text_content(getattr(response, "output_text", None))
+        if text:
+            return text
+        raise ValueError("OpenAI response did not include any choices.")
+
+    message = getattr(choices[0], "message", None)
+    if message is None:
+        raise ValueError("OpenAI response is missing the first choice message.")
+
+    text = _coerce_text_content(getattr(message, "content", None))
+    if text:
+        return text
+
+    refusal = _coerce_text_content(getattr(message, "refusal", None))
+    if refusal:
+        raise ValueError(f"OpenAI response refused the request: {refusal}")
+
+    if getattr(message, "tool_calls", None):
+        raise ValueError("OpenAI response returned tool calls instead of text content.")
+
+    text = _coerce_text_content(getattr(response, "output_text", None))
+    if text:
+        return text
+
+    raise ValueError("OpenAI response did not include text content.")
 
 
 class AIClient(ABC):
@@ -84,7 +139,10 @@ class AnthropicClient(AIClient):
             messages=[{"role": "user", "content": user}]
         )
 
-        return message.content[0].text
+        text = _coerce_text_content(message.content)
+        if not text:
+            raise ValueError("Anthropic response did not include text content.")
+        return text
 
 
 class OpenAIClient(AIClient):
@@ -136,7 +194,7 @@ class OpenAIClient(AIClient):
             max_tokens=max_tokens
         )
 
-        return response.choices[0].message.content
+        return _extract_openai_message_text(response)
 
 
 class GeminiClient(AIClient):
@@ -185,7 +243,15 @@ class GeminiClient(AIClient):
             )
         )
 
-        return response.text
+        text = _coerce_text_content(getattr(response, "text", None))
+        if text:
+            return text
+
+        text = _coerce_text_content(getattr(response, "candidates", None))
+        if text:
+            return text
+
+        raise ValueError("Gemini response did not include text content.")
 
 
 def create_ai_client(config: AIConfig) -> AIClient:

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -1,0 +1,62 @@
+# Horizon MCP
+
+Horizon includes a built-in MCP server that exposes the native Horizon pipeline as staged tools and read-only resources.
+
+The MCP layer does not reimplement Horizon business logic. It reuses the existing fetch, score, filter, enrich, and summarize modules from the main codebase.
+
+## Tools
+
+| Tool | Description |
+| --- | --- |
+| `hz_validate_config` | Validate Horizon config and required environment variables |
+| `hz_fetch_items` | Fetch and deduplicate content into the `raw` stage |
+| `hz_score_items` | Score items from a stage into `scored` |
+| `hz_filter_items` | Filter scored items into `filtered` |
+| `hz_enrich_items` | Enrich filtered items into `enriched` |
+| `hz_generate_summary` | Generate markdown from a stage |
+| `hz_run_pipeline` | Run fetch -> score -> filter -> enrich -> summarize |
+| `hz_list_runs` | List recent run artifacts |
+| `hz_get_run_meta` | Read metadata for a run |
+| `hz_get_run_stage` | Read items from a run stage |
+| `hz_get_run_summary` | Read a generated summary |
+| `hz_get_metrics` | Read in-memory server metrics |
+
+## Resources
+
+- `horizon://server/info`
+- `horizon://metrics`
+- `horizon://runs`
+- `horizon://runs/{run_id}/meta`
+- `horizon://runs/{run_id}/items/{stage}`
+- `horizon://runs/{run_id}/summary/{language}`
+- `horizon://config/effective`
+
+## Install and Start
+
+```bash
+uv sync
+uv run horizon-mcp
+```
+
+The server runs over stdio and is intended to be launched by an MCP client.
+
+## Run Artifacts
+
+Each run writes artifacts under `data/mcp-runs/<run_id>/`:
+
+- `meta.json`
+- `raw_items.json`
+- `scored_items.json`
+- `filtered_items.json`
+- `enriched_items.json`
+- `summary-<lang>.md`
+
+## Design Principles
+
+1. Keep Horizon as the single source of business logic.
+2. Preserve staged re-entry so a run can continue from intermediate artifacts.
+3. Default to no extra side effects unless explicitly requested.
+
+## Client Setup
+
+See [integration.md](integration.md).

--- a/src/mcp/__init__.py
+++ b/src/mcp/__init__.py
@@ -1,0 +1,5 @@
+"""Horizon MCP package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/src/mcp/errors.py
+++ b/src/mcp/errors.py
@@ -1,0 +1,18 @@
+"""Error definitions for Horizon MCP service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class HorizonMcpError(Exception):
+    """Structured exception with stable error code."""
+
+    code: str
+    message: str
+    details: Any = None
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"{self.code}: {self.message}"

--- a/src/mcp/horizon_adapter.py
+++ b/src/mcp/horizon_adapter.py
@@ -1,0 +1,318 @@
+"""Adapter layer that reuses Horizon's native Python modules."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+
+from .errors import HorizonMcpError
+
+
+VALID_SOURCES = {"github", "hackernews", "rss", "reddit", "telegram"}
+ENV_KEY_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+
+
+@dataclass
+class HorizonRuntime:
+    """Loaded runtime references from a Horizon codebase."""
+
+    horizon_path: Path
+    ContentItem: Any
+    Config: Any
+    StorageManager: Any
+    HorizonOrchestrator: Any
+    create_ai_client: Any
+    ContentAnalyzer: Any
+    ContentEnricher: Any
+    DailySummarizer: Any
+
+
+def resolve_horizon_path(explicit: str | None = None) -> Path:
+    """Resolve Horizon repository path by explicit arg/env/common locations."""
+
+    candidates: list[Path] = []
+    if explicit:
+        candidates.append(Path(explicit).expanduser())
+
+    env_path = os.getenv("HORIZON_PATH")
+    if env_path:
+        candidates.append(Path(env_path).expanduser())
+
+    repo_root = Path(__file__).resolve().parents[2]
+    cwd = Path.cwd()
+    candidates.extend(
+        [
+            repo_root,
+            cwd,
+            cwd / "Horizon",
+            cwd.parent / "Horizon",
+        ]
+    )
+
+    seen: set[Path] = set()
+    for candidate in candidates:
+        path = candidate.resolve()
+        if path in seen:
+            continue
+        seen.add(path)
+        if _is_horizon_repo(path):
+            return path
+
+    checked = ", ".join(str(p.resolve()) for p in candidates)
+    raise HorizonMcpError(
+        code="HZ_HORIZON_NOT_FOUND",
+        message="Horizon repository was not found. Pass horizon_path or set HORIZON_PATH.",
+        details={"checked": checked},
+    )
+
+
+def resolve_config_path(horizon_path: Path, config_path: str | None = None) -> Path:
+    """Resolve config path, defaulting to <horizon>/data/config.json."""
+
+    if not config_path:
+        path = (horizon_path / "data/config.json").resolve()
+    else:
+        raw = Path(config_path).expanduser()
+        if raw.is_absolute():
+            path = raw.resolve()
+        else:
+            candidate = (horizon_path / raw).resolve()
+            path = candidate if candidate.exists() else (Path.cwd() / raw).resolve()
+
+    if not path.exists():
+        raise HorizonMcpError(
+            code="HZ_CONFIG_NOT_FOUND",
+            message="Config file does not exist.",
+            details={"config_path": str(path)},
+        )
+
+    return path
+
+
+def load_runtime(horizon_path: Path) -> HorizonRuntime:
+    """Load Horizon modules dynamically from local repository path."""
+
+    if not _is_horizon_repo(horizon_path):
+        raise HorizonMcpError(
+            code="HZ_INVALID_HORIZON_PATH",
+            message="horizon_path is not a valid Horizon repository.",
+            details={"horizon_path": str(horizon_path)},
+        )
+
+    load_dotenv(horizon_path / ".env", override=False)
+    _load_mcp_secrets(horizon_path, override=False)
+
+    horizon_path_str = str(horizon_path)
+    if horizon_path_str not in sys.path:
+        sys.path.insert(0, horizon_path_str)
+
+    try:
+        models = importlib.import_module("src.models")
+        storage = importlib.import_module("src.storage.manager")
+        orchestrator = importlib.import_module("src.orchestrator")
+        ai_client = importlib.import_module("src.ai.client")
+        analyzer = importlib.import_module("src.ai.analyzer")
+        enricher = importlib.import_module("src.ai.enricher")
+        summarizer = importlib.import_module("src.ai.summarizer")
+    except Exception as exc:  # pragma: no cover - import failure edge case
+        raise HorizonMcpError(
+            code="HZ_IMPORT_FAILED",
+            message="Failed to load Horizon modules.",
+            details={"error": str(exc)},
+        ) from exc
+
+    return HorizonRuntime(
+        horizon_path=horizon_path,
+        ContentItem=models.ContentItem,
+        Config=models.Config,
+        StorageManager=storage.StorageManager,
+        HorizonOrchestrator=orchestrator.HorizonOrchestrator,
+        create_ai_client=ai_client.create_ai_client,
+        ContentAnalyzer=analyzer.ContentAnalyzer,
+        ContentEnricher=enricher.ContentEnricher,
+        DailySummarizer=summarizer.DailySummarizer,
+    )
+
+
+def load_config(runtime: HorizonRuntime, config_path: Path) -> Any:
+    """Load Horizon config using native pydantic model."""
+
+    try:
+        payload = json.loads(config_path.read_text(encoding="utf-8"))
+        return runtime.Config.model_validate(payload)
+    except Exception as exc:
+        raise HorizonMcpError(
+            code="HZ_CONFIG_INVALID",
+            message="Failed to parse config file.",
+            details={"config_path": str(config_path), "error": str(exc)},
+        ) from exc
+
+
+def make_storage(runtime: HorizonRuntime, config_path: Path) -> Any:
+    """Build Horizon storage manager bound to config's data directory."""
+
+    data_dir = str(config_path.parent.resolve())
+    return runtime.StorageManager(data_dir=data_dir)
+
+
+def make_orchestrator(runtime: HorizonRuntime, config: Any, storage: Any) -> Any:
+    """Build native Horizon orchestrator."""
+
+    return runtime.HorizonOrchestrator(config, storage)
+
+
+def apply_source_filter(config: Any, sources: list[str] | None) -> tuple[Any, list[str], list[str]]:
+    """Return filtered config and source selection diagnostics."""
+
+    if not sources:
+        enabled = get_enabled_sources(config)
+        return config, enabled, []
+
+    wanted = {s.strip().lower() for s in sources if s.strip()}
+    unknown = sorted(wanted - VALID_SOURCES)
+    chosen = sorted(wanted & VALID_SOURCES)
+
+    clone = config.model_copy(deep=True)
+
+    if "github" not in wanted:
+        clone.sources.github = []
+    if "hackernews" not in wanted:
+        clone.sources.hackernews.enabled = False
+    if "rss" not in wanted:
+        clone.sources.rss = []
+    if "reddit" not in wanted:
+        clone.sources.reddit.enabled = False
+        clone.sources.reddit.subreddits = []
+        clone.sources.reddit.users = []
+    if "telegram" not in wanted:
+        clone.sources.telegram.enabled = False
+        clone.sources.telegram.channels = []
+
+    return clone, chosen, unknown
+
+
+def get_enabled_sources(config: Any) -> list[str]:
+    """List enabled top-level source types in effective config."""
+
+    enabled: list[str] = []
+    if getattr(config.sources, "github", None):
+        enabled.append("github")
+    if getattr(config.sources.hackernews, "enabled", False):
+        enabled.append("hackernews")
+    if getattr(config.sources, "rss", None):
+        enabled.append("rss")
+    if getattr(config.sources.reddit, "enabled", False):
+        enabled.append("reddit")
+    if getattr(config.sources.telegram, "enabled", False):
+        enabled.append("telegram")
+    return enabled
+
+
+def items_to_dicts(items: list[Any]) -> list[dict[str, Any]]:
+    """Serialize Horizon ContentItem models."""
+
+    return [item.model_dump(mode="json") for item in items]
+
+
+def dicts_to_items(runtime: HorizonRuntime, payload: list[dict[str, Any]]) -> list[Any]:
+    """Deserialize ContentItem list."""
+
+    return [runtime.ContentItem.model_validate(item) for item in payload]
+
+
+def get_source_counts(items: list[Any]) -> dict[str, int]:
+    """Count items by source type."""
+
+    counts: dict[str, int] = {}
+    for item in items:
+        key = item.source_type.value
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def _is_horizon_repo(path: Path) -> bool:
+    return (path / "src" / "main.py").exists() and (path / "pyproject.toml").exists()
+
+
+def _load_mcp_secrets(horizon_path: Path, override: bool = False) -> None:
+    """Load MCP secrets from JSON and inject string environment variables."""
+
+    secrets_path = _resolve_secrets_path(horizon_path)
+    if not secrets_path:
+        return
+
+    try:
+        payload = json.loads(secrets_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise HorizonMcpError(
+            code="HZ_SECRETS_INVALID",
+            message="Failed to parse MCP secrets file.",
+            details={"secrets_path": str(secrets_path), "error": str(exc)},
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise HorizonMcpError(
+            code="HZ_SECRETS_INVALID",
+            message="MCP secrets file must be a JSON object.",
+            details={"secrets_path": str(secrets_path)},
+        )
+
+    env_payload = payload.get("env", payload)
+    if not isinstance(env_payload, dict):
+        raise HorizonMcpError(
+            code="HZ_SECRETS_INVALID",
+            message="The env field in MCP secrets must be a JSON object.",
+            details={"secrets_path": str(secrets_path)},
+        )
+
+    for key, value in env_payload.items():
+        if not ENV_KEY_RE.fullmatch(str(key)):
+            continue
+        if not isinstance(value, str):
+            raise HorizonMcpError(
+                code="HZ_SECRETS_INVALID",
+                message=f"MCP secret {key} must be a string.",
+                details={"secrets_path": str(secrets_path), "key": key},
+            )
+        if value.strip() == "":
+            continue
+        if override or not os.getenv(key):
+            os.environ[key] = value
+
+
+def _resolve_secrets_path(horizon_path: Path) -> Path | None:
+    """Resolve secrets config path via env and common locations."""
+
+    explicit = os.getenv("HORIZON_MCP_SECRETS_PATH")
+    if explicit:
+        explicit_path = Path(explicit).expanduser().resolve()
+        if explicit_path.exists():
+            return explicit_path
+        raise HorizonMcpError(
+            code="HZ_SECRETS_NOT_FOUND",
+            message="HORIZON_MCP_SECRETS_PATH points to a missing file.",
+            details={"secrets_path": str(explicit_path)},
+        )
+
+    cwd = Path.cwd()
+    candidates = [
+        cwd / ".cursor" / "mcp.secrets.json",
+        cwd / ".cursor" / "mcp.secrets.local.json",
+        cwd / "config" / "mcp.secrets.json",
+        cwd / "config" / "mcp.secrets.local.json",
+        horizon_path / "data" / "mcp.secrets.json",
+        horizon_path / "data" / "mcp-secrets.json",
+    ]
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        if resolved.exists():
+            return resolved
+    return None

--- a/src/mcp/integration.md
+++ b/src/mcp/integration.md
@@ -1,0 +1,99 @@
+# Horizon MCP Integration
+
+## Recommended Command
+
+Start the built-in MCP server from the Horizon repository root:
+
+```bash
+uv run horizon-mcp
+```
+
+If you need a Python module fallback:
+
+```bash
+uv run python -m src.mcp.server
+```
+
+## Two Setup Modes
+
+### Option A: Client Config With Explicit `cwd`
+
+Some MCP clients need a fixed working directory in their config. In that case, the absolute path is only used in the client-side `cwd` field, not in Horizon's code.
+
+Example:
+
+```json
+{
+  "mcpServers": {
+    "horizon": {
+      "command": "uv",
+      "args": ["run", "horizon-mcp"],
+      "cwd": "/absolute/path/to/Horizon"
+    }
+  }
+}
+```
+
+Restart the client after saving the config.
+
+### Option B: Local Start Without Any Path In Config
+
+If your workflow allows you to start the MCP server manually, no absolute path is needed at all:
+
+```bash
+cd /absolute/path/to/Horizon
+uv run horizon-mcp
+```
+
+This is the cleanest way to avoid path values in client configuration.
+
+## Secret Files
+
+Instead of exporting environment variables manually, you can place a JSON file in one of these locations:
+
+- `.cursor/mcp.secrets.json`
+- `.cursor/mcp.secrets.local.json`
+- `config/mcp.secrets.json`
+- `config/mcp.secrets.local.json`
+- `<horizon_path>/data/mcp.secrets.json`
+- `<horizon_path>/data/mcp-secrets.json`
+
+Supported formats:
+
+```json
+{
+  "OPENAI_API_KEY": "sk-xxxx",
+  "ANTHROPIC_API_KEY": "sk-ant-xxxx",
+  "GOOGLE_API_KEY": "xxxx",
+  "GITHUB_TOKEN": "ghp_xxxx"
+}
+```
+
+```json
+{
+  "env": {
+    "OPENAI_API_KEY": "sk-xxxx",
+    "ANTHROPIC_API_KEY": "sk-ant-xxxx",
+    "GOOGLE_API_KEY": "xxxx",
+    "GITHUB_TOKEN": "ghp_xxxx"
+  }
+}
+```
+
+You can also point to a custom secrets file with:
+
+```json
+{
+  "HORIZON_MCP_SECRETS_PATH": "/absolute/path/to/mcp.secrets.json"
+}
+```
+
+## Smoke Check
+
+Run the local smoke check from the repository root:
+
+```bash
+uv run python scripts/check_mcp.py
+```
+
+It verifies module import, path resolution, config loading, and metrics access.

--- a/src/mcp/run_store.py
+++ b/src/mcp/run_store.py
@@ -1,0 +1,133 @@
+"""Run artifact persistence for Horizon MCP."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+
+STAGES = {
+    "raw": "raw_items.json",
+    "scored": "scored_items.json",
+    "filtered": "filtered_items.json",
+    "enriched": "enriched_items.json",
+}
+
+
+@dataclass
+class RunStore:
+    """Store intermediate artifacts per pipeline run."""
+
+    root: Path
+
+    def __post_init__(self) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def create_run(self, run_id: str | None = None) -> str:
+        run_id = run_id or self._make_run_id()
+        run_dir = self.root / run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+        meta_path = run_dir / "meta.json"
+        if not meta_path.exists():
+            self.write_json(run_id, "meta.json", {"run_id": run_id, "created_at": self._utc_now()})
+        return run_id
+
+    def run_dir(self, run_id: str) -> Path:
+        path = self.root / run_id
+        if not path.exists():
+            raise FileNotFoundError(f"Run not found: {run_id}")
+        return path
+
+    def has_stage(self, run_id: str, stage: str) -> bool:
+        return (self.run_dir(run_id) / self._stage_file(stage)).exists()
+
+    def save_items(self, run_id: str, stage: str, items: list[dict[str, Any]]) -> Path:
+        return self.write_json(run_id, self._stage_file(stage), items)
+
+    def load_items(self, run_id: str, stage: str) -> list[dict[str, Any]]:
+        return self.read_json(run_id, self._stage_file(stage))
+
+    def save_summary(self, run_id: str, language: str, markdown: str) -> Path:
+        filename = f"summary-{language}.md"
+        path = self.run_dir(run_id) / filename
+        path.write_text(markdown, encoding="utf-8")
+        return path
+
+    def load_summary(self, run_id: str, language: str) -> str:
+        path = self.run_dir(run_id) / f"summary-{language}.md"
+        if not path.exists():
+            raise FileNotFoundError(f"Summary not found: run={run_id} lang={language}")
+        return path.read_text(encoding="utf-8")
+
+    def update_meta(self, run_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        meta = self.read_json(run_id, "meta.json")
+        meta.update(updates)
+        meta["updated_at"] = self._utc_now()
+        self.write_json(run_id, "meta.json", meta)
+        return meta
+
+    def load_meta(self, run_id: str) -> dict[str, Any]:
+        return self.read_json(run_id, "meta.json")
+
+    def list_runs(self, limit: int = 20) -> list[dict[str, Any]]:
+        """List runs sorted by create/update time descending."""
+
+        entries: list[dict[str, Any]] = []
+        for run_dir in self.root.iterdir():
+            if not run_dir.is_dir():
+                continue
+            meta_path = run_dir / "meta.json"
+            if not meta_path.exists():
+                continue
+            try:
+                meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                continue
+
+            created = meta.get("created_at") or ""
+            updated = meta.get("updated_at") or created
+            entries.append(
+                {
+                    "run_id": meta.get("run_id", run_dir.name),
+                    "created_at": created,
+                    "updated_at": updated,
+                    "meta": meta,
+                }
+            )
+
+        entries.sort(key=lambda x: x["updated_at"] or x["created_at"], reverse=True)
+        return entries[: max(0, limit)]
+
+    def write_json(self, run_id: str, filename: str, payload: Any) -> Path:
+        path = self.run_dir(run_id) / filename
+        path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        return path
+
+    def read_json(self, run_id: str, filename: str) -> Any:
+        path = self.run_dir(run_id) / filename
+        if not path.exists():
+            raise FileNotFoundError(f"Artifact not found: run={run_id} file={filename}")
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def _stage_file(stage: str) -> str:
+        if stage not in STAGES:
+            supported = ", ".join(sorted(STAGES))
+            raise ValueError(f"Unsupported stage '{stage}', expected one of: {supported}")
+        return STAGES[stage]
+
+    @staticmethod
+    def _make_run_id() -> str:
+        now = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        return f"run-{now}-{uuid4().hex[:8]}"
+
+    @staticmethod
+    def _utc_now() -> str:
+        return datetime.now(timezone.utc).isoformat()

--- a/src/mcp/server.py
+++ b/src/mcp/server.py
@@ -1,0 +1,470 @@
+"""MCP server entrypoint for Horizon."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from time import perf_counter
+from typing import Any, Awaitable, Callable
+
+from mcp.server.fastmcp import FastMCP
+
+from .errors import HorizonMcpError
+from .service import HorizonPipelineService
+
+
+mcp = FastMCP(name="horizon-mcp")
+service = HorizonPipelineService()
+
+SERVER_STARTED_AT = datetime.now(timezone.utc).isoformat()
+METRICS: dict[str, Any] = {
+    "started_at": SERVER_STARTED_AT,
+    "tool_calls_total": 0,
+    "tool_calls_success": 0,
+    "tool_calls_failed": 0,
+    "tool_calls_by_name": {},
+    "tool_errors_by_code": {},
+    "tool_last_duration_ms": {},
+    "last_error": None,
+}
+
+
+def _ok(tool: str, data: dict[str, Any], duration_ms: float | None = None) -> dict[str, Any]:
+    payload = {
+        "ok": True,
+        "tool": tool,
+        "data": data,
+        "meta": {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        },
+    }
+    if duration_ms is not None:
+        payload["meta"]["duration_ms"] = round(duration_ms, 2)
+    return payload
+
+
+def _err(tool: str, error: Exception, duration_ms: float | None = None) -> dict[str, Any]:
+    if isinstance(error, HorizonMcpError):
+        code = error.code
+        message = error.message
+        details = error.details
+    else:
+        code = "HZ_INTERNAL_ERROR"
+        message = str(error)
+        details = None
+
+    payload = {
+        "ok": False,
+        "tool": tool,
+        "error": {
+            "code": code,
+            "message": message,
+            "details": details,
+        },
+        "meta": {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        },
+    }
+    if duration_ms is not None:
+        payload["meta"]["duration_ms"] = round(duration_ms, 2)
+    return payload
+
+
+def _record_metrics(tool: str, ok: bool, duration_ms: float, error_code: str | None = None) -> None:
+    METRICS["tool_calls_total"] += 1
+    if ok:
+        METRICS["tool_calls_success"] += 1
+    else:
+        METRICS["tool_calls_failed"] += 1
+
+    by_name = METRICS["tool_calls_by_name"]
+    by_name[tool] = by_name.get(tool, 0) + 1
+
+    METRICS["tool_last_duration_ms"][tool] = round(duration_ms, 2)
+
+    if error_code:
+        by_code = METRICS["tool_errors_by_code"]
+        by_code[error_code] = by_code.get(error_code, 0) + 1
+        METRICS["last_error"] = {
+            "tool": tool,
+            "code": error_code,
+            "at": datetime.now(timezone.utc).isoformat(),
+        }
+
+
+async def _run_tool(tool: str, runner: Callable[[], Awaitable[dict[str, Any]]]) -> dict[str, Any]:
+    started = perf_counter()
+    try:
+        data = await runner()
+        elapsed_ms = (perf_counter() - started) * 1000
+        _record_metrics(tool, ok=True, duration_ms=elapsed_ms)
+        return _ok(tool, data, duration_ms=elapsed_ms)
+    except Exception as exc:
+        elapsed_ms = (perf_counter() - started) * 1000
+        payload = _err(tool, exc, duration_ms=elapsed_ms)
+        code = payload["error"]["code"]
+        _record_metrics(tool, ok=False, duration_ms=elapsed_ms, error_code=code)
+        return payload
+
+
+def _resource_result(resource: str, loader: Callable[[], Any]) -> dict[str, Any]:
+    try:
+        data = loader()
+        return {
+            "ok": True,
+            "resource": resource,
+            "data": data,
+        }
+    except Exception as exc:
+        return _err(resource, exc)
+
+
+def _metrics_snapshot() -> dict[str, Any]:
+    uptime_seconds = (
+        datetime.now(timezone.utc) - datetime.fromisoformat(METRICS["started_at"])
+    ).total_seconds()
+    return {
+        **METRICS,
+        "uptime_seconds": round(uptime_seconds, 2),
+    }
+
+
+@mcp.tool()
+async def hz_validate_config(
+    horizon_path: str | None = None,
+    config_path: str | None = None,
+    sources: list[str] | None = None,
+    check_env: bool = True,
+) -> dict[str, Any]:
+    """Validate Horizon config and required environment variables."""
+
+    return await _run_tool(
+        "hz_validate_config",
+        lambda: service.validate_config(
+            horizon_path=horizon_path,
+            config_path=config_path,
+            sources=sources,
+            check_env=check_env,
+        ),
+    )
+
+
+@mcp.tool()
+async def hz_fetch_items(
+    hours: int = 24,
+    run_id: str | None = None,
+    horizon_path: str | None = None,
+    config_path: str | None = None,
+    sources: list[str] | None = None,
+) -> dict[str, Any]:
+    """Fetch and deduplicate content into the raw stage."""
+
+    return await _run_tool(
+        "hz_fetch_items",
+        lambda: service.fetch_items(
+            hours=hours,
+            run_id=run_id,
+            horizon_path=horizon_path,
+            config_path=config_path,
+            sources=sources,
+        ),
+    )
+
+
+@mcp.tool()
+async def hz_score_items(
+    run_id: str,
+    source_stage: str = "raw",
+    horizon_path: str | None = None,
+    config_path: str | None = None,
+) -> dict[str, Any]:
+    """Score a stage into the scored stage."""
+
+    return await _run_tool(
+        "hz_score_items",
+        lambda: service.score_items(
+            run_id=run_id,
+            source_stage=source_stage,
+            horizon_path=horizon_path,
+            config_path=config_path,
+        ),
+    )
+
+
+@mcp.tool()
+async def hz_filter_items(
+    run_id: str,
+    threshold: float | None = None,
+    source_stage: str = "scored",
+    topic_dedup: bool = True,
+    horizon_path: str | None = None,
+    config_path: str | None = None,
+) -> dict[str, Any]:
+    """Filter scored items into the filtered stage."""
+
+    return await _run_tool(
+        "hz_filter_items",
+        lambda: service.filter_items(
+            run_id=run_id,
+            threshold=threshold,
+            source_stage=source_stage,
+            topic_dedup=topic_dedup,
+            horizon_path=horizon_path,
+            config_path=config_path,
+        ),
+    )
+
+
+@mcp.tool()
+async def hz_enrich_items(
+    run_id: str,
+    source_stage: str = "filtered",
+    horizon_path: str | None = None,
+    config_path: str | None = None,
+) -> dict[str, Any]:
+    """Enrich filtered items into the enriched stage."""
+
+    return await _run_tool(
+        "hz_enrich_items",
+        lambda: service.enrich_items(
+            run_id=run_id,
+            source_stage=source_stage,
+            horizon_path=horizon_path,
+            config_path=config_path,
+        ),
+    )
+
+
+@mcp.tool()
+async def hz_generate_summary(
+    run_id: str,
+    language: str = "zh",
+    source_stage: str | None = None,
+    horizon_path: str | None = None,
+    config_path: str | None = None,
+    save_to_horizon_data: bool = False,
+) -> dict[str, Any]:
+    """Generate a markdown summary from a stage."""
+
+    return await _run_tool(
+        "hz_generate_summary",
+        lambda: service.generate_summary(
+            run_id=run_id,
+            language=language,
+            source_stage=source_stage,
+            horizon_path=horizon_path,
+            config_path=config_path,
+            save_to_horizon_data=save_to_horizon_data,
+        ),
+    )
+
+
+@mcp.tool()
+async def hz_run_pipeline(
+    hours: int = 24,
+    languages: list[str] | None = None,
+    threshold: float | None = None,
+    horizon_path: str | None = None,
+    config_path: str | None = None,
+    sources: list[str] | None = None,
+    enrich: bool = True,
+    topic_dedup: bool = True,
+    save_to_horizon_data: bool = False,
+) -> dict[str, Any]:
+    """Run fetch -> score -> filter -> enrich -> summarize in one call."""
+
+    return await _run_tool(
+        "hz_run_pipeline",
+        lambda: service.run_pipeline(
+            hours=hours,
+            languages=languages,
+            threshold=threshold,
+            horizon_path=horizon_path,
+            config_path=config_path,
+            sources=sources,
+            enrich=enrich,
+            topic_dedup=topic_dedup,
+            save_to_horizon_data=save_to_horizon_data,
+        ),
+    )
+
+
+@mcp.tool()
+def hz_list_runs(limit: int = 20) -> dict[str, Any]:
+    """List recent runs and stage states."""
+
+    started = perf_counter()
+    try:
+        data = service.list_runs(limit=limit)
+        elapsed_ms = (perf_counter() - started) * 1000
+        _record_metrics("hz_list_runs", ok=True, duration_ms=elapsed_ms)
+        return _ok("hz_list_runs", data, duration_ms=elapsed_ms)
+    except Exception as exc:
+        elapsed_ms = (perf_counter() - started) * 1000
+        payload = _err("hz_list_runs", exc, duration_ms=elapsed_ms)
+        _record_metrics(
+            "hz_list_runs",
+            ok=False,
+            duration_ms=elapsed_ms,
+            error_code=payload["error"]["code"],
+        )
+        return payload
+
+
+@mcp.tool()
+def hz_get_run_meta(run_id: str) -> dict[str, Any]:
+    """Read run metadata."""
+
+    started = perf_counter()
+    try:
+        data = service.get_run_meta(run_id)
+        elapsed_ms = (perf_counter() - started) * 1000
+        _record_metrics("hz_get_run_meta", ok=True, duration_ms=elapsed_ms)
+        return _ok("hz_get_run_meta", data, duration_ms=elapsed_ms)
+    except Exception as exc:
+        elapsed_ms = (perf_counter() - started) * 1000
+        payload = _err("hz_get_run_meta", exc, duration_ms=elapsed_ms)
+        _record_metrics(
+            "hz_get_run_meta",
+            ok=False,
+            duration_ms=elapsed_ms,
+            error_code=payload["error"]["code"],
+        )
+        return payload
+
+
+@mcp.tool()
+def hz_get_run_stage(run_id: str, stage: str, max_items: int = 200) -> dict[str, Any]:
+    """Read items from a run stage."""
+
+    started = perf_counter()
+    try:
+        data = service.get_run_stage(run_id=run_id, stage=stage, max_items=max_items)
+        elapsed_ms = (perf_counter() - started) * 1000
+        _record_metrics("hz_get_run_stage", ok=True, duration_ms=elapsed_ms)
+        return _ok("hz_get_run_stage", data, duration_ms=elapsed_ms)
+    except Exception as exc:
+        elapsed_ms = (perf_counter() - started) * 1000
+        payload = _err("hz_get_run_stage", exc, duration_ms=elapsed_ms)
+        _record_metrics(
+            "hz_get_run_stage",
+            ok=False,
+            duration_ms=elapsed_ms,
+            error_code=payload["error"]["code"],
+        )
+        return payload
+
+
+@mcp.tool()
+def hz_get_run_summary(run_id: str, language: str = "zh") -> dict[str, Any]:
+    """Read a generated run summary."""
+
+    started = perf_counter()
+    try:
+        data = service.get_run_summary(run_id=run_id, language=language)
+        elapsed_ms = (perf_counter() - started) * 1000
+        _record_metrics("hz_get_run_summary", ok=True, duration_ms=elapsed_ms)
+        return _ok("hz_get_run_summary", data, duration_ms=elapsed_ms)
+    except Exception as exc:
+        elapsed_ms = (perf_counter() - started) * 1000
+        payload = _err("hz_get_run_summary", exc, duration_ms=elapsed_ms)
+        _record_metrics(
+            "hz_get_run_summary",
+            ok=False,
+            duration_ms=elapsed_ms,
+            error_code=payload["error"]["code"],
+        )
+        return payload
+
+
+@mcp.tool()
+def hz_get_metrics() -> dict[str, Any]:
+    """Read in-memory server metrics."""
+
+    started = perf_counter()
+    try:
+        data = _metrics_snapshot()
+        elapsed_ms = (perf_counter() - started) * 1000
+        _record_metrics("hz_get_metrics", ok=True, duration_ms=elapsed_ms)
+        return _ok("hz_get_metrics", data, duration_ms=elapsed_ms)
+    except Exception as exc:
+        elapsed_ms = (perf_counter() - started) * 1000
+        payload = _err("hz_get_metrics", exc, duration_ms=elapsed_ms)
+        _record_metrics(
+            "hz_get_metrics",
+            ok=False,
+            duration_ms=elapsed_ms,
+            error_code=payload["error"]["code"],
+        )
+        return payload
+
+
+@mcp.resource("horizon://server/info")
+def r_server_info() -> dict[str, Any]:
+    """Server metadata resource."""
+
+    return {
+        "name": "horizon-mcp",
+        "started_at": SERVER_STARTED_AT,
+        "runs_root": str(service.runs_root.resolve()),
+    }
+
+
+@mcp.resource("horizon://metrics")
+def r_metrics() -> dict[str, Any]:
+    """In-memory metrics snapshot."""
+
+    return _resource_result("horizon://metrics", _metrics_snapshot)
+
+
+@mcp.resource("horizon://runs")
+def r_runs() -> dict[str, Any]:
+    """Recent run list."""
+
+    return _resource_result("horizon://runs", lambda: service.list_runs(limit=30))
+
+
+@mcp.resource("horizon://runs/{run_id}/meta")
+def r_run_meta(run_id: str) -> dict[str, Any]:
+    """Run metadata resource."""
+
+    return _resource_result(
+        f"horizon://runs/{run_id}/meta",
+        lambda: service.get_run_meta(run_id),
+    )
+
+
+@mcp.resource("horizon://runs/{run_id}/items/{stage}")
+def r_run_items(run_id: str, stage: str) -> dict[str, Any]:
+    """Run stage items resource."""
+
+    return _resource_result(
+        f"horizon://runs/{run_id}/items/{stage}",
+        lambda: service.get_run_stage(run_id=run_id, stage=stage, max_items=200),
+    )
+
+
+@mcp.resource("horizon://runs/{run_id}/summary/{language}")
+def r_run_summary(run_id: str, language: str) -> dict[str, Any]:
+    """Run summary resource."""
+
+    return _resource_result(
+        f"horizon://runs/{run_id}/summary/{language}",
+        lambda: service.get_run_summary(run_id=run_id, language=language),
+    )
+
+
+@mcp.resource("horizon://config/effective")
+def r_effective_config() -> dict[str, Any]:
+    """Effective default config resolved from local Horizon path."""
+
+    return _resource_result("horizon://config/effective", service.get_effective_config)
+
+
+def main() -> None:
+    """Run MCP server over stdio."""
+
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mcp/service.py
+++ b/src/mcp/service.py
@@ -1,0 +1,598 @@
+"""Application service for staged Horizon pipeline execution."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from .errors import HorizonMcpError
+from .horizon_adapter import (
+    apply_source_filter,
+    dicts_to_items,
+    get_enabled_sources,
+    get_source_counts,
+    items_to_dicts,
+    load_config,
+    load_runtime,
+    make_orchestrator,
+    make_storage,
+    resolve_config_path,
+    resolve_horizon_path,
+)
+from .run_store import RunStore
+
+
+def _default_runs_root() -> Path:
+    return Path(__file__).resolve().parents[2] / "data" / "mcp-runs"
+
+
+@dataclass
+class PipelineContext:
+    """Resolved execution context per call."""
+
+    horizon_path: Path
+    config_path: Path
+    runtime: Any
+    config: Any
+
+
+class HorizonPipelineService:
+    """High-level staged pipeline service."""
+
+    def __init__(self, runs_root: Path | None = None):
+        self.runs_root = Path(runs_root).resolve() if runs_root else _default_runs_root().resolve()
+        self._run_store: RunStore | None = None
+
+    @property
+    def run_store(self) -> RunStore:
+        if self._run_store is None:
+            self._run_store = RunStore(self.runs_root)
+        return self._run_store
+
+    def list_runs(self, limit: int = 20) -> dict[str, Any]:
+        """List recent runs and stage availability."""
+
+        runs = self.run_store.list_runs(limit=limit)
+        items = []
+        for run in runs:
+            run_id = run["run_id"]
+            stages = {}
+            for stage in ("raw", "scored", "filtered", "enriched"):
+                stages[stage] = self.run_store.has_stage(run_id, stage)
+            items.append(
+                {
+                    "run_id": run_id,
+                    "created_at": run.get("created_at"),
+                    "updated_at": run.get("updated_at"),
+                    "stages": stages,
+                    "meta": run.get("meta", {}),
+                }
+            )
+        return {"count": len(items), "items": items}
+
+    def get_run_meta(self, run_id: str) -> dict[str, Any]:
+        """Read run metadata."""
+
+        try:
+            meta = self.run_store.load_meta(run_id)
+        except FileNotFoundError as exc:
+            raise HorizonMcpError(
+                code="HZ_RUN_NOT_FOUND",
+                message=f"run_id={run_id} does not exist.",
+                details={"run_id": run_id},
+            ) from exc
+        return {"run_id": run_id, "meta": meta}
+
+    def get_run_stage(
+        self,
+        run_id: str,
+        stage: str,
+        max_items: int = 200,
+    ) -> dict[str, Any]:
+        """Read staged item payload (JSON)."""
+
+        if max_items <= 0:
+            raise HorizonMcpError(code="HZ_INVALID_INPUT", message="max_items must be greater than 0.")
+        try:
+            items = self.run_store.load_items(run_id, stage)
+        except ValueError as exc:
+            raise HorizonMcpError(
+                code="HZ_INVALID_STAGE",
+                message=str(exc),
+                details={"stage": stage},
+            ) from exc
+        except FileNotFoundError as exc:
+            raise HorizonMcpError(
+                code="HZ_STAGE_NOT_FOUND",
+                message=f"run_id={run_id} is missing stage artifact: {stage}",
+                details={"run_id": run_id, "stage": stage},
+            ) from exc
+
+        return {
+            "run_id": run_id,
+            "stage": stage,
+            "count": len(items),
+            "items": items[:max_items],
+            "truncated": len(items) > max_items,
+        }
+
+    def get_run_summary(self, run_id: str, language: str = "zh") -> dict[str, Any]:
+        """Read generated markdown summary for a run."""
+
+        try:
+            markdown = self.run_store.load_summary(run_id, language)
+        except FileNotFoundError as exc:
+            raise HorizonMcpError(
+                code="HZ_SUMMARY_NOT_FOUND",
+                message=f"run_id={run_id} is missing summary for language={language}.",
+                details={"run_id": run_id, "language": language},
+            ) from exc
+        return {
+            "run_id": run_id,
+            "language": language,
+            "summary": markdown,
+        }
+
+    def get_effective_config(
+        self,
+        horizon_path: str | None = None,
+        config_path: str | None = None,
+        sources: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Return effective config after optional source filtering."""
+
+        ctx, selected_sources, unknown_sources = self._build_context(
+            horizon_path=horizon_path,
+            config_path=config_path,
+            sources=sources,
+        )
+        return {
+            "horizon_path": str(ctx.horizon_path),
+            "config_path": str(ctx.config_path),
+            "selected_sources": selected_sources,
+            "unknown_sources": unknown_sources,
+            "config": ctx.config.model_dump(mode="json"),
+        }
+
+    async def validate_config(
+        self,
+        horizon_path: str | None = None,
+        config_path: str | None = None,
+        sources: list[str] | None = None,
+        check_env: bool = True,
+    ) -> dict[str, Any]:
+        ctx, selected_sources, unknown_sources = self._build_context(
+            horizon_path=horizon_path,
+            config_path=config_path,
+            sources=sources,
+        )
+
+        warnings: list[str] = []
+        missing_env: list[str] = []
+
+        if check_env:
+            required = [ctx.config.ai.api_key_env]
+            for key in required:
+                if not os.getenv(key):
+                    missing_env.append(key)
+
+            if ctx.config.sources.github and not os.getenv("GITHUB_TOKEN"):
+                warnings.append("GITHUB_TOKEN is not set; GitHub fetching may hit strict rate limits.")
+
+            if getattr(ctx.config, "email", None) and ctx.config.email and ctx.config.email.enabled:
+                pwd_key = ctx.config.email.password_env
+                if not os.getenv(pwd_key):
+                    missing_env.append(pwd_key)
+
+        return {
+            "horizon_path": str(ctx.horizon_path),
+            "config_path": str(ctx.config_path),
+            "ai": {
+                "provider": ctx.config.ai.provider.value,
+                "model": ctx.config.ai.model,
+                "languages": list(ctx.config.ai.languages),
+                "api_key_env": ctx.config.ai.api_key_env,
+            },
+            "filtering": {
+                "ai_score_threshold": ctx.config.filtering.ai_score_threshold,
+                "time_window_hours": ctx.config.filtering.time_window_hours,
+            },
+            "enabled_sources": get_enabled_sources(ctx.config),
+            "selected_sources": selected_sources,
+            "unknown_sources": unknown_sources,
+            "missing_env": missing_env,
+            "warnings": warnings,
+        }
+
+    async def fetch_items(
+        self,
+        hours: int = 24,
+        run_id: str | None = None,
+        horizon_path: str | None = None,
+        config_path: str | None = None,
+        sources: list[str] | None = None,
+    ) -> dict[str, Any]:
+        if hours <= 0:
+            raise HorizonMcpError(code="HZ_INVALID_INPUT", message="hours must be greater than 0.")
+
+        ctx, selected_sources, unknown_sources = self._build_context(
+            horizon_path=horizon_path,
+            config_path=config_path,
+            sources=sources,
+        )
+
+        storage = make_storage(ctx.runtime, ctx.config_path)
+        orchestrator = make_orchestrator(ctx.runtime, ctx.config, storage)
+
+        run_id = self.run_store.create_run(run_id)
+        since = datetime.now(timezone.utc) - timedelta(hours=hours)
+
+        raw_items = await orchestrator._fetch_all_sources(since)
+        merged_items = orchestrator._merge_cross_source_duplicates(raw_items)
+
+        self.run_store.save_items(run_id, "raw", items_to_dicts(merged_items))
+        meta = self.run_store.update_meta(
+            run_id,
+            {
+                "horizon_path": str(ctx.horizon_path),
+                "config_path": str(ctx.config_path),
+                "hours": hours,
+                "since": since.isoformat(),
+                "source_selection": selected_sources,
+                "unknown_sources": unknown_sources,
+                "raw_count_before_merge": len(raw_items),
+                "raw_count": len(merged_items),
+            },
+        )
+
+        return {
+            "run_id": run_id,
+            "fetched": len(merged_items),
+            "raw_before_merge": len(raw_items),
+            "source_counts": get_source_counts(merged_items),
+            "artifact": str((self.run_store.run_dir(run_id) / "raw_items.json").resolve()),
+            "meta": meta,
+        }
+
+    async def score_items(
+        self,
+        run_id: str,
+        source_stage: str = "raw",
+        horizon_path: str | None = None,
+        config_path: str | None = None,
+    ) -> dict[str, Any]:
+        items, ctx = self._load_stage_items(
+            run_id=run_id,
+            stage=source_stage,
+            horizon_path=horizon_path,
+            config_path=config_path,
+        )
+
+        if not items:
+            raise HorizonMcpError(code="HZ_EMPTY_INPUT", message="No items available for scoring.")
+
+        ai_client = ctx.runtime.create_ai_client(ctx.config.ai)
+        analyzer = ctx.runtime.ContentAnalyzer(ai_client)
+        scored_items = await analyzer.analyze_batch(items)
+
+        self.run_store.save_items(run_id, "scored", items_to_dicts(scored_items))
+        score_threshold = ctx.config.filtering.ai_score_threshold
+        above_threshold = [x for x in scored_items if x.ai_score and x.ai_score >= score_threshold]
+
+        meta = self.run_store.update_meta(
+            run_id,
+            {
+                "scored_count": len(scored_items),
+                "scored_threshold": score_threshold,
+                "scored_above_threshold": len(above_threshold),
+            },
+        )
+
+        return {
+            "run_id": run_id,
+            "scored": len(scored_items),
+            "above_threshold": len(above_threshold),
+            "score_distribution": self._score_distribution(scored_items),
+            "artifact": str((self.run_store.run_dir(run_id) / "scored_items.json").resolve()),
+            "meta": meta,
+        }
+
+    async def filter_items(
+        self,
+        run_id: str,
+        threshold: float | None = None,
+        source_stage: str = "scored",
+        topic_dedup: bool = True,
+        horizon_path: str | None = None,
+        config_path: str | None = None,
+    ) -> dict[str, Any]:
+        items, ctx = self._load_stage_items(
+            run_id=run_id,
+            stage=source_stage,
+            horizon_path=horizon_path,
+            config_path=config_path,
+        )
+
+        effective_threshold = threshold if threshold is not None else ctx.config.filtering.ai_score_threshold
+
+        important_items = [item for item in items if item.ai_score and item.ai_score >= effective_threshold]
+        important_items.sort(key=lambda x: x.ai_score or 0, reverse=True)
+
+        before_dedup = len(important_items)
+        if topic_dedup and important_items:
+            storage = make_storage(ctx.runtime, ctx.config_path)
+            orchestrator = make_orchestrator(ctx.runtime, ctx.config, storage)
+            important_items = orchestrator._merge_topic_duplicates(important_items)
+
+        self.run_store.save_items(run_id, "filtered", items_to_dicts(important_items))
+        meta = self.run_store.update_meta(
+            run_id,
+            {
+                "filtered_count": len(important_items),
+                "filter_threshold": effective_threshold,
+                "topic_dedup_enabled": topic_dedup,
+                "topic_dedup_removed": before_dedup - len(important_items),
+            },
+        )
+
+        return {
+            "run_id": run_id,
+            "kept": len(important_items),
+            "threshold": effective_threshold,
+            "removed_by_topic_dedup": before_dedup - len(important_items),
+            "source_counts": get_source_counts(important_items),
+            "artifact": str((self.run_store.run_dir(run_id) / "filtered_items.json").resolve()),
+            "meta": meta,
+        }
+
+    async def enrich_items(
+        self,
+        run_id: str,
+        source_stage: str = "filtered",
+        horizon_path: str | None = None,
+        config_path: str | None = None,
+    ) -> dict[str, Any]:
+        items, ctx = self._load_stage_items(
+            run_id=run_id,
+            stage=source_stage,
+            horizon_path=horizon_path,
+            config_path=config_path,
+        )
+
+        if not items:
+            raise HorizonMcpError(code="HZ_EMPTY_INPUT", message="No items available for enrichment.")
+
+        ai_client = ctx.runtime.create_ai_client(ctx.config.ai)
+        enricher = ctx.runtime.ContentEnricher(ai_client)
+        await enricher.enrich_batch(items)
+
+        self.run_store.save_items(run_id, "enriched", items_to_dicts(items))
+
+        citation_count = 0
+        for item in items:
+            citation_count += len(item.metadata.get("sources", []))
+
+        meta = self.run_store.update_meta(
+            run_id,
+            {
+                "enriched_count": len(items),
+                "citation_count": citation_count,
+            },
+        )
+
+        return {
+            "run_id": run_id,
+            "enriched": len(items),
+            "citation_count": citation_count,
+            "artifact": str((self.run_store.run_dir(run_id) / "enriched_items.json").resolve()),
+            "meta": meta,
+        }
+
+    async def generate_summary(
+        self,
+        run_id: str,
+        language: str = "zh",
+        source_stage: str | None = None,
+        horizon_path: str | None = None,
+        config_path: str | None = None,
+        save_to_horizon_data: bool = False,
+    ) -> dict[str, Any]:
+        stage = source_stage or self._pick_summary_stage(run_id)
+        items, ctx = self._load_stage_items(
+            run_id=run_id,
+            stage=stage,
+            horizon_path=horizon_path,
+            config_path=config_path,
+        )
+
+        total_fetched = self._total_fetched(run_id, fallback=len(items))
+        date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+        summarizer = ctx.runtime.DailySummarizer()
+        summary = await summarizer.generate_summary(
+            items,
+            date_str,
+            total_fetched,
+            language=language,
+        )
+
+        run_summary_path = self.run_store.save_summary(run_id, language, summary)
+        published_path = None
+        if save_to_horizon_data:
+            storage = make_storage(ctx.runtime, ctx.config_path)
+            published_path = storage.save_daily_summary(date_str, summary, language=language)
+
+        summary_meta = {
+            "summary_stage": stage,
+            "summary_language": language,
+            "summary_generated_at": datetime.now(timezone.utc).isoformat(),
+            "summary_artifact": str(run_summary_path.resolve()),
+        }
+        if published_path:
+            summary_meta["summary_published_path"] = str(Path(published_path).resolve())
+        meta = self.run_store.update_meta(run_id, summary_meta)
+
+        return {
+            "run_id": run_id,
+            "language": language,
+            "source_stage": stage,
+            "total_fetched": total_fetched,
+            "items_used": len(items),
+            "summary_path": str(run_summary_path.resolve()),
+            "published_path": str(Path(published_path).resolve()) if published_path else None,
+            "preview": summary[:1200],
+            "meta": meta,
+        }
+
+    async def run_pipeline(
+        self,
+        hours: int = 24,
+        languages: list[str] | None = None,
+        threshold: float | None = None,
+        horizon_path: str | None = None,
+        config_path: str | None = None,
+        sources: list[str] | None = None,
+        enrich: bool = True,
+        topic_dedup: bool = True,
+        save_to_horizon_data: bool = False,
+    ) -> dict[str, Any]:
+        fetch_result = await self.fetch_items(
+            hours=hours,
+            horizon_path=horizon_path,
+            config_path=config_path,
+            sources=sources,
+        )
+        run_id = fetch_result["run_id"]
+
+        score_result = await self.score_items(
+            run_id=run_id,
+            horizon_path=horizon_path,
+            config_path=config_path,
+        )
+
+        filter_result = await self.filter_items(
+            run_id=run_id,
+            threshold=threshold,
+            topic_dedup=topic_dedup,
+            horizon_path=horizon_path,
+            config_path=config_path,
+        )
+
+        enrich_result: dict[str, Any] | None = None
+        stage_for_summary = "filtered"
+        if enrich:
+            enrich_result = await self.enrich_items(
+                run_id=run_id,
+                source_stage="filtered",
+                horizon_path=horizon_path,
+                config_path=config_path,
+            )
+            stage_for_summary = "enriched"
+
+        ctx, _, _ = self._build_context(
+            horizon_path=horizon_path,
+            config_path=config_path,
+            sources=sources,
+        )
+        final_languages = languages if languages else list(ctx.config.ai.languages)
+
+        summaries = []
+        for lang in final_languages:
+            summary_result = await self.generate_summary(
+                run_id=run_id,
+                language=lang,
+                source_stage=stage_for_summary,
+                horizon_path=horizon_path,
+                config_path=config_path,
+                save_to_horizon_data=save_to_horizon_data,
+            )
+            summaries.append(summary_result)
+
+        return {
+            "run_id": run_id,
+            "fetch": fetch_result,
+            "score": score_result,
+            "filter": filter_result,
+            "enrich": enrich_result,
+            "summaries": summaries,
+            "meta": self.run_store.load_meta(run_id),
+        }
+
+    def _build_context(
+        self,
+        horizon_path: str | None,
+        config_path: str | None,
+        sources: list[str] | None,
+    ) -> tuple[PipelineContext, list[str], list[str]]:
+        resolved_horizon = resolve_horizon_path(horizon_path)
+        runtime = load_runtime(resolved_horizon)
+        resolved_config = resolve_config_path(resolved_horizon, config_path)
+        config = load_config(runtime, resolved_config)
+        effective_config, selected_sources, unknown_sources = apply_source_filter(config, sources)
+
+        return (
+            PipelineContext(
+                horizon_path=resolved_horizon,
+                config_path=resolved_config,
+                runtime=runtime,
+                config=effective_config,
+            ),
+            selected_sources,
+            unknown_sources,
+        )
+
+    def _load_stage_items(
+        self,
+        run_id: str,
+        stage: str,
+        horizon_path: str | None,
+        config_path: str | None,
+    ) -> tuple[list[Any], PipelineContext]:
+        ctx, _, _ = self._build_context(horizon_path=horizon_path, config_path=config_path, sources=None)
+        try:
+            payload = self.run_store.load_items(run_id, stage)
+        except FileNotFoundError as exc:
+            raise HorizonMcpError(
+                code="HZ_STAGE_NOT_FOUND",
+                message=f"run_id={run_id} is missing stage artifact: {stage}",
+                details={"run_id": run_id, "stage": stage},
+            ) from exc
+        items = dicts_to_items(ctx.runtime, payload)
+        return items, ctx
+
+    def _pick_summary_stage(self, run_id: str) -> str:
+        for stage in ("enriched", "filtered", "scored", "raw"):
+            if self.run_store.has_stage(run_id, stage):
+                return stage
+        raise HorizonMcpError(
+            code="HZ_STAGE_NOT_FOUND",
+            message=f"run_id={run_id} has no usable stage for summary generation.",
+            details={"run_id": run_id},
+        )
+
+    def _total_fetched(self, run_id: str, fallback: int) -> int:
+        try:
+            raw = self.run_store.load_items(run_id, "raw")
+            return len(raw)
+        except Exception:
+            return fallback
+
+    @staticmethod
+    def _score_distribution(items: list[Any]) -> dict[str, int]:
+        buckets = {"0-2": 0, "3-4": 0, "5-6": 0, "7-8": 0, "9-10": 0}
+        for item in items:
+            score = float(item.ai_score or 0.0)
+            if score < 3:
+                buckets["0-2"] += 1
+            elif score < 5:
+                buckets["3-4"] += 1
+            elif score < 7:
+                buckets["5-6"] += 1
+            elif score < 9:
+                buckets["7-8"] += 1
+            else:
+                buckets["9-10"] += 1
+        return buckets

--- a/src/mcp/service.py
+++ b/src/mcp/service.py
@@ -363,7 +363,25 @@ class HorizonPipelineService:
         )
 
         if not items:
-            raise HorizonMcpError(code="HZ_EMPTY_INPUT", message="No items available for enrichment.")
+            self.run_store.save_items(run_id, "enriched", [])
+            meta = self.run_store.update_meta(
+                run_id,
+                {
+                    "enriched_count": 0,
+                    "citation_count": 0,
+                    "enrich_skipped": True,
+                    "enrich_skipped_reason": "empty_input",
+                },
+            )
+            return {
+                "run_id": run_id,
+                "enriched": 0,
+                "citation_count": 0,
+                "artifact": str((self.run_store.run_dir(run_id) / "enriched_items.json").resolve()),
+                "meta": meta,
+                "skipped": True,
+                "reason": "empty_input",
+            }
 
         ai_client = ctx.runtime.create_ai_client(ctx.config.ai)
         enricher = ctx.runtime.ContentEnricher(ai_client)
@@ -380,6 +398,7 @@ class HorizonPipelineService:
             {
                 "enriched_count": len(items),
                 "citation_count": citation_count,
+                "enrich_skipped": False,
             },
         )
 
@@ -483,7 +502,7 @@ class HorizonPipelineService:
 
         enrich_result: dict[str, Any] | None = None
         stage_for_summary = "filtered"
-        if enrich:
+        if enrich and filter_result["kept"] > 0:
             enrich_result = await self.enrich_items(
                 run_id=run_id,
                 source_stage="filtered",
@@ -491,6 +510,14 @@ class HorizonPipelineService:
                 config_path=config_path,
             )
             stage_for_summary = "enriched"
+        elif enrich:
+            enrich_result = {
+                "run_id": run_id,
+                "enriched": 0,
+                "citation_count": 0,
+                "skipped": True,
+                "reason": "empty_filtered_stage",
+            }
 
         ctx, _, _ = self._build_context(
             horizon_path=horizon_path,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_ai_analysis.py
+++ b/tests/test_ai_analysis.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from src.ai.analyzer import ContentAnalyzer
+from src.ai.client import OpenAIClient
+from src.models import AIConfig, AIProvider, ContentItem, SourceType
+
+
+class FakeAIClient:
+    def __init__(self, response: str):
+        self.response = response
+
+    async def complete(
+        self,
+        system: str,
+        user: str,
+        temperature: float = 0.3,
+        max_tokens: int = 4096,
+    ) -> str:
+        return self.response
+
+
+def make_item() -> ContentItem:
+    return ContentItem(
+        id="telegram:test:1",
+        source_type=SourceType.TELEGRAM,
+        title="Structured output regression",
+        url="https://example.com/post",
+        content="This is a test item.",
+        author="tester",
+        published_at=datetime.now(timezone.utc),
+    )
+
+
+def test_openai_client_extracts_structured_message_content(monkeypatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    config = AIConfig(provider=AIProvider.OPENAI, model="deepseek-chat", api_key_env="OPENAI_API_KEY")
+    client = OpenAIClient(config)
+
+    class FakeCompletions:
+        async def create(self, **kwargs):  # type: ignore[no-untyped-def]
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(
+                            content=[
+                                {"type": "text", "text": '{"score": 9, "reason": "high impact"}'},
+                            ]
+                        )
+                    )
+                ]
+            )
+
+    client.client = SimpleNamespace(chat=SimpleNamespace(completions=FakeCompletions()))
+
+    result = asyncio.run(client.complete(system="sys", user="usr"))
+
+    assert result == '{"score": 9, "reason": "high impact"}'
+
+
+def test_content_analyzer_parses_wrapped_json_response() -> None:
+    analyzer = ContentAnalyzer(
+        FakeAIClient(
+            """
+            <think>hidden reasoning</think>
+            Here is the result:
+            ```json
+            {
+              "score": "8/10",
+              "reason": "Useful technical update.",
+              "summary": "A concise summary.",
+              "tags": "ai, tooling, mcp"
+            }
+            ```
+            """
+        )
+    )
+    item = make_item()
+
+    analyzed = asyncio.run(analyzer.analyze_batch([item]))
+
+    assert analyzed[0].ai_score == 8.0
+    assert analyzed[0].ai_reason == "Useful technical update."
+    assert analyzed[0].ai_summary == "A concise summary."
+    assert analyzed[0].ai_tags == ["ai", "tooling", "mcp"]

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from src.mcp.horizon_adapter import _load_mcp_secrets, resolve_config_path, resolve_horizon_path
+
+
+def test_resolve_horizon_path_accepts_explicit_repo() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+
+    assert resolve_horizon_path(str(repo_root)) == repo_root.resolve()
+
+
+def test_resolve_config_path_defaults_to_repo_data_config() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+
+    assert resolve_config_path(repo_root) == (repo_root / "data" / "config.json").resolve()
+
+
+def test_load_mcp_secrets_loads_generic_env_keys(tmp_path: Path, monkeypatch) -> None:
+    secrets_path = tmp_path / "mcp.secrets.json"
+    secrets_path.write_text(
+        json.dumps(
+            {
+                "env": {
+                    "ANTHROPIC_API_KEY": "sk-ant-test",
+                    "CUSTOM_TOKEN": "token-123",
+                    "lowercase": "ignored",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    repo_root = Path(__file__).resolve().parents[1]
+    monkeypatch.setenv("HORIZON_MCP_SECRETS_PATH", str(secrets_path))
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("CUSTOM_TOKEN", raising=False)
+
+    _load_mcp_secrets(repo_root, override=False)
+
+    assert os.environ["ANTHROPIC_API_KEY"] == "sk-ant-test"
+    assert os.environ["CUSTOM_TOKEN"] == "token-123"
+    assert "lowercase" not in os.environ

--- a/tests/test_mcp_errors.py
+++ b/tests/test_mcp_errors.py
@@ -1,0 +1,8 @@
+from src.mcp.errors import HorizonMcpError
+
+
+def test_horizon_mcp_error_string_representation() -> None:
+    err = HorizonMcpError(code="E_TEST", message="boom", details={"k": "v"})
+
+    assert str(err) == "E_TEST: boom"
+    assert err.details == {"k": "v"}

--- a/tests/test_mcp_run_store.py
+++ b/tests/test_mcp_run_store.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.mcp.run_store import RunStore
+
+
+def test_create_run_writes_meta(tmp_path: Path) -> None:
+    store = RunStore(tmp_path)
+
+    run_id = store.create_run()
+    meta = store.load_meta(run_id)
+
+    assert run_id.startswith("run-")
+    assert meta["run_id"] == run_id
+    assert "created_at" in meta
+
+
+def test_save_and_load_stage_items(tmp_path: Path) -> None:
+    store = RunStore(tmp_path)
+    run_id = store.create_run("run-fixed")
+    items = [{"title": "foo"}, {"title": "bar"}]
+
+    path = store.save_items(run_id, "raw", items)
+    loaded = store.load_items(run_id, "raw")
+
+    assert path.name == "raw_items.json"
+    assert loaded == items
+    assert store.has_stage(run_id, "raw") is True
+
+
+def test_update_meta_sets_updated_at(tmp_path: Path) -> None:
+    store = RunStore(tmp_path)
+    run_id = store.create_run("run-meta")
+
+    meta = store.update_meta(run_id, {"status": "done"})
+
+    assert meta["status"] == "done"
+    assert "updated_at" in meta
+
+
+def test_save_and_load_summary(tmp_path: Path) -> None:
+    store = RunStore(tmp_path)
+    run_id = store.create_run("run-summary")
+
+    saved = store.save_summary(run_id, "zh", "# 摘要")
+    content = store.load_summary(run_id, "zh")
+
+    assert saved.name == "summary-zh.md"
+    assert content == "# 摘要"
+
+
+def test_unsupported_stage_raises(tmp_path: Path) -> None:
+    store = RunStore(tmp_path)
+    run_id = store.create_run("run-invalid-stage")
+
+    with pytest.raises(ValueError, match="Unsupported stage"):
+        store.save_items(run_id, "unknown", [])
+
+
+def test_missing_run_raises(tmp_path: Path) -> None:
+    store = RunStore(tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="Run not found"):
+        store.run_dir("missing-run")
+
+
+def test_missing_artifact_raises(tmp_path: Path) -> None:
+    store = RunStore(tmp_path)
+    run_id = store.create_run("run-missing-file")
+
+    with pytest.raises(FileNotFoundError, match="Artifact not found"):
+        store.read_json(run_id, "does-not-exist.json")
+
+
+def test_list_runs_returns_desc_order(tmp_path: Path) -> None:
+    store = RunStore(tmp_path)
+    run1 = store.create_run("run-1")
+    store.update_meta(run1, {"seq": 1})
+    run2 = store.create_run("run-2")
+    store.update_meta(run2, {"seq": 2})
+
+    runs = store.list_runs(limit=10)
+
+    assert runs[0]["run_id"] == "run-2"
+    assert runs[1]["run_id"] == "run-1"

--- a/tests/test_mcp_service_smoke.py
+++ b/tests/test_mcp_service_smoke.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from src.mcp.server import hz_get_metrics
+from src.mcp.service import HorizonPipelineService
+
+
+def test_validate_config_smoke(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        (repo_root / "data" / "config.example.json").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    service = HorizonPipelineService(runs_root=tmp_path / "mcp-runs")
+    result = asyncio.run(
+        service.validate_config(
+            horizon_path=str(repo_root),
+            config_path=str(config_path),
+            check_env=False,
+        )
+    )
+
+    assert result["config_path"] == str(config_path.resolve())
+    assert result["enabled_sources"]
+    assert result["missing_env"] == []
+
+
+def test_get_effective_config_can_filter_sources(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        (repo_root / "data" / "config.example.json").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    service = HorizonPipelineService(runs_root=tmp_path / "mcp-runs")
+    result = service.get_effective_config(
+        horizon_path=str(repo_root),
+        config_path=str(config_path),
+        sources=["rss"],
+    )
+
+    assert result["selected_sources"] == ["rss"]
+    assert result["config"]["sources"]["github"] == []
+    assert result["config"]["sources"]["rss"]
+
+
+def test_metrics_tool_smoke() -> None:
+    result = hz_get_metrics()
+
+    assert result["ok"] is True
+    assert result["tool"] == "hz_get_metrics"

--- a/tests/test_mcp_service_smoke.py
+++ b/tests/test_mcp_service_smoke.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from types import SimpleNamespace
 
 from src.mcp.server import hz_get_metrics
 from src.mcp.service import HorizonPipelineService
@@ -54,3 +55,67 @@ def test_metrics_tool_smoke() -> None:
 
     assert result["ok"] is True
     assert result["tool"] == "hz_get_metrics"
+
+
+def test_enrich_items_returns_noop_for_empty_stage(tmp_path: Path, monkeypatch) -> None:
+    service = HorizonPipelineService(runs_root=tmp_path / "mcp-runs")
+    service.run_store.create_run("run-empty")
+
+    monkeypatch.setattr(service, "_load_stage_items", lambda **kwargs: ([], SimpleNamespace()))
+
+    result = asyncio.run(service.enrich_items(run_id="run-empty"))
+
+    assert result["run_id"] == "run-empty"
+    assert result["enriched"] == 0
+    assert result["citation_count"] == 0
+    assert result["skipped"] is True
+    assert result["reason"] == "empty_input"
+    assert service.run_store.load_items("run-empty", "enriched") == []
+    assert service.run_store.load_meta("run-empty")["enrich_skipped"] is True
+
+
+def test_run_pipeline_skips_enrich_when_filter_is_empty(tmp_path: Path, monkeypatch) -> None:
+    service = HorizonPipelineService(runs_root=tmp_path / "mcp-runs")
+    service.run_store.create_run("run-empty-filter")
+
+    async def fake_fetch_items(**kwargs):  # type: ignore[no-untyped-def]
+        return {"run_id": "run-empty-filter", "meta": {"raw_count": 3}}
+
+    async def fake_score_items(**kwargs):  # type: ignore[no-untyped-def]
+        return {"run_id": "run-empty-filter", "scored": 3}
+
+    async def fake_filter_items(**kwargs):  # type: ignore[no-untyped-def]
+        return {"run_id": "run-empty-filter", "kept": 0}
+
+    async def fail_if_called(**kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("enrich_items should not be called when filtered output is empty")
+
+    async def fake_generate_summary(**kwargs):  # type: ignore[no-untyped-def]
+        return {
+            "run_id": "run-empty-filter",
+            "language": kwargs["language"],
+            "source_stage": kwargs["source_stage"],
+            "summary_path": "summary.md",
+        }
+
+    monkeypatch.setattr(service, "fetch_items", fake_fetch_items)
+    monkeypatch.setattr(service, "score_items", fake_score_items)
+    monkeypatch.setattr(service, "filter_items", fake_filter_items)
+    monkeypatch.setattr(service, "enrich_items", fail_if_called)
+    monkeypatch.setattr(service, "generate_summary", fake_generate_summary)
+    monkeypatch.setattr(
+        service,
+        "_build_context",
+        lambda **kwargs: (
+            SimpleNamespace(config=SimpleNamespace(ai=SimpleNamespace(languages=["zh"]))),
+            [],
+            [],
+        ),
+    )
+
+    result = asyncio.run(service.run_pipeline(hours=6, enrich=True))
+
+    assert result["run_id"] == "run-empty-filter"
+    assert result["enrich"]["skipped"] is True
+    assert result["enrich"]["reason"] == "empty_filtered_stage"
+    assert result["summaries"][0]["source_stage"] == "filtered"

--- a/uv.lock
+++ b/uv.lock
@@ -251,6 +251,11 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/85/57c314a6b35336efbbdc13e5fc9ae13f6b60a0647cfa7c1221178ac6d8ae/brotlicffi-1.2.0.0.tar.gz", hash = "sha256:34345d8d1f9d534fcac2249e57a4c3c8801a33c9942ff9f8574f67a175e17adb", size = 476682, upload-time = "2025-11-21T18:17:57.334Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/87/ba6298c3d7f8d66ce80d7a487f2a487ebae74a79c6049c7c2990178ce529/brotlicffi-1.2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b13fb476a96f02e477a506423cb5e7bc21e0e3ac4c060c20ba31c44056e38c68", size = 433038, upload-time = "2026-03-05T17:57:37.96Z" },
+    { url = "https://files.pythonhosted.org/packages/00/49/16c7a77d1cae0519953ef0389a11a9c2e2e62e87d04f8e7afbae40124255/brotlicffi-1.2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:17db36fb581f7b951635cd6849553a95c6f2f53c1a707817d06eae5aeff5f6af", size = 1541124, upload-time = "2026-03-05T17:57:39.488Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/17/fab2c36ea820e2288f8c1bf562de1b6cd9f30e28d66f1ce2929a4baff6de/brotlicffi-1.2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40190192790489a7b054312163d0ce82b07d1b6e706251036898ce1684ef12e9", size = 1541983, upload-time = "2026-03-05T17:57:41.061Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c9/849a669b3b3bb8ac96005cdef04df4db658c33443a7fc704a6d4a2f07a56/brotlicffi-1.2.0.0-cp314-cp314t-win32.whl", hash = "sha256:a8079e8ecc32ecef728036a1d9b7105991ce6a5385cf51ee8c02297c90fb08c2", size = 349046, upload-time = "2026-03-05T17:57:42.76Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/25/09c0fd21cfc451fa38ad538f4d18d8be566746531f7f27143f63f8c45a9f/brotlicffi-1.2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:ca90c4266704ca0a94de8f101b4ec029624273380574e4cf19301acfa46c61a0", size = 385653, upload-time = "2026-03-05T17:57:44.224Z" },
     { url = "https://files.pythonhosted.org/packages/e4/df/a72b284d8c7bef0ed5756b41c2eb7d0219a1dd6ac6762f1c7bdbc31ef3af/brotlicffi-1.2.0.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:9458d08a7ccde8e3c0afedbf2c70a8263227a68dea5ab13590593f4c0a4fd5f4", size = 432340, upload-time = "2025-11-21T18:17:42.277Z" },
     { url = "https://files.pythonhosted.org/packages/74/2b/cc55a2d1d6fb4f5d458fba44a3d3f91fb4320aa14145799fd3a996af0686/brotlicffi-1.2.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:84e3d0020cf1bd8b8131f4a07819edee9f283721566fe044a20ec792ca8fd8b7", size = 1534002, upload-time = "2025-11-21T18:17:43.746Z" },
     { url = "https://files.pythonhosted.org/packages/e4/9c/d51486bf366fc7d6735f0e46b5b96ca58dc005b250263525a1eea3cd5d21/brotlicffi-1.2.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:33cfb408d0cff64cd50bef268c0fed397c46fbb53944aa37264148614a62e990", size = 1536547, upload-time = "2025-11-21T18:17:45.729Z" },
@@ -433,6 +438,110 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/56/95b7e30fa389756cb56630faa728da46a27b8c6eb46f9d557c68fff12b65/coverage-7.13.4.tar.gz", hash = "sha256:e5c8f6ed1e61a8b2dcdf31eb0b9bbf0130750ca79c1c49eb898e2ad86f5ccc91", size = 827239, upload-time = "2026-02-09T12:59:03.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/ad/b59e5b451cf7172b8d1043dc0fa718f23aab379bc1521ee13d4bd9bfa960/coverage-7.13.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d490ba50c3f35dd7c17953c68f3270e7ccd1c6642e2d2afe2d8e720b98f5a053", size = 219278, upload-time = "2026-02-09T12:56:31.673Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/17/0cb7ca3de72e5f4ef2ec2fa0089beafbcaaaead1844e8b8a63d35173d77d/coverage-7.13.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:19bc3c88078789f8ef36acb014d7241961dbf883fd2533d18cb1e7a5b4e28b11", size = 219783, upload-time = "2026-02-09T12:56:33.104Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/63/325d8e5b11e0eaf6d0f6a44fad444ae58820929a9b0de943fa377fe73e85/coverage-7.13.4-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3998e5a32e62fdf410c0dbd3115df86297995d6e3429af80b8798aad894ca7aa", size = 250200, upload-time = "2026-02-09T12:56:34.474Z" },
+    { url = "https://files.pythonhosted.org/packages/76/53/c16972708cbb79f2942922571a687c52bd109a7bd51175aeb7558dff2236/coverage-7.13.4-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e264226ec98e01a8e1054314af91ee6cde0eacac4f465cc93b03dbe0bce2fd7", size = 252114, upload-time = "2026-02-09T12:56:35.749Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/c2/7ab36d8b8cc412bec9ea2d07c83c48930eb4ba649634ba00cb7e4e0f9017/coverage-7.13.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a3aa4e7b9e416774b21797365b358a6e827ffadaaca81b69ee02946852449f00", size = 254220, upload-time = "2026-02-09T12:56:37.796Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/4d/cf52c9a3322c89a0e6febdfbc83bb45c0ed3c64ad14081b9503adee702e7/coverage-7.13.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:71ca20079dd8f27fcf808817e281e90220475cd75115162218d0e27549f95fef", size = 256164, upload-time = "2026-02-09T12:56:39.016Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e9/eb1dd17bd6de8289df3580e967e78294f352a5df8a57ff4671ee5fc3dcd0/coverage-7.13.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e2f25215f1a359ab17320b47bcdaca3e6e6356652e8256f2441e4ef972052903", size = 250325, upload-time = "2026-02-09T12:56:40.668Z" },
+    { url = "https://files.pythonhosted.org/packages/71/07/8c1542aa873728f72267c07278c5cc0ec91356daf974df21335ccdb46368/coverage-7.13.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d65b2d373032411e86960604dc4edac91fdfb5dca539461cf2cbe78327d1e64f", size = 251913, upload-time = "2026-02-09T12:56:41.97Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d7/c62e2c5e4483a748e27868e4c32ad3daa9bdddbba58e1bc7a15e252baa74/coverage-7.13.4-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94eb63f9b363180aff17de3e7c8760c3ba94664ea2695c52f10111244d16a299", size = 249974, upload-time = "2026-02-09T12:56:43.323Z" },
+    { url = "https://files.pythonhosted.org/packages/98/9f/4c5c015a6e98ced54efd0f5cf8d31b88e5504ecb6857585fc0161bb1e600/coverage-7.13.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e856bf6616714c3a9fbc270ab54103f4e685ba236fa98c054e8f87f266c93505", size = 253741, upload-time = "2026-02-09T12:56:45.155Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/59/0f4eef89b9f0fcd9633b5d350016f54126ab49426a70ff4c4e87446cabdc/coverage-7.13.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:65dfcbe305c3dfe658492df2d85259e0d79ead4177f9ae724b6fb245198f55d6", size = 249695, upload-time = "2026-02-09T12:56:46.636Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2c/b7476f938deb07166f3eb281a385c262675d688ff4659ad56c6c6b8e2e70/coverage-7.13.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b507778ae8a4c915436ed5c2e05b4a6cecfa70f734e19c22a005152a11c7b6a9", size = 250599, upload-time = "2026-02-09T12:56:48.13Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/34/c3420709d9846ee3785b9f2831b4d94f276f38884032dca1457fa83f7476/coverage-7.13.4-cp311-cp311-win32.whl", hash = "sha256:784fc3cf8be001197b652d51d3fd259b1e2262888693a4636e18879f613a62a9", size = 221780, upload-time = "2026-02-09T12:56:50.479Z" },
+    { url = "https://files.pythonhosted.org/packages/61/08/3d9c8613079d2b11c185b865de9a4c1a68850cfda2b357fae365cf609f29/coverage-7.13.4-cp311-cp311-win_amd64.whl", hash = "sha256:2421d591f8ca05b308cf0092807308b2facbefe54af7c02ac22548b88b95c98f", size = 222715, upload-time = "2026-02-09T12:56:51.815Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1a/54c3c80b2f056164cc0a6cdcb040733760c7c4be9d780fe655f356f433e4/coverage-7.13.4-cp311-cp311-win_arm64.whl", hash = "sha256:79e73a76b854d9c6088fe5d8b2ebe745f8681c55f7397c3c0a016192d681045f", size = 221385, upload-time = "2026-02-09T12:56:53.194Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/81/4ce2fdd909c5a0ed1f6dedb88aa57ab79b6d1fbd9b588c1ac7ef45659566/coverage-7.13.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:02231499b08dabbe2b96612993e5fc34217cdae907a51b906ac7fca8027a4459", size = 219449, upload-time = "2026-02-09T12:56:54.889Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/96/5238b1efc5922ddbdc9b0db9243152c09777804fb7c02ad1741eb18a11c0/coverage-7.13.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40aa8808140e55dc022b15d8aa7f651b6b3d68b365ea0398f1441e0b04d859c3", size = 219810, upload-time = "2026-02-09T12:56:56.33Z" },
+    { url = "https://files.pythonhosted.org/packages/78/72/2f372b726d433c9c35e56377cf1d513b4c16fe51841060d826b95caacec1/coverage-7.13.4-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5b856a8ccf749480024ff3bd7310adaef57bf31fd17e1bfc404b7940b6986634", size = 251308, upload-time = "2026-02-09T12:56:57.858Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a0/2ea570925524ef4e00bb6c82649f5682a77fac5ab910a65c9284de422600/coverage-7.13.4-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c048ea43875fbf8b45d476ad79f179809c590ec7b79e2035c662e7afa3192e3", size = 254052, upload-time = "2026-02-09T12:56:59.754Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ac/45dc2e19a1939098d783c846e130b8f862fbb50d09e0af663988f2f21973/coverage-7.13.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b7b38448866e83176e28086674fe7368ab8590e4610fb662b44e345b86d63ffa", size = 255165, upload-time = "2026-02-09T12:57:01.287Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/4d/26d236ff35abc3b5e63540d3386e4c3b192168c1d96da5cb2f43c640970f/coverage-7.13.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:de6defc1c9badbf8b9e67ae90fd00519186d6ab64e5cc5f3d21359c2a9b2c1d3", size = 257432, upload-time = "2026-02-09T12:57:02.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/55/14a966c757d1348b2e19caf699415a2a4c4f7feaa4bbc6326a51f5c7dd1b/coverage-7.13.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7eda778067ad7ffccd23ecffce537dface96212576a07924cbf0d8799d2ded5a", size = 251716, upload-time = "2026-02-09T12:57:04.056Z" },
+    { url = "https://files.pythonhosted.org/packages/77/33/50116647905837c66d28b2af1321b845d5f5d19be9655cb84d4a0ea806b4/coverage-7.13.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e87f6c587c3f34356c3759f0420693e35e7eb0e2e41e4c011cb6ec6ecbbf1db7", size = 253089, upload-time = "2026-02-09T12:57:05.503Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b4/8efb11a46e3665d92635a56e4f2d4529de6d33f2cb38afd47d779d15fc99/coverage-7.13.4-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8248977c2e33aecb2ced42fef99f2d319e9904a36e55a8a68b69207fb7e43edc", size = 251232, upload-time = "2026-02-09T12:57:06.879Z" },
+    { url = "https://files.pythonhosted.org/packages/51/24/8cd73dd399b812cc76bb0ac260e671c4163093441847ffe058ac9fda1e32/coverage-7.13.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:25381386e80ae727608e662474db537d4df1ecd42379b5ba33c84633a2b36d47", size = 255299, upload-time = "2026-02-09T12:57:08.245Z" },
+    { url = "https://files.pythonhosted.org/packages/03/94/0a4b12f1d0e029ce1ccc1c800944a9984cbe7d678e470bb6d3c6bc38a0da/coverage-7.13.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ee756f00726693e5ba94d6df2bdfd64d4852d23b09bb0bc700e3b30e6f333985", size = 250796, upload-time = "2026-02-09T12:57:10.142Z" },
+    { url = "https://files.pythonhosted.org/packages/73/44/6002fbf88f6698ca034360ce474c406be6d5a985b3fdb3401128031eef6b/coverage-7.13.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fdfc1e28e7c7cdce44985b3043bc13bbd9c747520f94a4d7164af8260b3d91f0", size = 252673, upload-time = "2026-02-09T12:57:12.197Z" },
+    { url = "https://files.pythonhosted.org/packages/de/c6/a0279f7c00e786be75a749a5674e6fa267bcbd8209cd10c9a450c655dfa7/coverage-7.13.4-cp312-cp312-win32.whl", hash = "sha256:01d4cbc3c283a17fc1e42d614a119f7f438eabb593391283adca8dc86eff1246", size = 221990, upload-time = "2026-02-09T12:57:14.085Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4e/c0a25a425fcf5557d9abd18419c95b63922e897bc86c1f327f155ef234a9/coverage-7.13.4-cp312-cp312-win_amd64.whl", hash = "sha256:9401ebc7ef522f01d01d45532c68c5ac40fb27113019b6b7d8b208f6e9baa126", size = 222800, upload-time = "2026-02-09T12:57:15.944Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ac/92da44ad9a6f4e3a7debd178949d6f3769bedca33830ce9b1dcdab589a37/coverage-7.13.4-cp312-cp312-win_arm64.whl", hash = "sha256:b1ec7b6b6e93255f952e27ab58fbc68dcc468844b16ecbee881aeb29b6ab4d8d", size = 221415, upload-time = "2026-02-09T12:57:17.497Z" },
+    { url = "https://files.pythonhosted.org/packages/db/23/aad45061a31677d68e47499197a131eea55da4875d16c1f42021ab963503/coverage-7.13.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b66a2da594b6068b48b2692f043f35d4d3693fb639d5ea8b39533c2ad9ac3ab9", size = 219474, upload-time = "2026-02-09T12:57:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/70/9b8b67a0945f3dfec1fd896c5cefb7c19d5a3a6d74630b99a895170999ae/coverage-7.13.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3599eb3992d814d23b35c536c28df1a882caa950f8f507cef23d1cbf334995ac", size = 219844, upload-time = "2026-02-09T12:57:20.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/fd/7e859f8fab324cef6c4ad7cff156ca7c489fef9179d5749b0c8d321281c2/coverage-7.13.4-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:93550784d9281e374fb5a12bf1324cc8a963fd63b2d2f223503ef0fd4aa339ea", size = 250832, upload-time = "2026-02-09T12:57:22.007Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/dc/b2442d10020c2f52617828862d8b6ee337859cd8f3a1f13d607dddda9cf7/coverage-7.13.4-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b720ce6a88a2755f7c697c23268ddc47a571b88052e6b155224347389fdf6a3b", size = 253434, upload-time = "2026-02-09T12:57:23.339Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/88/6728a7ad17428b18d836540630487231f5470fb82454871149502f5e5aa2/coverage-7.13.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7b322db1284a2ed3aa28ffd8ebe3db91c929b7a333c0820abec3d838ef5b3525", size = 254676, upload-time = "2026-02-09T12:57:24.774Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/bc/21244b1b8cedf0dff0a2b53b208015fe798d5f2a8d5348dbfece04224fff/coverage-7.13.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f4594c67d8a7c89cf922d9df0438c7c7bb022ad506eddb0fdb2863359ff78242", size = 256807, upload-time = "2026-02-09T12:57:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/97/a0/ddba7ed3251cff51006737a727d84e05b61517d1784a9988a846ba508877/coverage-7.13.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:53d133df809c743eb8bce33b24bcababb371f4441340578cd406e084d94a6148", size = 251058, upload-time = "2026-02-09T12:57:27.614Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/55/e289addf7ff54d3a540526f33751951bf0878f3809b47f6dfb3def69c6f7/coverage-7.13.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76451d1978b95ba6507a039090ba076105c87cc76fc3efd5d35d72093964d49a", size = 252805, upload-time = "2026-02-09T12:57:29.066Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4e/cc276b1fa4a59be56d96f1dabddbdc30f4ba22e3b1cd42504c37b3313255/coverage-7.13.4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7f57b33491e281e962021de110b451ab8a24182589be17e12a22c79047935e23", size = 250766, upload-time = "2026-02-09T12:57:30.522Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/1093b8f93018f8b41a8cf29636c9292502f05e4a113d4d107d14a3acd044/coverage-7.13.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:1731dc33dc276dafc410a885cbf5992f1ff171393e48a21453b78727d090de80", size = 254923, upload-time = "2026-02-09T12:57:31.946Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/55/ea2796da2d42257f37dbea1aab239ba9263b31bd91d5527cdd6db5efe174/coverage-7.13.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:bd60d4fe2f6fa7dff9223ca1bbc9f05d2b6697bc5961072e5d3b952d46e1b1ea", size = 250591, upload-time = "2026-02-09T12:57:33.842Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/7c4bb72aacf8af5020675aa633e59c1fbe296d22aed191b6a5b711eb2bc7/coverage-7.13.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9181a3ccead280b828fae232df12b16652702b49d41e99d657f46cc7b1f6ec7a", size = 252364, upload-time = "2026-02-09T12:57:35.743Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/38/a8d2ec0146479c20bbaa7181b5b455a0c41101eed57f10dd19a78ab44c80/coverage-7.13.4-cp313-cp313-win32.whl", hash = "sha256:f53d492307962561ac7de4cd1de3e363589b000ab69617c6156a16ba7237998d", size = 222010, upload-time = "2026-02-09T12:57:37.25Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/0c/dbfafbe90a185943dcfbc766fe0e1909f658811492d79b741523a414a6cc/coverage-7.13.4-cp313-cp313-win_amd64.whl", hash = "sha256:e6f70dec1cc557e52df5306d051ef56003f74d56e9c4dd7ddb07e07ef32a84dd", size = 222818, upload-time = "2026-02-09T12:57:38.734Z" },
+    { url = "https://files.pythonhosted.org/packages/04/d1/934918a138c932c90d78301f45f677fb05c39a3112b96fd2c8e60503cdc7/coverage-7.13.4-cp313-cp313-win_arm64.whl", hash = "sha256:fb07dc5da7e849e2ad31a5d74e9bece81f30ecf5a42909d0a695f8bd1874d6af", size = 221438, upload-time = "2026-02-09T12:57:40.223Z" },
+    { url = "https://files.pythonhosted.org/packages/52/57/ee93ced533bcb3e6df961c0c6e42da2fc6addae53fb95b94a89b1e33ebd7/coverage-7.13.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:40d74da8e6c4b9ac18b15331c4b5ebc35a17069410cad462ad4f40dcd2d50c0d", size = 220165, upload-time = "2026-02-09T12:57:41.639Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/e0/969fc285a6fbdda49d91af278488d904dcd7651b2693872f0ff94e40e84a/coverage-7.13.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4223b4230a376138939a9173f1bdd6521994f2aff8047fae100d6d94d50c5a12", size = 220516, upload-time = "2026-02-09T12:57:44.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b8/9531944e16267e2735a30a9641ff49671f07e8138ecf1ca13db9fd2560c7/coverage-7.13.4-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1d4be36a5114c499f9f1f9195e95ebf979460dbe2d88e6816ea202010ba1c34b", size = 261804, upload-time = "2026-02-09T12:57:45.989Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f3/e63df6d500314a2a60390d1989240d5f27318a7a68fa30ad3806e2a9323e/coverage-7.13.4-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:200dea7d1e8095cc6e98cdabe3fd1d21ab17d3cee6dab00cadbb2fe35d9c15b9", size = 263885, upload-time = "2026-02-09T12:57:47.42Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/67/7654810de580e14b37670b60a09c599fa348e48312db5b216d730857ffe6/coverage-7.13.4-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8eb931ee8e6d8243e253e5ed7336deea6904369d2fd8ae6e43f68abbf167092", size = 266308, upload-time = "2026-02-09T12:57:49.345Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/39d41eca0eab3cc82115953ad41c4e77935286c930e8fad15eaed1389d83/coverage-7.13.4-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:75eab1ebe4f2f64d9509b984f9314d4aa788540368218b858dad56dc8f3e5eb9", size = 267452, upload-time = "2026-02-09T12:57:50.811Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6d/39c0fbb8fc5cd4d2090811e553c2108cf5112e882f82505ee7495349a6bf/coverage-7.13.4-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c35eb28c1d085eb7d8c9b3296567a1bebe03ce72962e932431b9a61f28facf26", size = 261057, upload-time = "2026-02-09T12:57:52.447Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/a2/60010c669df5fa603bb5a97fb75407e191a846510da70ac657eb696b7fce/coverage-7.13.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:eb88b316ec33760714a4720feb2816a3a59180fd58c1985012054fa7aebee4c2", size = 263875, upload-time = "2026-02-09T12:57:53.938Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d9/63b22a6bdbd17f1f96e9ed58604c2a6b0e72a9133e37d663bef185877cf6/coverage-7.13.4-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7d41eead3cc673cbd38a4417deb7fd0b4ca26954ff7dc6078e33f6ff97bed940", size = 261500, upload-time = "2026-02-09T12:57:56.012Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bf/69f86ba1ad85bc3ad240e4c0e57a2e620fbc0e1645a47b5c62f0e941ad7f/coverage-7.13.4-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:fb26a934946a6afe0e326aebe0730cdff393a8bc0bbb65a2f41e30feddca399c", size = 265212, upload-time = "2026-02-09T12:57:57.5Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f2/5f65a278a8c2148731831574c73e42f57204243d33bedaaf18fa79c5958f/coverage-7.13.4-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:dae88bc0fc77edaa65c14be099bd57ee140cf507e6bfdeea7938457ab387efb0", size = 260398, upload-time = "2026-02-09T12:57:59.027Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/80/6e8280a350ee9fea92f14b8357448a242dcaa243cb2c72ab0ca591f66c8c/coverage-7.13.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:845f352911777a8e722bfce168958214951e07e47e5d5d9744109fa5fe77f79b", size = 262584, upload-time = "2026-02-09T12:58:01.129Z" },
+    { url = "https://files.pythonhosted.org/packages/22/63/01ff182fc95f260b539590fb12c11ad3e21332c15f9799cb5e2386f71d9f/coverage-7.13.4-cp313-cp313t-win32.whl", hash = "sha256:2fa8d5f8de70688a28240de9e139fa16b153cc3cbb01c5f16d88d6505ebdadf9", size = 222688, upload-time = "2026-02-09T12:58:02.736Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/43/89de4ef5d3cd53b886afa114065f7e9d3707bdb3e5efae13535b46ae483d/coverage-7.13.4-cp313-cp313t-win_amd64.whl", hash = "sha256:9351229c8c8407645840edcc277f4a2d44814d1bc34a2128c11c2a031d45a5dd", size = 223746, upload-time = "2026-02-09T12:58:05.362Z" },
+    { url = "https://files.pythonhosted.org/packages/35/39/7cf0aa9a10d470a5309b38b289b9bb07ddeac5d61af9b664fe9775a4cb3e/coverage-7.13.4-cp313-cp313t-win_arm64.whl", hash = "sha256:30b8d0512f2dc8c8747557e8fb459d6176a2c9e5731e2b74d311c03b78451997", size = 222003, upload-time = "2026-02-09T12:58:06.952Z" },
+    { url = "https://files.pythonhosted.org/packages/92/11/a9cf762bb83386467737d32187756a42094927150c3e107df4cb078e8590/coverage-7.13.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:300deaee342f90696ed186e3a00c71b5b3d27bffe9e827677954f4ee56969601", size = 219522, upload-time = "2026-02-09T12:58:08.623Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/28/56e6d892b7b052236d67c95f1936b6a7cf7c3e2634bf27610b8cbd7f9c60/coverage-7.13.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29e3220258d682b6226a9b0925bc563ed9a1ebcff3cad30f043eceea7eaf2689", size = 219855, upload-time = "2026-02-09T12:58:10.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/69/233459ee9eb0c0d10fcc2fe425a029b3fa5ce0f040c966ebce851d030c70/coverage-7.13.4-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:391ee8f19bef69210978363ca930f7328081c6a0152f1166c91f0b5fdd2a773c", size = 250887, upload-time = "2026-02-09T12:58:12.503Z" },
+    { url = "https://files.pythonhosted.org/packages/06/90/2cdab0974b9b5bbc1623f7876b73603aecac11b8d95b85b5b86b32de5eab/coverage-7.13.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0dd7ab8278f0d58a0128ba2fca25824321f05d059c1441800e934ff2efa52129", size = 253396, upload-time = "2026-02-09T12:58:14.615Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/15/ea4da0f85bf7d7b27635039e649e99deb8173fe551096ea15017f7053537/coverage-7.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78cdf0d578b15148b009ccf18c686aa4f719d887e76e6b40c38ffb61d264a552", size = 254745, upload-time = "2026-02-09T12:58:16.162Z" },
+    { url = "https://files.pythonhosted.org/packages/99/11/bb356e86920c655ca4d61daee4e2bbc7258f0a37de0be32d233b561134ff/coverage-7.13.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:48685fee12c2eb3b27c62f2658e7ea21e9c3239cba5a8a242801a0a3f6a8c62a", size = 257055, upload-time = "2026-02-09T12:58:17.892Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/0f/9ae1f8cb17029e09da06ca4e28c9e1d5c1c0a511c7074592e37e0836c915/coverage-7.13.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4e83efc079eb39480e6346a15a1bcb3e9b04759c5202d157e1dd4303cd619356", size = 250911, upload-time = "2026-02-09T12:58:19.495Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3a/adfb68558fa815cbc29747b553bc833d2150228f251b127f1ce97e48547c/coverage-7.13.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecae9737b72408d6a950f7e525f30aca12d4bd8dd95e37342e5beb3a2a8c4f71", size = 252754, upload-time = "2026-02-09T12:58:21.064Z" },
+    { url = "https://files.pythonhosted.org/packages/32/b1/540d0c27c4e748bd3cd0bd001076ee416eda993c2bae47a73b7cc9357931/coverage-7.13.4-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ae4578f8528569d3cf303fef2ea569c7f4c4059a38c8667ccef15c6e1f118aa5", size = 250720, upload-time = "2026-02-09T12:58:22.622Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/95/383609462b3ffb1fe133014a7c84fc0dd01ed55ac6140fa1093b5af7ebb1/coverage-7.13.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:6fdef321fdfbb30a197efa02d48fcd9981f0d8ad2ae8903ac318adc653f5df98", size = 254994, upload-time = "2026-02-09T12:58:24.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ba/1761138e86c81680bfc3c49579d66312865457f9fe405b033184e5793cb3/coverage-7.13.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b0f6ccf3dbe577170bebfce1318707d0e8c3650003cb4b3a9dd744575daa8b5", size = 250531, upload-time = "2026-02-09T12:58:26.271Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/8e/05900df797a9c11837ab59c4d6fe94094e029582aab75c3309a93e6fb4e3/coverage-7.13.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75fcd519f2a5765db3f0e391eb3b7d150cce1a771bf4c9f861aeab86c767a3c0", size = 252189, upload-time = "2026-02-09T12:58:27.807Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bd/29c9f2db9ea4ed2738b8a9508c35626eb205d51af4ab7bf56a21a2e49926/coverage-7.13.4-cp314-cp314-win32.whl", hash = "sha256:8e798c266c378da2bd819b0677df41ab46d78065fb2a399558f3f6cae78b2fbb", size = 222258, upload-time = "2026-02-09T12:58:29.441Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/4d/1f8e723f6829977410efeb88f73673d794075091c8c7c18848d273dc9d73/coverage-7.13.4-cp314-cp314-win_amd64.whl", hash = "sha256:245e37f664d89861cf2329c9afa2c1fe9e6d4e1a09d872c947e70718aeeac505", size = 223073, upload-time = "2026-02-09T12:58:31.026Z" },
+    { url = "https://files.pythonhosted.org/packages/51/5b/84100025be913b44e082ea32abcf1afbf4e872f5120b7a1cab1d331b1e13/coverage-7.13.4-cp314-cp314-win_arm64.whl", hash = "sha256:ad27098a189e5838900ce4c2a99f2fe42a0bf0c2093c17c69b45a71579e8d4a2", size = 221638, upload-time = "2026-02-09T12:58:32.599Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/e4/c884a405d6ead1370433dad1e3720216b4f9fd8ef5b64bfd984a2a60a11a/coverage-7.13.4-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:85480adfb35ffc32d40918aad81b89c69c9cc5661a9b8a81476d3e645321a056", size = 220246, upload-time = "2026-02-09T12:58:34.181Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5c/4d7ed8b23b233b0fffbc9dfec53c232be2e695468523242ea9fd30f97ad2/coverage-7.13.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79be69cf7f3bf9b0deeeb062eab7ac7f36cd4cc4c4dd694bd28921ba4d8596cc", size = 220514, upload-time = "2026-02-09T12:58:35.704Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6f/3284d4203fd2f28edd73034968398cd2d4cb04ab192abc8cff007ea35679/coverage-7.13.4-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:caa421e2684e382c5d8973ac55e4f36bed6821a9bad5c953494de960c74595c9", size = 261877, upload-time = "2026-02-09T12:58:37.864Z" },
+    { url = "https://files.pythonhosted.org/packages/09/aa/b672a647bbe1556a85337dc95bfd40d146e9965ead9cc2fe81bde1e5cbce/coverage-7.13.4-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14375934243ee05f56c45393fe2ce81fe5cc503c07cee2bdf1725fb8bef3ffaf", size = 264004, upload-time = "2026-02-09T12:58:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/79/a1/aa384dbe9181f98bba87dd23dda436f0c6cf2e148aecbb4e50fc51c1a656/coverage-7.13.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25a41c3104d08edb094d9db0d905ca54d0cd41c928bb6be3c4c799a54753af55", size = 266408, upload-time = "2026-02-09T12:58:41.852Z" },
+    { url = "https://files.pythonhosted.org/packages/53/5e/5150bf17b4019bc600799f376bb9606941e55bd5a775dc1e096b6ffea952/coverage-7.13.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f01afcff62bf9a08fb32b2c1d6e924236c0383c02c790732b6537269e466a72", size = 267544, upload-time = "2026-02-09T12:58:44.093Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ed/f1de5c675987a4a7a672250d2c5c9d73d289dbf13410f00ed7181d8017dd/coverage-7.13.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:eb9078108fbf0bcdde37c3f4779303673c2fa1fe8f7956e68d447d0dd426d38a", size = 260980, upload-time = "2026-02-09T12:58:45.721Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/e3/fe758d01850aa172419a6743fe76ba8b92c29d181d4f676ffe2dae2ba631/coverage-7.13.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e086334e8537ddd17e5f16a344777c1ab8194986ec533711cbe6c41cde841b6", size = 263871, upload-time = "2026-02-09T12:58:47.334Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/76/b829869d464115e22499541def9796b25312b8cf235d3bb00b39f1675395/coverage-7.13.4-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:725d985c5ab621268b2edb8e50dfe57633dc69bda071abc470fed55a14935fd3", size = 261472, upload-time = "2026-02-09T12:58:48.995Z" },
+    { url = "https://files.pythonhosted.org/packages/14/9e/caedb1679e73e2f6ad240173f55218488bfe043e38da577c4ec977489915/coverage-7.13.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:3c06f0f1337c667b971ca2f975523347e63ec5e500b9aa5882d91931cd3ef750", size = 265210, upload-time = "2026-02-09T12:58:51.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/10/0dd02cb009b16ede425b49ec344aba13a6ae1dc39600840ea6abcb085ac4/coverage-7.13.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:590c0ed4bf8e85f745e6b805b2e1c457b2e33d5255dd9729743165253bc9ad39", size = 260319, upload-time = "2026-02-09T12:58:53.081Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8e/234d2c927af27c6d7a5ffad5bd2cf31634c46a477b4c7adfbfa66baf7ebb/coverage-7.13.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eb30bf180de3f632cd043322dad5751390e5385108b2807368997d1a92a509d0", size = 262638, upload-time = "2026-02-09T12:58:55.258Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/64/e5547c8ff6964e5965c35a480855911b61509cce544f4d442caa759a0702/coverage-7.13.4-cp314-cp314t-win32.whl", hash = "sha256:c4240e7eded42d131a2d2c4dec70374b781b043ddc79a9de4d55ca71f8e98aea", size = 223040, upload-time = "2026-02-09T12:58:56.936Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/96/38086d58a181aac86d503dfa9c47eb20715a79c3e3acbdf786e92e5c09a8/coverage-7.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4c7d3cc01e7350f2f0f6f7036caaf5673fb56b6998889ccfe9e1c1fe75a9c932", size = 224148, upload-time = "2026-02-09T12:58:58.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/72/8d10abd3740a0beb98c305e0c3faf454366221c0f37a8bcf8f60020bb65a/coverage-7.13.4-cp314-cp314t-win_arm64.whl", hash = "sha256:23e3f687cf945070d1c90f85db66d11e3025665d8dafa831301a0e0038f3db9b", size = 222172, upload-time = "2026-02-09T12:59:00.396Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/4a/331fe2caf6799d591109bb9c08083080f6de90a823695d412a935622abb2/coverage-7.13.4-py3-none-any.whl", hash = "sha256:1af1641e57cf7ba1bd67d677c9abdbcd6cc2ab7da3bca7fa1e2b7e50e65f2ad0", size = 211242, upload-time = "2026-02-09T12:59:02.032Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
 
 [[package]]
@@ -729,11 +838,18 @@ dependencies = [
     { name = "google-genai" },
     { name = "httpx" },
     { name = "markdown" },
+    { name = "mcp" },
     { name = "openai" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "rich" },
     { name = "tenacity" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
 ]
 
 [package.metadata]
@@ -745,12 +861,16 @@ requires-dist = [
     { name = "google-genai", specifier = ">=0.3.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "markdown", specifier = ">=3.10.2" },
+    { name = "mcp", specifier = ">=1.0.0" },
     { name = "openai", specifier = ">=1.54.0" },
     { name = "pydantic", specifier = ">=2.9.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "rich", specifier = ">=13.9.0" },
     { name = "tenacity", specifier = ">=9.0.0" },
 ]
+provides-extras = ["dev"]
 
 [[package]]
 name = "hpack"
@@ -802,6 +922,15 @@ socks = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "hyperframe"
 version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -817,6 +946,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -902,6 +1040,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
     { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
     { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -1025,6 +1190,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
 ]
 
 [[package]]
@@ -1170,6 +1360,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/92/e5/3d197a0947a166649f566706d7a4c8f7fe38f1fa7b24c9bcffe4c7591d44/openai-2.21.0.tar.gz", hash = "sha256:81b48ce4b8bbb2cc3af02047ceb19561f7b1dc0d4e52d1de7f02abfd15aa59b7", size = 644374, upload-time = "2026-02-14T00:12:01.577Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/56/0a89092a453bb2c676d66abee44f863e742b2110d4dbb1dbcca3f7e5fc33/openai-2.21.0-py3-none-any.whl", hash = "sha256:0bc1c775e5b1536c294eded39ee08f8407656537ccc71b1004104fe1602e267c", size = 1103065, upload-time = "2026-02-14T00:11:59.603Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -1452,6 +1660,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1461,12 +1683,98 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
+    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
 ]
 
 [[package]]
@@ -1495,6 +1803,114 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
 ]
 
 [[package]]
@@ -1543,12 +1959,92 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/9f/c3695c2d2d4ef70072c3a06992850498b01c6bc9be531950813716b426fa/sse_starlette-3.3.2.tar.gz", hash = "sha256:678fca55a1945c734d8472a6cad186a55ab02840b4f6786f5ee8770970579dcd", size = 32326, upload-time = "2026-02-28T11:24:34.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/28/8cb142d3fe80c4a2d8af54ca0b003f47ce0ba920974e7990fa6e016402d1/sse_starlette-3.3.2-py3-none-any.whl", hash = "sha256:5c3ea3dad425c601236726af2f27689b74494643f57017cafcb6f8c9acfbb862", size = 14270, upload-time = "2026-02-28T11:24:32.984Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "0.52.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/30/31573e9457673ab10aa432461bee537ce6cef177667deca369efb79df071/tomli-2.4.0.tar.gz", hash = "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c", size = 17477, upload-time = "2026-01-11T11:22:38.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/d9/3dc2289e1f3b32eb19b9785b6a006b28ee99acb37d1d47f78d4c10e28bf8/tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867", size = 153663, upload-time = "2026-01-11T11:21:45.27Z" },
+    { url = "https://files.pythonhosted.org/packages/51/32/ef9f6845e6b9ca392cd3f64f9ec185cc6f09f0a2df3db08cbe8809d1d435/tomli-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9", size = 148469, upload-time = "2026-01-11T11:21:46.873Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c2/506e44cce89a8b1b1e047d64bd495c22c9f71f21e05f380f1a950dd9c217/tomli-2.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:551e321c6ba03b55676970b47cb1b73f14a0a4dce6a3e1a9458fd6d921d72e95", size = 236039, upload-time = "2026-01-11T11:21:48.503Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/40/e1b65986dbc861b7e986e8ec394598187fa8aee85b1650b01dd925ca0be8/tomli-2.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e3f639a7a8f10069d0e15408c0b96a2a828cfdec6fca05296ebcdcc28ca7c76", size = 243007, upload-time = "2026-01-11T11:21:49.456Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6f/6e39ce66b58a5b7ae572a0f4352ff40c71e8573633deda43f6a379d56b3e/tomli-2.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b168f2731796b045128c45982d3a4874057626da0e2ef1fdd722848b741361d", size = 240875, upload-time = "2026-01-11T11:21:50.755Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ad/cb089cb190487caa80204d503c7fd0f4d443f90b95cf4ef5cf5aa0f439b0/tomli-2.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:133e93646ec4300d651839d382d63edff11d8978be23da4cc106f5a18b7d0576", size = 246271, upload-time = "2026-01-11T11:21:51.81Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/69125220e47fd7a3a27fd0de0c6398c89432fec41bc739823bcc66506af6/tomli-2.4.0-cp311-cp311-win32.whl", hash = "sha256:b6c78bdf37764092d369722d9946cb65b8767bfa4110f902a1b2542d8d173c8a", size = 96770, upload-time = "2026-01-11T11:21:52.647Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0d/a22bb6c83f83386b0008425a6cd1fa1c14b5f3dd4bad05e98cf3dbbf4a64/tomli-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:d3d1654e11d724760cdb37a3d7691f0be9db5fbdaef59c9f532aabf87006dbaa", size = 107626, upload-time = "2026-01-11T11:21:53.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6d/77be674a3485e75cacbf2ddba2b146911477bd887dda9d8c9dfb2f15e871/tomli-2.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:cae9c19ed12d4e8f3ebf46d1a75090e4c0dc16271c5bce1c833ac168f08fb614", size = 94842, upload-time = "2026-01-11T11:21:54.831Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/43/7389a1869f2f26dba52404e1ef13b4784b6b37dac93bac53457e3ff24ca3/tomli-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:920b1de295e72887bafa3ad9f7a792f811847d57ea6b1215154030cf131f16b1", size = 154894, upload-time = "2026-01-11T11:21:56.07Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/05/2f9bf110b5294132b2edf13fe6ca6ae456204f3d749f623307cbb7a946f2/tomli-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d6d9a4aee98fac3eab4952ad1d73aee87359452d1c086b5ceb43ed02ddb16b8", size = 149053, upload-time = "2026-01-11T11:21:57.467Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/41/1eda3ca1abc6f6154a8db4d714a4d35c4ad90adc0bcf700657291593fbf3/tomli-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36b9d05b51e65b254ea6c2585b59d2c4cb91c8a3d91d0ed0f17591a29aaea54a", size = 243481, upload-time = "2026-01-11T11:21:58.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6d/02ff5ab6c8868b41e7d4b987ce2b5f6a51d3335a70aa144edd999e055a01/tomli-2.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c8a885b370751837c029ef9bc014f27d80840e48bac415f3412e6593bbc18c1", size = 251720, upload-time = "2026-01-11T11:22:00.178Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/57/0405c59a909c45d5b6f146107c6d997825aa87568b042042f7a9c0afed34/tomli-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8768715ffc41f0008abe25d808c20c3d990f42b6e2e58305d5da280ae7d1fa3b", size = 247014, upload-time = "2026-01-11T11:22:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/2e37568edd944b4165735687cbaf2fe3648129e440c26d02223672ee0630/tomli-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b438885858efd5be02a9a133caf5812b8776ee0c969fea02c45e8e3f296ba51", size = 251820, upload-time = "2026-01-11T11:22:02.727Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/1c/ee3b707fdac82aeeb92d1a113f803cf6d0f37bdca0849cb489553e1f417a/tomli-2.4.0-cp312-cp312-win32.whl", hash = "sha256:0408e3de5ec77cc7f81960c362543cbbd91ef883e3138e81b729fc3eea5b9729", size = 97712, upload-time = "2026-01-11T11:22:03.777Z" },
+    { url = "https://files.pythonhosted.org/packages/69/13/c07a9177d0b3bab7913299b9278845fc6eaaca14a02667c6be0b0a2270c8/tomli-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:685306e2cc7da35be4ee914fd34ab801a6acacb061b6a7abca922aaf9ad368da", size = 108296, upload-time = "2026-01-11T11:22:04.86Z" },
+    { url = "https://files.pythonhosted.org/packages/18/27/e267a60bbeeee343bcc279bb9e8fbed0cbe224bc7b2a3dc2975f22809a09/tomli-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:5aa48d7c2356055feef06a43611fc401a07337d5b006be13a30f6c58f869e3c3", size = 94553, upload-time = "2026-01-11T11:22:05.854Z" },
+    { url = "https://files.pythonhosted.org/packages/34/91/7f65f9809f2936e1f4ce6268ae1903074563603b2a2bd969ebbda802744f/tomli-2.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84d081fbc252d1b6a982e1870660e7330fb8f90f676f6e78b052ad4e64714bf0", size = 154915, upload-time = "2026-01-11T11:22:06.703Z" },
+    { url = "https://files.pythonhosted.org/packages/20/aa/64dd73a5a849c2e8f216b755599c511badde80e91e9bc2271baa7b2cdbb1/tomli-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9a08144fa4cba33db5255f9b74f0b89888622109bd2776148f2597447f92a94e", size = 149038, upload-time = "2026-01-11T11:22:07.56Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8a/6d38870bd3d52c8d1505ce054469a73f73a0fe62c0eaf5dddf61447e32fa/tomli-2.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c73add4bb52a206fd0c0723432db123c0c75c280cbd67174dd9d2db228ebb1b4", size = 242245, upload-time = "2026-01-11T11:22:08.344Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bb/8002fadefb64ab2669e5b977df3f5e444febea60e717e755b38bb7c41029/tomli-2.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fb2945cbe303b1419e2706e711b7113da57b7db31ee378d08712d678a34e51e", size = 250335, upload-time = "2026-01-11T11:22:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/4cdb6f791682b2ea916af2de96121b3cb1284d7c203d97d92d6003e91c8d/tomli-2.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bbb1b10aa643d973366dc2cb1ad94f99c1726a02343d43cbc011edbfac579e7c", size = 245962, upload-time = "2026-01-11T11:22:11.27Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/4a/5f25789f9a460bd858ba9756ff52d0830d825b458e13f754952dd15fb7bb/tomli-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4cbcb367d44a1f0c2be408758b43e1ffb5308abe0ea222897d6bfc8e8281ef2f", size = 250396, upload-time = "2026-01-11T11:22:12.325Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/2f/b73a36fea58dfa08e8b3a268750e6853a6aac2a349241a905ebd86f3047a/tomli-2.4.0-cp313-cp313-win32.whl", hash = "sha256:7d49c66a7d5e56ac959cb6fc583aff0651094ec071ba9ad43df785abc2320d86", size = 97530, upload-time = "2026-01-11T11:22:13.865Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/af/ca18c134b5d75de7e8dc551c5234eaba2e8e951f6b30139599b53de9c187/tomli-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:3cf226acb51d8f1c394c1b310e0e0e61fecdd7adcb78d01e294ac297dd2e7f87", size = 108227, upload-time = "2026-01-11T11:22:15.224Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c3/b386b832f209fee8073c8138ec50f27b4460db2fdae9ffe022df89a57f9b/tomli-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:d20b797a5c1ad80c516e41bc1fb0443ddb5006e9aaa7bda2d71978346aeb9132", size = 94748, upload-time = "2026-01-11T11:22:16.009Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c4/84047a97eb1004418bc10bdbcfebda209fca6338002eba2dc27cc6d13563/tomli-2.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:26ab906a1eb794cd4e103691daa23d95c6919cc2fa9160000ac02370cc9dd3f6", size = 154725, upload-time = "2026-01-11T11:22:17.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5d/d39038e646060b9d76274078cddf146ced86dc2b9e8bbf737ad5983609a0/tomli-2.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:20cedb4ee43278bc4f2fee6cb50daec836959aadaf948db5172e776dd3d993fc", size = 148901, upload-time = "2026-01-11T11:22:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e5/383be1724cb30f4ce44983d249645684a48c435e1cd4f8b5cded8a816d3c/tomli-2.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39b0b5d1b6dd03684b3fb276407ebed7090bbec989fa55838c98560c01113b66", size = 243375, upload-time = "2026-01-11T11:22:19.154Z" },
+    { url = "https://files.pythonhosted.org/packages/31/f0/bea80c17971c8d16d3cc109dc3585b0f2ce1036b5f4a8a183789023574f2/tomli-2.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a26d7ff68dfdb9f87a016ecfd1e1c2bacbe3108f4e0f8bcd2228ef9a766c787d", size = 250639, upload-time = "2026-01-11T11:22:20.168Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8f/2853c36abbb7608e3f945d8a74e32ed3a74ee3a1f468f1ffc7d1cb3abba6/tomli-2.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:20ffd184fb1df76a66e34bd1b36b4a4641bd2b82954befa32fe8163e79f1a702", size = 246897, upload-time = "2026-01-11T11:22:21.544Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f0/6c05e3196ed5337b9fe7ea003e95fd3819a840b7a0f2bf5a408ef1dad8ed/tomli-2.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75c2f8bbddf170e8effc98f5e9084a8751f8174ea6ccf4fca5398436e0320bc8", size = 254697, upload-time = "2026-01-11T11:22:23.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f5/2922ef29c9f2951883525def7429967fc4d8208494e5ab524234f06b688b/tomli-2.4.0-cp314-cp314-win32.whl", hash = "sha256:31d556d079d72db7c584c0627ff3a24c5d3fb4f730221d3444f3efb1b2514776", size = 98567, upload-time = "2026-01-11T11:22:24.033Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/31/22b52e2e06dd2a5fdbc3ee73226d763b184ff21fc24e20316a44ccc4d96b/tomli-2.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:43e685b9b2341681907759cf3a04e14d7104b3580f808cfde1dfdb60ada85475", size = 108556, upload-time = "2026-01-11T11:22:25.378Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3d/5058dff3255a3d01b705413f64f4306a141a8fd7a251e5a495e3f192a998/tomli-2.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:3d895d56bd3f82ddd6faaff993c275efc2ff38e52322ea264122d72729dca2b2", size = 96014, upload-time = "2026-01-11T11:22:26.138Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4e/75dab8586e268424202d3a1997ef6014919c941b50642a1682df43204c22/tomli-2.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:5b5807f3999fb66776dbce568cc9a828544244a8eb84b84b9bafc080c99597b9", size = 163339, upload-time = "2026-01-11T11:22:27.143Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e3/b904d9ab1016829a776d97f163f183a48be6a4deb87304d1e0116a349519/tomli-2.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c084ad935abe686bd9c898e62a02a19abfc9760b5a79bc29644463eaf2840cb0", size = 159490, upload-time = "2026-01-11T11:22:28.399Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/5a/fc3622c8b1ad823e8ea98a35e3c632ee316d48f66f80f9708ceb4f2a0322/tomli-2.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f2e3955efea4d1cfbcb87bc321e00dc08d2bcb737fd1d5e398af111d86db5df", size = 269398, upload-time = "2026-01-11T11:22:29.345Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/33/62bd6152c8bdd4c305ad9faca48f51d3acb2df1f8791b1477d46ff86e7f8/tomli-2.4.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e0fe8a0b8312acf3a88077a0802565cb09ee34107813bba1c7cd591fa6cfc8d", size = 276515, upload-time = "2026-01-11T11:22:30.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ff/ae53619499f5235ee4211e62a8d7982ba9e439a0fb4f2f351a93d67c1dd2/tomli-2.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:413540dce94673591859c4c6f794dfeaa845e98bf35d72ed59636f869ef9f86f", size = 273806, upload-time = "2026-01-11T11:22:32.56Z" },
+    { url = "https://files.pythonhosted.org/packages/47/71/cbca7787fa68d4d0a9f7072821980b39fbb1b6faeb5f5cf02f4a5559fa28/tomli-2.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0dc56fef0e2c1c470aeac5b6ca8cc7b640bb93e92d9803ddaf9ea03e198f5b0b", size = 281340, upload-time = "2026-01-11T11:22:33.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/00/d595c120963ad42474cf6ee7771ad0d0e8a49d0f01e29576ee9195d9ecdf/tomli-2.4.0-cp314-cp314t-win32.whl", hash = "sha256:d878f2a6707cc9d53a1be1414bbb419e629c3d6e67f69230217bb663e76b5087", size = 108106, upload-time = "2026-01-11T11:22:34.451Z" },
+    { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
 ]
 
 [[package]]
@@ -1591,6 +2087,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 摘要
- 集成 Horizon 内置 MCP 服务，包括 server、run store、adapter、文档与基础 smoke tests
- 增强 AI 输出解析兼容性，支持 OpenAI 兼容接口返回的结构化 content、包裹在代码块中的 JSON、`<think>` 包裹文本以及字符串形式分数
- 当 `filtered` 阶段为空时跳过 enrichment，而不是直接中断流水线，并补充对应回归测试

## 变更说明
- `src/mcp/*`：新增 MCP 服务实现、运行产物管理、错误模型、集成文档与检查脚本
- `src/ai/client.py`：统一提取 OpenAI/Anthropic/Gemini 响应中的文本内容，减少因响应结构差异导致的解析失败
- `src/ai/analyzer.py`：增强 JSON 解析与字段归一化逻辑，提升对真实模型输出的容错能力
- `src/mcp/service.py`：在过滤结果为空时跳过 enrichment，并继续产出 summary，避免因为空输入导致全流程失败
- `tests/test_ai_analysis.py`：新增 AI 输出解析回归测试
- `tests/test_mcp_service_smoke.py`：新增空阶段与跳过 enrichment 的回归测试

## 测试结果
已执行以下自动化测试：
- `uv run pytest tests/test_ai_analysis.py tests/test_mcp_service_smoke.py`
- 结果：`7 passed, 1 warning in 1.73s`

已执行以下手动验证：
- 使用 OpenAI 兼容配置在新进程中直接调用 AI client，确认最小结构化 JSON 响应可正常返回
- 使用同一运行时在新进程中执行完整流水线 `HorizonPipelineService.run_pipeline()`，结果成功到达 `enriched` 阶段
- 实际运行结果：
  - `run_id = run-20260307T124600Z-fac8a1e6`
  - `raw_count = 34`
  - `scored_count = 34`
  - `scored_above_threshold = 15`
  - `filtered_count = 15`
  - `enriched_count = 15`
  - `summary_stage = enriched`

## 已知外部依赖告警
本次全流程验证中，主流程已成功，但部分外部数据源仍有环境相关告警：
- GitHub API 返回 `401 Unauthorized`
- `LWN.net` 返回 `403 Forbidden`
- 个别 RSS 源抓取失败

这些问题不影响本 MR 中 MCP 流程与 AI 输出兼容性修复的正确性，但如果后续要在 CI 或默认环境中启用这些数据源，建议单独补齐对应凭据或配置。

Made with [Cursor](https://cursor.com)