### PR TITLE
feat(RSS): add zh/en RSS feed buttons

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,6 +7,10 @@ url: "https://thysrael.github.io" # the base hostname & protocol for your site, 
 # Build settings
 markdown: kramdown
 future: true # Allow future posts to be published
+plugins:
+  - jekyll-feed
+feed:
+  path: feed.xml
 exclude:
   - ".github"
   - "node_modules"

--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -1,3 +1,11 @@
 <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌅</text></svg>">
 <link rel="apple-touch-icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌅</text></svg>">
 <link rel="shortcut icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌅</text></svg>">
+<link rel="alternate" type="application/rss+xml" title="Horizon Daily RSS (All)" href="{{ '/feed.xml' | relative_url }}">
+<link rel="alternate" type="application/atom+xml" title="Horizon Daily RSS (ZH)" href="{{ '/feed-zh.xml' | relative_url }}">
+<link rel="alternate" type="application/atom+xml" title="Horizon Daily RSS (EN)" href="{{ '/feed-en.xml' | relative_url }}">
+<style>
+.rss-icon{opacity:.6;color:inherit;margin-left:12px;vertical-align:middle;text-decoration:none;transition:all .2s}
+.rss-icon:hover{opacity:1;color:#f26522}
+.rss-icon svg{width:0.9em;height:0.9em;display:inline-block}
+</style>

--- a/docs/feed-en.xml
+++ b/docs/feed-en.xml
@@ -1,0 +1,22 @@
+---
+layout: null
+permalink: /feed-en.xml
+---
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>{{ site.title }} - English Digest</title>
+  <link href="{{ '/feed-en.xml' | absolute_url }}" rel="self"/>
+  <link href="{{ '/' | absolute_url }}"/>
+  <updated>{{ site.time | date_to_xmlschema }}</updated>
+  <id>{{ '/' | absolute_url }}</id>
+  {% assign en_posts = site.posts | where: "lang", "en" %}
+  {% for post in en_posts limit:50 %}
+  <entry>
+    <title>{{ post.title | escape }}</title>
+    <link href="{{ post.url | absolute_url }}"/>
+    <updated>{{ post.date | date_to_xmlschema }}</updated>
+    <id>{{ post.url | absolute_url }}</id>
+    <content type="html"><![CDATA[ {{ post.content }} ]]></content>
+  </entry>
+  {% endfor %}
+</feed>

--- a/docs/feed-zh.xml
+++ b/docs/feed-zh.xml
@@ -1,0 +1,22 @@
+---
+layout: null
+permalink: /feed-zh.xml
+---
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>{{ site.title }} - 中文摘要</title>
+  <link href="{{ '/feed-zh.xml' | absolute_url }}" rel="self"/>
+  <link href="{{ '/' | absolute_url }}"/>
+  <updated>{{ site.time | date_to_xmlschema }}</updated>
+  <id>{{ '/' | absolute_url }}</id>
+  {% assign zh_posts = site.posts | where: "lang", "zh" %}
+  {% for post in zh_posts limit:50 %}
+  <entry>
+    <title>{{ post.title | escape }}</title>
+    <link href="{{ post.url | absolute_url }}"/>
+    <updated>{{ post.date | date_to_xmlschema }}</updated>
+    <id>{{ post.url | absolute_url }}</id>
+    <content type="html"><![CDATA[ {{ post.content }} ]]></content>
+  </entry>
+  {% endfor %}
+</feed>

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ Welcome to [Horizon](https://github.com/thysrael/Horizon), an AI-driven informat
 - [Source Scrapers](scrapers) — How Horizon collects content from GitHub, Hacker News, RSS, and Reddit
 - [Scoring System](scoring) — AI-based content analysis and the 0-10 scoring scale
 
-## 中文速递
+## 中文速递 <a class="rss-icon" href="{{ '/feed-zh.xml' | relative_url }}" aria-label="订阅中文"><svg viewBox="0 0 448 512" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M128.081 415.959c0 35.369-28.672 64.041-64.041 64.041S0 451.328 0 415.959s28.672-64.041 64.041-64.041 64.04 28.673 64.04 64.041zm175.66 47.25c-8.354-154.6-132.185-278.587-286.95-286.95C7.656 175.765 0 183.105 0 192.253v48.069c0 8.415 6.49 15.472 14.887 16.018 111.832 7.284 201.473 96.702 208.772 208.772.547 8.397 7.604 14.887 16.018 14.887h48.069c9.149.001 16.489-7.655 15.995-16.79zm144.249.288C439.596 229.677 251.465 40.445 16.503 32.01 7.473 31.686 0 38.981 0 48.016v48.068c0 8.625 6.835 15.645 15.453 15.999 191.179 7.839 344.627 161.316 352.465 352.465.353 8.618 7.373 15.453 15.999 15.453h48.068c9.034-.001 16.329-7.474 16.005-16.504z"/></svg></a>
 
 <ul>
   {% assign zh_posts = site.posts | where: "lang", "zh" %}
@@ -26,7 +26,7 @@ Welcome to [Horizon](https://github.com/thysrael/Horizon), an AI-driven informat
   {% endfor %}
 </ul>
 
-## English Digest
+## English Digest <a class="rss-icon" href="{{ '/feed-en.xml' | relative_url }}" aria-label="Subscribe English"><svg viewBox="0 0 448 512" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M128.081 415.959c0 35.369-28.672 64.041-64.041 64.041S0 451.328 0 415.959s28.672-64.041 64.041-64.041 64.04 28.673 64.04 64.041zm175.66 47.25c-8.354-154.6-132.185-278.587-286.95-286.95C7.656 175.765 0 183.105 0 192.253v48.069c0 8.415 6.49 15.472 14.887 16.018 111.832 7.284 201.473 96.702 208.772 208.772.547 8.397 7.604 14.887 16.018 14.887h48.069c9.149.001 16.489-7.655 15.995-16.79zm144.249.288C439.596 229.677 251.465 40.445 16.503 32.01 7.473 31.686 0 38.981 0 48.016v48.068c0 8.625 6.835 15.645 15.453 15.999 191.179 7.839 344.627 161.316 352.465 352.465.353 8.618 7.373 15.453 15.999 15.453h48.068c9.034-.001 16.329-7.474 16.005-16.504z"/></svg></a>
 
 <ul>
   {% assign en_posts = site.posts | where: "lang", "en" %}


### PR DESCRIPTION
实现 #8 的需求：

1. 使用 jekyll-feed 插件自动生成全站的 RSS 订阅链接
2. 使用模板分别生成中英文 RSS 订阅链接
3. 在中英文标题旁分别加入 RSS 订阅按钮