### PR TITLE
feat: print token usage summary after each run

### DIFF
--- a/src/ai/client.py
+++ b/src/ai/client.py
@@ -10,6 +10,7 @@ from google import genai
 from google.genai import types
 
 from ..models import AIConfig, AIProvider
+from .tokens import record_usage
 
 
 class AIClient(ABC):
@@ -83,7 +84,13 @@ class AnthropicClient(AIClient):
             system=system,
             messages=[{"role": "user", "content": user}]
         )
-
+        usage = getattr(message, "usage", None)
+        if usage is not None:
+            record_usage(
+                "anthropic",
+                input_tokens=getattr(usage, "input_tokens", 0),
+                output_tokens=getattr(usage, "output_tokens", 0),
+            )
         return message.content[0].text
 
 
@@ -136,7 +143,13 @@ class OpenAIClient(AIClient):
             max_tokens=max_tokens,
             response_format={"type": "json_object"}
         )
-
+        usage = getattr(response, "usage", None)
+        if usage is not None:
+            record_usage(
+                "openai",
+                input_tokens=getattr(usage, "prompt_tokens", 0),
+                output_tokens=getattr(usage, "completion_tokens", 0),
+            )
         return response.choices[0].message.content
 
 
@@ -196,7 +209,13 @@ class MiniMaxClient(AIClient):
             temperature=temperature,
             max_tokens=max_tokens,
         )
-
+        usage = getattr(response, "usage", None)
+        if usage is not None:
+            record_usage(
+                "minimax",
+                input_tokens=getattr(usage, "prompt_tokens", 0),
+                output_tokens=getattr(usage, "completion_tokens", 0),
+            )
         return response.choices[0].message.content
 
 
@@ -246,7 +265,12 @@ class GeminiClient(AIClient):
                 response_mime_type="application/json"
             )
         )
-
+        usage = getattr(response, "usage_metadata", None)
+        if usage is not None:
+            total = getattr(usage, "total_token_count", 0) or 0
+            prompt = getattr(usage, "prompt_token_count", 0) or 0
+            completion = max(0, total - prompt)
+            record_usage("gemini", input_tokens=prompt, output_tokens=completion)
         return response.text
 
 

--- a/src/ai/tokens.py
+++ b/src/ai/tokens.py
@@ -1,0 +1,66 @@
+"""Lightweight token usage tracker shared across AI clients.
+
+This module keeps a simple in-memory counter of tokens used during a single
+Horizon run, so the orchestrator can print a summary at the end.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass
+class ProviderUsage:
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+    @property
+    def total(self) -> int:
+        return self.input_tokens + self.output_tokens
+
+
+@dataclass
+class TokenUsageSnapshot:
+    total_input_tokens: int
+    total_output_tokens: int
+    per_provider: Dict[str, ProviderUsage] = field(default_factory=dict)
+
+    @property
+    def total_tokens(self) -> int:
+        return self.total_input_tokens + self.total_output_tokens
+
+
+_provider_usage: Dict[str, ProviderUsage] = {}
+
+
+def record_usage(provider: str, input_tokens: int = 0, output_tokens: int = 0) -> None:
+    """Accumulate token usage for a given provider.
+
+    Args:
+        provider: Provider identifier, e.g. "openai", "anthropic".
+        input_tokens: Prompt / input tokens used.
+        output_tokens: Completion / output tokens used.
+    """
+    if input_tokens <= 0 and output_tokens <= 0:
+        return
+
+    usage = _provider_usage.setdefault(provider, ProviderUsage())
+    usage.input_tokens += max(0, input_tokens)
+    usage.output_tokens += max(0, output_tokens)
+
+
+def get_usage_snapshot() -> TokenUsageSnapshot:
+    """Return a snapshot of accumulated token usage."""
+    total_in = sum(u.input_tokens for u in _provider_usage.values())
+    total_out = sum(u.output_tokens for u in _provider_usage.values())
+    return TokenUsageSnapshot(
+        total_input_tokens=total_in,
+        total_output_tokens=total_out,
+        per_provider=dict(_provider_usage),
+    )
+
+
+def reset_usage() -> None:
+    """Reset all accumulated usage (useful for tests)."""
+    _provider_usage.clear()

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -21,6 +21,7 @@ from .ai.client import create_ai_client
 from .ai.analyzer import ContentAnalyzer
 from .ai.summarizer import DailySummarizer
 from .ai.enricher import ContentEnricher
+from .ai.tokens import get_usage_snapshot
 
 
 class HorizonOrchestrator:
@@ -161,6 +162,20 @@ class HorizonOrchestrator:
                     self.email_manager.send_daily_summary(summary, subject, subscribers)
 
             self.console.print("[bold green]✅ Horizon completed successfully![/bold green]")
+            usage = get_usage_snapshot()
+            if usage.total_tokens > 0:
+                self.console.print(
+                    f"\n🧮 Token usage this run: "
+                    f"{usage.total_tokens} tokens "
+                    f"(input: {usage.total_input_tokens}, output: {usage.total_output_tokens})"
+                )
+                for provider, u in sorted(usage.per_provider.items()):
+                    if u.total <= 0:
+                        continue
+                    self.console.print(
+                        f"   • {provider}: {u.total} tokens "
+                        f"(in: {u.input_tokens}, out: {u.output_tokens})"
+                    )
 
         except Exception as e:
             self.console.print(f"[bold red]❌ Error: {e}[/bold red]")


### PR DESCRIPTION
- Add src/ai/tokens.py for in-run usage accumulation
- Record usage in Anthropic, OpenAI, MiniMax, Gemini clients
- Orchestrator prints total and per-provider token counts on success