### PR TITLE
feat: webhook cli

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
 horizon = "src.main:main"
 horizon-mcp = "src.mcp.server:main"
 horizon-wizard = "src.setup.wizard:main"
+horizon-webhook = "src.cli_webhook:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/cli_webhook.py
+++ b/src/cli_webhook.py
@@ -1,0 +1,274 @@
+"""CLI entry point for testing webhook connectivity.
+
+Usage:
+    uv run horizon-webhook [options]
+
+This command sends a test notification using the webhook configuration
+from data/config.json, allowing you to verify connectivity and see
+the rendered content before running the full pipeline.
+"""
+
+import argparse
+import asyncio
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from dotenv import load_dotenv
+from rich.console import Console
+from rich.panel import Panel
+
+from .storage.manager import StorageManager
+from .models import ContentItem, SourceType
+from .services.webhook import WebhookNotifier, _render
+from .ai.summarizer import DailySummarizer
+
+
+console = Console()
+
+
+def _make_test_items():
+    """Create sample ContentItems for the test notification.
+
+    Each item contains both English and Chinese metadata so the
+    summarizer can render them in any configured language.
+    """
+    items = [
+        ContentItem(
+            id="github:test:1",
+            source_type=SourceType.GITHUB,
+            title="GPT-5 Released with Multimodal Capabilities",
+            url="https://example.com/gpt5",
+            content="OpenAI announced GPT-5 with major improvements.",
+            author="openai",
+            published_at=datetime(2026, 4, 24, 10, 0, tzinfo=timezone.utc),
+            fetched_at=datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc),
+            ai_score=9.0,
+            ai_summary="OpenAI released GPT-5 featuring multimodal capabilities and improved reasoning.",
+            ai_tags=["ai", "llm", "openai"],
+            metadata={
+                "title_zh": "GPT-5 发布：多模态能力大幅提升",
+                "detailed_summary_zh": "OpenAI 发布了 GPT-5，具备多模态能力和更强的推理能力。",
+            },
+        ),
+        ContentItem(
+            id="hackernews:test:2",
+            source_type=SourceType.HACKERNEWS,
+            title="New Linux Kernel 7.0 Released",
+            url="https://example.com/linux7",
+            content="Linux kernel 7.0 brings significant performance improvements.",
+            author="torvalds",
+            published_at=datetime(2026, 4, 24, 8, 0, tzinfo=timezone.utc),
+            fetched_at=datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc),
+            ai_score=7.5,
+            ai_summary="Linux kernel 7.0 released with performance gains and new hardware support.",
+            ai_tags=["linux", "kernel", "performance"],
+            metadata={
+                "title_zh": "Linux 内核 7.0 发布",
+                "detailed_summary_zh": "Linux 内核 7.0 发布，带来显著性能提升和新硬件支持。",
+            },
+        ),
+    ]
+    return items
+
+
+def _preview_variables(config, variables):
+    """Show a preview of the template rendering for the given variables."""
+    console.print("\n[bold]── Variable Rendering Preview ──[/bold]")
+
+    # Show URL rendering
+    url_env = config.url_env
+    url_value = None
+    if url_env:
+        from os import getenv
+        url_value = getenv(url_env)
+    if url_value:
+        rendered_url = _render(url_value, variables)
+        console.print(f"  [cyan]URL:[/cyan] {rendered_url}")
+
+    # Show body rendering
+    body = config.request_body
+    if body:
+        if isinstance(body, (dict, list)):
+            rendered = _render(body, variables)
+            rendered_str = json.dumps(rendered, ensure_ascii=False)
+            # Truncate for display
+            if len(rendered_str) > 3000:
+                rendered_str = rendered_str[:3000] + "\n... (truncated)"
+            console.print(Panel(rendered_str, title="Request Body (JSON)", border_style="green"))
+        elif isinstance(body, str):
+            rendered = _render(body, variables)
+            if len(rendered) > 3000:
+                rendered = rendered[:3000] + "\n... (truncated)"
+            console.print(Panel(rendered, title="Request Body (String)", border_style="green"))
+
+    # Show header rendering
+    headers = config.headers
+    if headers:
+        rendered_headers = _render(headers, variables)
+        console.print(f"  [cyan]Headers:[/cyan] {rendered_headers}")
+
+
+async def _run_test(webhook_config, lang: str, dry_run: bool, delivery_override: str = None):
+    """Execute the webhook test.
+
+    Args:
+        webhook_config: WebhookConfig from the application config
+        lang: Language code to test
+        dry_run: If True, preview without sending
+        delivery_override: Override delivery mode for this test
+    """
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    items = _make_test_items()
+    summarizer = DailySummarizer()
+    summary = await summarizer.generate_summary(items, today, len(items), language=lang)
+
+    # Use the effective config (possibly overridden)
+    effective_config = webhook_config
+    if delivery_override:
+        effective_config = webhook_config.model_copy(update={"delivery": delivery_override})
+
+    notifier = WebhookNotifier(effective_config, console=console)
+
+    if dry_run:
+        # Dry run: show what would be sent without actually sending
+        console.print(f"\n[bold yellow]── Dry Run (lang={lang}) ──[/bold yellow]")
+        console.print(f"  [cyan]Webhook enabled:[/cyan] {effective_config.enabled}")
+        console.print(f"  [cyan]URL env var:[/cyan] {effective_config.url_env}")
+        console.print(f"  [cyan]Delivery mode:[/cyan] {effective_config.delivery}")
+
+        webhook_languages = effective_config.languages
+        if webhook_languages and lang not in webhook_languages:
+            console.print(
+                f"  [yellow]Language '{lang}' is filtered out by webhook.languages={webhook_languages}. "
+                f"Notification would be skipped.[/yellow]"
+            )
+            return
+
+        # Build and preview variables for each message
+        base_vars = {
+            "date": today,
+            "language": lang,
+            "important_items": len(items),
+            "all_items": len(items),
+            "result": "success",
+            "timestamp": str(int(datetime.now(timezone.utc).timestamp())),
+        }
+
+        delivery = effective_config.delivery
+
+        if delivery == "summary_and_items":
+            console.print("\n[bold]── Message 1: Overview ──[/bold]")
+            overview = summarizer.generate_webhook_overview(items, today, len(items), language=lang)
+            overview_vars = {
+                **base_vars,
+                "message_title": f"Horizon {today} 总览" if lang == "zh" else f"Horizon {today} Overview",
+                "message_kind": "overview",
+                "summary": overview,
+            }
+            console.print(Panel(overview, title=overview_vars["message_title"], border_style="blue"))
+            _preview_variables(effective_config, overview_vars)
+
+            for i, item in enumerate(items, start=1):
+                console.print(f"\n[bold]── Message {i + 1}: Item {i}/{len(items)} ──[/bold]")
+                title = str(item.metadata.get(f"title_{lang}") or item.title)
+                item_summary = summarizer.generate_webhook_item(item, language=lang, index=i, total=len(items))
+                item_vars = {
+                    **base_vars,
+                    "message_title": f"{i}/{len(items)} {title}",
+                    "message_kind": "item",
+                    "item_index": i,
+                    "item_count": len(items),
+                    "item_title": title,
+                    "item_url": str(item.url),
+                    "item_score": item.ai_score or "",
+                    "summary": item_summary,
+                }
+                console.print(Panel(item_summary, title=item_vars["message_title"], border_style="green"))
+                _preview_variables(effective_config, item_vars)
+        else:
+            console.print("\n[bold]── Message: Summary ──[/bold]")
+            summary_vars = {
+                **base_vars,
+                "message_title": f"Horizon {today} 日报" if lang == "zh" else f"Horizon {today} Daily",
+                "message_kind": "summary",
+                "summary": summary,
+            }
+            # Truncate summary for display if too long
+            display_summary = summary if len(summary) <= 3000 else summary[:3000] + "\n... (truncated)"
+            console.print(Panel(display_summary, title=summary_vars["message_title"], border_style="blue"))
+            _preview_variables(effective_config, summary_vars)
+
+        console.print("\n[green]Dry run complete. No notification was sent.[/green]")
+    else:
+        # Actually send
+        console.print(f"\n[bold]── Sending Test Notification (lang={lang}) ──[/bold]")
+        await notifier.send_daily_summary(
+            summary=summary,
+            important_items=items,
+            all_items_count=len(items),
+            date=today,
+            lang=lang,
+            summarizer=summarizer,
+        )
+        console.print("[green]Test notification sent.[/green]")
+
+
+def main():
+    """CLI entry point for horizon-webhook."""
+    parser = argparse.ArgumentParser(
+        description="Test webhook connectivity and preview rendered content",
+    )
+    parser.add_argument(
+        "--lang",
+        default=None,
+        help="Language to test (en or zh). Defaults to the first language in config.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview the rendered content without actually sending the notification.",
+    )
+    parser.add_argument(
+        "--delivery",
+        default=None,
+        choices=["summary", "summary_and_items"],
+        help="Override the delivery mode from config for this test.",
+    )
+    args = parser.parse_args()
+
+    try:
+        load_dotenv()
+
+        storage = StorageManager(data_dir=str(Path("data")))
+        try:
+            config = storage.load_config()
+        except FileNotFoundError:
+            console.print("[bold red]Configuration file not found![/bold red]")
+            console.print("Run [bold cyan]uv run horizon-wizard[/bold cyan] to set up your configuration.")
+            sys.exit(1)
+
+        if not config.webhook or not config.webhook.enabled:
+            console.print("[yellow]Webhook is not enabled in config.json.[/yellow]")
+            console.print("Set [cyan]webhook.enabled = true[/cyan] in data/config.json to enable it.")
+            sys.exit(1)
+
+        # Determine test language
+        lang = args.lang
+        if not lang:
+            lang = config.ai.languages[0] if config.ai.languages else "en"
+
+        asyncio.run(_run_test(config.webhook, lang, args.dry_run, args.delivery))
+
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Interrupted by user[/yellow]")
+        sys.exit(0)
+    except Exception as e:
+        console.print(f"\n[bold red]Error: {e}[/bold red]")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -169,61 +169,14 @@ class HorizonOrchestrator:
 
                 # Send webhook notification if configured
                 if self.webhook_notifier:
-                    webhook_languages = getattr(self.config.webhook, "languages", None) if self.config.webhook else None
-                    if webhook_languages and lang not in webhook_languages:
-                        self.console.print(f"🔕 Skipping {lang.upper()} webhook notification (filtered by webhook.languages)")
-                        continue
-
-                    self.console.print(f"🔔 Sending {lang.upper()} webhook notification...")
-                    delivery = getattr(self.config.webhook, "delivery", "summary") if self.config.webhook else "summary"
-                    base_vars = {
-                        "date": today,
-                        "language": lang,
-                        "important_items": len(important_items),
-                        "all_items": len(all_items),
-                        "result": "success",
-                        "timestamp": str(int(datetime.now(timezone.utc).timestamp())),
-                    }
-
-                    if delivery == "summary_and_items":
-                        overview = summarizer.generate_webhook_overview(
-                            important_items,
-                            today,
-                            len(all_items),
-                            language=lang,
-                        )
-                        await self.webhook_notifier.notify({
-                            **base_vars,
-                            "message_title": f"Horizon {today} 总览" if lang == "zh" else f"Horizon {today} Overview",
-                            "message_kind": "overview",
-                            "summary": overview,
-                        })
-                        for item_index, item in enumerate(important_items, start=1):
-                            title = str(item.metadata.get(f"title_{lang}") or item.title)
-                            item_summary = summarizer.generate_webhook_item(
-                                item,
-                                language=lang,
-                                index=item_index,
-                                total=len(important_items),
-                            )
-                            await self.webhook_notifier.notify({
-                                **base_vars,
-                                "message_title": f"{item_index}/{len(important_items)} {title}",
-                                "message_kind": "item",
-                                "item_index": item_index,
-                                "item_count": len(important_items),
-                                "item_title": title,
-                                "item_url": str(item.url),
-                                "item_score": item.ai_score or "",
-                                "summary": item_summary,
-                            })
-                    else:
-                        await self.webhook_notifier.notify({
-                            **base_vars,
-                            "message_title": f"Horizon {today} 日报" if lang == "zh" else f"Horizon {today} Daily",
-                            "message_kind": "summary",
-                            "summary": summary,
-                        })
+                    await self.webhook_notifier.send_daily_summary(
+                        summary=summary,
+                        important_items=important_items,
+                        all_items_count=len(all_items),
+                        date=today,
+                        lang=lang,
+                        summarizer=summarizer,
+                    )
 
             self.console.print("[bold green]✅ Horizon completed successfully![/bold green]")
             usage = get_usage_snapshot()
@@ -246,19 +199,10 @@ class HorizonOrchestrator:
 
             # Send webhook failure notification if configured
             if self.webhook_notifier:
-                self.console.print("🔔 Sending webhook failure notification...")
-                webhook_vars = {
-                    "date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
-                    "language": "",
-                    "important_items": 0,
-                    "all_items": 0,
-                    "result": "failed",
-                    "timestamp": str(int(datetime.now(timezone.utc).timestamp())),
-                    "message_title": "Horizon generation failed",
-                    "message_kind": "failure",
-                    "summary": f"generation failed: {e}",
-                }
-                await self.webhook_notifier.notify(webhook_vars)
+                await self.webhook_notifier.send_failure(
+                    date=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+                    error_message=str(e),
+                )
 
             raise
 

--- a/src/services/webhook.py
+++ b/src/services/webhook.py
@@ -5,10 +5,12 @@ import json
 import logging
 import os
 import re
-from typing import Optional, Union
+from datetime import datetime, timezone
+from typing import List, Optional, Union
 import httpx
 
-from ..models import WebhookConfig
+from ..models import ContentItem, WebhookConfig
+from ..ai.summarizer import DailySummarizer
 
 logger = logging.getLogger(__name__)
 
@@ -302,3 +304,112 @@ class WebhookNotifier:
         except Exception as e:
             self.console.print(f"[red]Webhook call failed! Exception: {e}[/red]")
             logger.error("Webhook call failed! URL: %s, exception: %s", request_url, e)
+
+    async def send_daily_summary(
+        self,
+        summary: str,
+        important_items: List[ContentItem],
+        all_items_count: int,
+        date: str,
+        lang: str,
+        summarizer: DailySummarizer,
+    ) -> None:
+        """Send daily summary webhook notification.
+
+        Handles language filtering, delivery mode (summary vs summary_and_items),
+        and variable construction internally.
+
+        Args:
+            summary: Full markdown summary text
+            important_items: List of important content items
+            all_items_count: Total number of items fetched
+            date: Date string (YYYY-MM-DD)
+            lang: Language code ("en" or "zh")
+            summarizer: DailySummarizer instance for generating webhook overviews
+        """
+        # Language filter
+        webhook_languages = getattr(self.config, "languages", None)
+        if webhook_languages and lang not in webhook_languages:
+            self.console.print(
+                f"🔕 Skipping {lang.upper()} webhook notification "
+                f"(filtered by webhook.languages)"
+            )
+            return
+
+        self.console.print(f"🔔 Sending {lang.upper()} webhook notification...")
+
+        base_vars = {
+            "date": date,
+            "language": lang,
+            "important_items": len(important_items),
+            "all_items": all_items_count,
+            "result": "success",
+            "timestamp": str(int(datetime.now(timezone.utc).timestamp())),
+        }
+
+        delivery = getattr(self.config, "delivery", "summary")
+
+        if delivery == "summary_and_items":
+            overview = summarizer.generate_webhook_overview(
+                important_items, date, all_items_count, language=lang,
+            )
+            await self.notify({
+                **base_vars,
+                "message_title": (
+                    f"Horizon {date} 总览" if lang == "zh"
+                    else f"Horizon {date} Overview"
+                ),
+                "message_kind": "overview",
+                "summary": overview,
+            })
+            for item_index, item in enumerate(important_items, start=1):
+                title = str(item.metadata.get(f"title_{lang}") or item.title)
+                item_summary = summarizer.generate_webhook_item(
+                    item, language=lang, index=item_index,
+                    total=len(important_items),
+                )
+                await self.notify({
+                    **base_vars,
+                    "message_title": f"{item_index}/{len(important_items)} {title}",
+                    "message_kind": "item",
+                    "item_index": item_index,
+                    "item_count": len(important_items),
+                    "item_title": title,
+                    "item_url": str(item.url),
+                    "item_score": item.ai_score or "",
+                    "summary": item_summary,
+                })
+        else:
+            await self.notify({
+                **base_vars,
+                "message_title": (
+                    f"Horizon {date} 日报" if lang == "zh"
+                    else f"Horizon {date} Daily"
+                ),
+                "message_kind": "summary",
+                "summary": summary,
+            })
+
+    async def send_failure(
+        self,
+        date: str,
+        error_message: str,
+    ) -> None:
+        """Send webhook notification when the pipeline fails.
+
+        Args:
+            date: Date string (YYYY-MM-DD)
+            error_message: Description of the failure
+        """
+        self.console.print("🔔 Sending webhook failure notification...")
+        await self.notify({
+            "date": date,
+            "language": "",
+            "important_items": 0,
+            "all_items": 0,
+            "result": "failed",
+            "timestamp": str(int(datetime.now(timezone.utc).timestamp())),
+            "message_title": "Horizon generation failed",
+            "message_kind": "failure",
+            "summary": f"generation failed: {error_message}",
+        })

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -3,11 +3,12 @@
 import asyncio
 import json
 import os
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 
-from src.models import WebhookConfig
+from src.models import ContentItem, SourceType, WebhookConfig
 from src.services.webhook import (
     WebhookNotifier,
     _format_markdown_for_webhook,
@@ -17,6 +18,7 @@ from src.services.webhook import (
     _isjson,
     _extract_headers,
 )
+from src.ai.summarizer import DailySummarizer
 
 _TEST_URL_ENV = "TEST_WEBHOOK_URL"
 _TEST_URL = "https://example.com/webhook"
@@ -628,3 +630,311 @@ class TestWebhookConfigModel:
         assert config.url_env == "HORIZON_WEBHOOK_URL"
         assert config.delivery == "summary_and_items"
         assert config.languages == ["zh"]
+
+
+# ── Helper to build a ContentItem for testing ──
+
+
+def _make_item(title="Test Item", url="https://example.com/test", score=8.0):
+    """Create a minimal ContentItem for webhook tests."""
+    return ContentItem(
+        id="github:test:1",
+        source_type=SourceType.GITHUB,
+        title=title,
+        url=url,
+        content="Some content",
+        author="testuser",
+        published_at=datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc),
+        fetched_at=datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc),
+        ai_score=score,
+        ai_summary="AI summary",
+        ai_tags=["test"],
+    )
+
+
+# ── send_daily_summary ──
+
+
+class TestSendDailySummary:
+    def test_summary_delivery_calls_notify_once(self):
+        """delivery='summary' sends a single notify call with message_kind='summary'."""
+        os.environ[_TEST_URL_ENV] = _TEST_URL
+        config = WebhookConfig(
+            enabled=True,
+            url_env=_TEST_URL_ENV,
+            delivery="summary",
+        )
+        notifier = WebhookNotifier(config)
+        summarizer = DailySummarizer()
+        items = [_make_item()]
+        summary = "# Horizon Daily\nTest summary"
+
+        with patch.object(notifier, "notify", new_callable=AsyncMock) as mock_notify:
+            _run_async(notifier.send_daily_summary(
+                summary=summary,
+                important_items=items,
+                all_items_count=10,
+                date="2026-04-24",
+                lang="en",
+                summarizer=summarizer,
+            ))
+            mock_notify.assert_called_once()
+            vars = mock_notify.call_args[0][0]
+            assert vars["message_kind"] == "summary"
+            assert vars["message_title"] == "Horizon 2026-04-24 Daily"
+            assert vars["summary"] == summary
+            assert vars["important_items"] == 1
+            assert vars["all_items"] == 10
+            assert vars["result"] == "success"
+            assert vars["language"] == "en"
+        del os.environ[_TEST_URL_ENV]
+
+    def test_summary_delivery_zh_lang(self):
+        """Chinese lang uses '日报' in message_title."""
+        os.environ[_TEST_URL_ENV] = _TEST_URL
+        config = WebhookConfig(
+            enabled=True,
+            url_env=_TEST_URL_ENV,
+            delivery="summary",
+        )
+        notifier = WebhookNotifier(config)
+        summarizer = DailySummarizer()
+        items = [_make_item()]
+
+        with patch.object(notifier, "notify", new_callable=AsyncMock) as mock_notify:
+            _run_async(notifier.send_daily_summary(
+                summary="## 测试摘要",
+                important_items=items,
+                all_items_count=5,
+                date="2026-04-24",
+                lang="zh",
+                summarizer=summarizer,
+            ))
+            vars = mock_notify.call_args[0][0]
+            assert vars["message_title"] == "Horizon 2026-04-24 日报"
+            assert vars["language"] == "zh"
+        del os.environ[_TEST_URL_ENV]
+
+    def test_summary_and_items_delivery_calls_notify_multiple_times(self):
+        """delivery='summary_and_items' sends overview + N item notifications."""
+        os.environ[_TEST_URL_ENV] = _TEST_URL
+        config = WebhookConfig(
+            enabled=True,
+            url_env=_TEST_URL_ENV,
+            delivery="summary_and_items",
+        )
+        notifier = WebhookNotifier(config)
+        summarizer = DailySummarizer()
+        items = [_make_item(title="Item A"), _make_item(title="Item B", url="https://example.com/b")]
+        summary = "# Full summary"
+
+        with patch.object(notifier, "notify", new_callable=AsyncMock) as mock_notify:
+            _run_async(notifier.send_daily_summary(
+                summary=summary,
+                important_items=items,
+                all_items_count=20,
+                date="2026-04-24",
+                lang="en",
+                summarizer=summarizer,
+            ))
+            # 1 overview + 2 items = 3 calls
+            assert mock_notify.call_count == 3
+
+            # First call: overview
+            overview_vars = mock_notify.call_args_list[0][0][0]
+            assert overview_vars["message_kind"] == "overview"
+            assert overview_vars["message_title"] == "Horizon 2026-04-24 Overview"
+
+            # Second call: first item
+            item1_vars = mock_notify.call_args_list[1][0][0]
+            assert item1_vars["message_kind"] == "item"
+            assert item1_vars["item_index"] == 1
+            assert item1_vars["item_count"] == 2
+            assert item1_vars["item_url"] == "https://example.com/test"
+
+            # Third call: second item
+            item2_vars = mock_notify.call_args_list[2][0][0]
+            assert item2_vars["message_kind"] == "item"
+            assert item2_vars["item_index"] == 2
+            assert item2_vars["item_url"] == "https://example.com/b"
+        del os.environ[_TEST_URL_ENV]
+
+    def test_language_filter_skips_non_matching_lang(self):
+        """webhook.languages=['zh'] skips 'en' language."""
+        os.environ[_TEST_URL_ENV] = _TEST_URL
+        config = WebhookConfig(
+            enabled=True,
+            url_env=_TEST_URL_ENV,
+            delivery="summary",
+            languages=["zh"],
+        )
+        notifier = WebhookNotifier(config)
+        summarizer = DailySummarizer()
+        items = [_make_item()]
+
+        with patch.object(notifier, "notify", new_callable=AsyncMock) as mock_notify:
+            _run_async(notifier.send_daily_summary(
+                summary="English summary",
+                important_items=items,
+                all_items_count=10,
+                date="2026-04-24",
+                lang="en",
+                summarizer=summarizer,
+            ))
+            mock_notify.assert_not_called()
+        del os.environ[_TEST_URL_ENV]
+
+    def test_language_filter_passes_matching_lang(self):
+        """webhook.languages=['zh'] allows 'zh' language."""
+        os.environ[_TEST_URL_ENV] = _TEST_URL
+        config = WebhookConfig(
+            enabled=True,
+            url_env=_TEST_URL_ENV,
+            delivery="summary",
+            languages=["zh"],
+        )
+        notifier = WebhookNotifier(config)
+        summarizer = DailySummarizer()
+        items = [_make_item()]
+
+        with patch.object(notifier, "notify", new_callable=AsyncMock) as mock_notify:
+            _run_async(notifier.send_daily_summary(
+                summary="中文摘要",
+                important_items=items,
+                all_items_count=10,
+                date="2026-04-24",
+                lang="zh",
+                summarizer=summarizer,
+            ))
+            mock_notify.assert_called_once()
+        del os.environ[_TEST_URL_ENV]
+
+    def test_no_language_filter_sends_all(self):
+        """webhook.languages=None sends for all languages."""
+        os.environ[_TEST_URL_ENV] = _TEST_URL
+        config = WebhookConfig(
+            enabled=True,
+            url_env=_TEST_URL_ENV,
+            delivery="summary",
+            languages=None,
+        )
+        notifier = WebhookNotifier(config)
+        summarizer = DailySummarizer()
+        items = [_make_item()]
+
+        with patch.object(notifier, "notify", new_callable=AsyncMock) as mock_notify:
+            _run_async(notifier.send_daily_summary(
+                summary="English summary",
+                important_items=items,
+                all_items_count=10,
+                date="2026-04-24",
+                lang="en",
+                summarizer=summarizer,
+            ))
+            mock_notify.assert_called_once()
+        del os.environ[_TEST_URL_ENV]
+
+    def test_timestamp_is_current_utc(self):
+        """timestamp variable reflects the current UTC time."""
+        os.environ[_TEST_URL_ENV] = _TEST_URL
+        config = WebhookConfig(
+            enabled=True,
+            url_env=_TEST_URL_ENV,
+            delivery="summary",
+        )
+        notifier = WebhookNotifier(config)
+        summarizer = DailySummarizer()
+        items = [_make_item()]
+
+        before = int(datetime.now(timezone.utc).timestamp())
+        with patch.object(notifier, "notify", new_callable=AsyncMock) as mock_notify:
+            _run_async(notifier.send_daily_summary(
+                summary="test",
+                important_items=items,
+                all_items_count=5,
+                date="2026-04-24",
+                lang="en",
+                summarizer=summarizer,
+            ))
+            after = int(datetime.now(timezone.utc).timestamp())
+            vars = mock_notify.call_args[0][0]
+            ts = int(vars["timestamp"])
+            assert before <= ts <= after
+        del os.environ[_TEST_URL_ENV]
+
+    def test_summary_and_items_zh_overview_title(self):
+        """summary_and_items with zh lang uses '总览' in overview title."""
+        os.environ[_TEST_URL_ENV] = _TEST_URL
+        config = WebhookConfig(
+            enabled=True,
+            url_env=_TEST_URL_ENV,
+            delivery="summary_and_items",
+        )
+        notifier = WebhookNotifier(config)
+        summarizer = DailySummarizer()
+        items = [_make_item()]
+
+        with patch.object(notifier, "notify", new_callable=AsyncMock) as mock_notify:
+            _run_async(notifier.send_daily_summary(
+                summary="中文摘要",
+                important_items=items,
+                all_items_count=10,
+                date="2026-04-24",
+                lang="zh",
+                summarizer=summarizer,
+            ))
+            overview_vars = mock_notify.call_args_list[0][0][0]
+            assert overview_vars["message_title"] == "Horizon 2026-04-24 总览"
+        del os.environ[_TEST_URL_ENV]
+
+
+# ── send_failure_notification ──
+
+
+class TestSendFailureNotification:
+    def test_failure_calls_notify_with_failure_vars(self):
+        """send_failure_notification sends notify with correct failure vars."""
+        os.environ[_TEST_URL_ENV] = _TEST_URL
+        config = WebhookConfig(
+            enabled=True,
+            url_env=_TEST_URL_ENV,
+        )
+        notifier = WebhookNotifier(config)
+
+        with patch.object(notifier, "notify", new_callable=AsyncMock) as mock_notify:
+            _run_async(notifier.send_failure(
+                date="2026-04-24",
+                error_message="something went wrong",
+            ))
+            mock_notify.assert_called_once()
+            vars = mock_notify.call_args[0][0]
+            assert vars["date"] == "2026-04-24"
+            assert vars["result"] == "failed"
+            assert vars["language"] == ""
+            assert vars["important_items"] == 0
+            assert vars["all_items"] == 0
+            assert vars["message_kind"] == "failure"
+            assert vars["message_title"] == "Horizon generation failed"
+            assert "something went wrong" in vars["summary"]
+        del os.environ[_TEST_URL_ENV]
+
+    def test_failure_timestamp_is_current_utc(self):
+        """Failure notification timestamp reflects current UTC time."""
+        os.environ[_TEST_URL_ENV] = _TEST_URL
+        config = WebhookConfig(
+            enabled=True,
+            url_env=_TEST_URL_ENV,
+        )
+        notifier = WebhookNotifier(config)
+
+        before = int(datetime.now(timezone.utc).timestamp())
+        with patch.object(notifier, "notify", new_callable=AsyncMock) as mock_notify:
+            _run_async(notifier.send_failure(
+                date="2026-04-24",
+                error_message="error",
+            ))
+            after = int(datetime.now(timezone.utc).timestamp())
+            vars = mock_notify.call_args[0][0]
+            ts = int(vars["timestamp"])
+            assert before <= ts <= after
+        del os.environ[_TEST_URL_ENV]


### PR DESCRIPTION
使用`horizon-webhook`可以快速应用用户的webhook配置，进行连通性或者模板的调整，而不需要等待horizon运行生成。比如
<img width="908" height="1070" alt="image" src="https://github.com/user-attachments/assets/85b46a40-0500-4d88-a9d3-6ce2bda0c904" />
