### PR TITLE
feat: per-item throttle to respect provider rate limits

### DIFF
--- a/src/ai/analyzer.py
+++ b/src/ai/analyzer.py
@@ -31,6 +31,10 @@ class ContentAnalyzer:
         items: List[ContentItem],
         batch_size: int = 10
     ) -> List[ContentItem]:
+        import asyncio, os
+        # Throttle between items to respect free-tier RPM limits.
+        # Gemini AI Studio free tier: ~15 RPM on flash-lite. 4.5s spacing = ~13 RPM, safe margin.
+        throttle_sec = float(os.environ.get("HORIZON_THROTTLE_SEC", "4.5"))
         analyzed_items = []
 
         with Progress(
@@ -55,6 +59,8 @@ class ContentAnalyzer:
                         item.ai_summary = item.title
                         analyzed_items.append(item)
                     progress.advance(task)
+                    if throttle_sec > 0:
+                        await asyncio.sleep(throttle_sec)
 
         return analyzed_items
 


### PR DESCRIPTION
## Problem

When using free-tier or low-RPM AI providers (Gemini AI Studio, Anthropic free tier, etc.), Horizon's scorer fires sequential requests as fast as Python can issue them. Free-tier RPM caps are typically 10-15 requests per minute on the relevant models. Without throttling, the scorer exhausts the per-minute quota within the first batch, and the tenacity retry layer (3 attempts with 2-10s exponential backoff) is too short to get out of the rate-limit window.

In real-world testing on Gemini 2.5 Flash-Lite free tier, this caused ~95% of items to fail with \`429 RESOURCE_EXHAUSTED\` even though the daily quota was nowhere near exhausted. The error wraps as \`RetryError[<Future ... raised ClientError>]\` in the scorer's catch block, hiding the underlying 429.

## Fix

Add an env-tunable \`asyncio.sleep()\` between items in \`analyze_batch\`. Default 4.5s — that's ~13 RPM, comfortably under a 15-RPM cap. Override via \`HORIZON_THROTTLE_SEC\` env var; set to \`0\` to disable entirely (e.g. for paid-tier deployments with high RPM headroom).

\`\`\`python
throttle_sec = float(os.environ.get(\"HORIZON_THROTTLE_SEC\", \"4.5\"))
...
if throttle_sec > 0:
    await asyncio.sleep(throttle_sec)
\`\`\`

Six new lines in \`src/ai/analyzer.py\`. No behavior change for users who set \`HORIZON_THROTTLE_SEC=0\` or have throughput headroom.

## Why a default of 4.5s

Most free-tier limits I tested (Gemini 2.5 Flash-Lite, Gemini 2.0 Flash) cap at ~15 RPM. Fixed 4.5s gives 13.3 RPM with margin for short bursts. Users on paid tiers with much higher RPM ceilings should set \`HORIZON_THROTTLE_SEC=1.0\` or \`0\` for full throughput.

## Tradeoffs

- A 100-item run at 4.5s/item = ~7.5 minutes added wall time. For a daily personal pipeline that's negligible. For interactive use it would be intrusive — but the analyzer isn't called interactively.
- Doesn't help with daily quotas, only RPM. Daily quota exhaustion still requires upgrading to paid tier or reducing the source list.

## Notes

- Cherry-picked from a downstream feature branch that also includes a domain-specific source-list customization. Submitting only the generalizable throttle change here.
- I'm happy to revise the default value, env var name, or move the constant to config if maintainers prefer. The minimum useful fix is the inter-item sleep; everything else is a parameter.