### PR TITLE
feat: supports running Horizon with Azure OpenAI deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@
 # AI API Keys (configure at least one)
 ANTHROPIC_API_KEY=sk-ant-xxx
 OPENAI_API_KEY=sk-xxx
+AZURE_OPENAI_API_KEY=xxx
+AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
 GOOGLE_API_KEY=xxx
 MINIMAX_API_KEY=xxx
 DASHSCOPE_API_KEY=xxx

--- a/.github/workflows/daily-summary.yml
+++ b/.github/workflows/daily-summary.yml
@@ -1,8 +1,8 @@
 name: Daily Horizon Summary
 
 on:
-  # schedule:
-  #   - cron: '0 0 */2 * *'  # Runs every 2 days at 00:00 UTC
+  schedule:
+    - cron: '0 22 * * *'  # Runs daily at 22:00 UTC (06:00 Beijing)
   workflow_dispatch:      # Allow manual trigger
 
 jobs:
@@ -33,6 +33,8 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
           LWN_KEY: ${{ secrets.LWN_KEY }}
         run: uv run horizon --hours 48
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,20 @@ Minimal manual configuration:
 
 For the full reference, see the [Configuration Guide](docs/configuration.md).
 
+**Using Azure OpenAI:**
+
+```jsonc
+{
+  "ai": {
+    "provider": "azure",
+    "model": "gpt-4o",                          // Azure deployment name
+    "api_key_env": "AZURE_OPENAI_API_KEY",
+    "azure_endpoint_env": "AZURE_OPENAI_ENDPOINT",
+    "api_version": "2024-10-21"
+  }
+}
+```
+
 ### 3. Run
 
 #### Local Installation

--- a/README_zh.md
+++ b/README_zh.md
@@ -242,6 +242,20 @@ cp data/config.example.json data/config.json  # 自定义信息源
 
 完整配置参考请查看[配置指南](docs/configuration.md)。
 
+**使用 Azure OpenAI：**
+
+```jsonc
+{
+  "ai": {
+    "provider": "azure",
+    "model": "gpt-4o",                          // Azure deployment 名称
+    "api_key_env": "AZURE_OPENAI_API_KEY",
+    "azure_endpoint_env": "AZURE_OPENAI_ENDPOINT",
+    "api_version": "2024-10-21"
+  }
+}
+```
+
 ### 3. 运行
 
 #### 本地安装

--- a/data/config.json
+++ b/data/config.json
@@ -1,10 +1,11 @@
 {
   "version": "1.0",
   "ai": {
-    "provider": "openai",
-    "model": "deepseek-v4-pro",
-    "base_url": "https://api.deepseek.com",
-    "api_key_env": "OPENAI_API_KEY",
+    "provider": "azure",
+    "model": "gpt-5.4-nano",
+    "api_key_env": "AZURE_OPENAI_API_KEY",
+    "azure_endpoint_env": "AZURE_OPENAI_ENDPOINT",
+    "api_version": "2025-04-01-preview",
     "temperature": 0.3,
     "max_tokens": 8192,
     "languages": [

--- a/src/ai/client.py
+++ b/src/ai/client.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from typing import Optional
 
 from anthropic import AsyncAnthropic
-from openai import AsyncOpenAI
+from openai import AsyncOpenAI, AsyncAzureOpenAI
 from google import genai
 from google.genai import types
 
@@ -154,6 +154,97 @@ class OpenAIClient(AIClient):
             temperature=temperature,
             max_tokens=max_tokens,
             response_format={"type": "json_object"}
+        )
+        usage = getattr(response, "usage", None)
+        if usage is not None:
+            record_usage(
+                "openai",
+                input_tokens=getattr(usage, "prompt_tokens", 0),
+                output_tokens=getattr(usage, "completion_tokens", 0),
+            )
+        return response.choices[0].message.content
+
+
+class AzureOpenAIClient(AIClient):
+    """Client for Azure OpenAI deployments.
+
+    Uses the native AsyncAzureOpenAI client, which requires the deployment
+    name (passed as `model`), azure_endpoint (resource base URL), and
+    api_version. The deployment path is assembled internally by the SDK.
+    """
+
+    # Newer reasoning-series deployments (o1/o3/gpt-5.x) reject legacy
+    # `max_tokens` and require `max_completion_tokens` instead.
+    _MODELS_REQUIRING_MAX_COMPLETION_TOKENS = ("o1", "o3", "o4", "gpt-5")
+
+    def __init__(self, config: AIConfig):
+        """Initialize Azure OpenAI client.
+
+        Args:
+            config: AI configuration
+        """
+        self.config = config
+
+        api_key = os.getenv(config.api_key_env)
+        if not api_key:
+            raise ValueError(f"Missing API key: {config.api_key_env}")
+        if not config.azure_endpoint_env:
+            raise ValueError("azure_endpoint_env is required for azure provider")
+        azure_endpoint = os.getenv(config.azure_endpoint_env)
+        if not azure_endpoint:
+            raise ValueError(f"Missing Azure endpoint: {config.azure_endpoint_env}")
+        if not config.api_version:
+            raise ValueError("api_version is required for azure provider")
+
+        self.client = AsyncAzureOpenAI(
+            api_key=api_key,
+            azure_endpoint=azure_endpoint,
+            api_version=config.api_version,
+        )
+        self.model = config.model
+        self.temperature = config.temperature
+        self.max_tokens = config.max_tokens
+        self._use_max_completion_tokens = any(
+            config.model.startswith(prefix)
+            for prefix in self._MODELS_REQUIRING_MAX_COMPLETION_TOKENS
+        )
+
+    async def complete(
+        self,
+        system: str,
+        user: str,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+    ) -> str:
+        """Generate completion using Azure OpenAI.
+
+        Args:
+            system: System prompt
+            user: User prompt
+            temperature: Sampling temperature
+            max_tokens: Maximum tokens to generate
+
+        Returns:
+            str: Generated text
+        """
+        temperature = self.temperature if temperature is None else temperature
+        max_tokens = self.max_tokens if max_tokens is None else max_tokens
+
+        tokens_kwarg = (
+            {"max_completion_tokens": max_tokens}
+            if self._use_max_completion_tokens
+            else {"max_tokens": max_tokens}
+        )
+
+        response = await self.client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            temperature=temperature,
+            response_format={"type": "json_object"},
+            **tokens_kwarg,
         )
         usage = getattr(response, "usage", None)
         if usage is not None:
@@ -371,6 +462,8 @@ def create_ai_client(config: AIConfig) -> AIClient:
         return AnthropicClient(config)
     elif config.provider == AIProvider.OPENAI:
         return OpenAIClient(config)
+    elif config.provider == AIProvider.AZURE:
+        return AzureOpenAIClient(config)
     elif config.provider == AIProvider.ALI:
         return AliClient(config)
     elif config.provider == AIProvider.GEMINI:

--- a/src/models.py
+++ b/src/models.py
@@ -40,6 +40,7 @@ class AIProvider(str, Enum):
     """Supported AI providers."""
     ANTHROPIC = "anthropic"
     OPENAI = "openai"
+    AZURE = "azure"
     ALI = "ali"
     GEMINI = "gemini"
     DOUBAO = "doubao"
@@ -57,6 +58,9 @@ class AIConfig(BaseModel):
     max_tokens: int = 4096
     throttle_sec: float = 0.0
     languages: List[str] = Field(default_factory=lambda: ["en"])
+    # Azure OpenAI specific; required when provider == AZURE
+    azure_endpoint_env: Optional[str] = None
+    api_version: Optional[str] = None
 
 
 class GitHubSourceConfig(BaseModel):


### PR DESCRIPTION
## Motivation                                                                                                                                                
  in regions or companies that require Azure for compliance/access reasons.

  ## Changes
  - Add `AZURE` to `AIProvider` enum
  - Add `azure_endpoint_env` and `api_version` fields to `AIConfig`
  - Implement `AzureOpenAIClient` using native `AsyncAzureOpenAI` SDK
  - Auto-detect o1/o3/gpt-5.x deployments that require `max_completion_tokens`
  - Read endpoint from env var (same pattern as `api_key_env`) so no
    sensitive values land in `config.json`
  - Document Azure configuration in README / README_zh

  ## Config example
  ```jsonc
  {
    "ai": {
      "provider": "azure",
      "model": "gpt-4o",
      "api_key_env": "AZURE_OPENAI_API_KEY",
      "azure_endpoint_env": "AZURE_OPENAI_ENDPOINT",
      "api_version": "2024-10-21"
    }
  }

  Backward compatibility

  No existing provider is modified. api_version and azure_endpoint_env
  are optional and only required when provider == "azure".

  Testing

  Verified locally against an Azure gpt-5.x deployment — uv run horizon --hours 24 produces ZH/EN summaries successfully.