### PR TITLE
Add SMTP username support for email delivery

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -272,6 +272,8 @@ Email delivery is optional and disabled unless `email.enabled` is `true`. Horizo
     "enabled": true,
     "smtp_server": "smtp.qq.com",
     "smtp_port": 465,
+    "smtp_username": null,
+    "imap_enabled": true,
     "imap_server": "imap.qq.com",
     "imap_port": 993,
     "email_address": "xxx@qq.com",
@@ -285,11 +287,34 @@ Email delivery is optional and disabled unless `email.enabled` is `true`. Horizo
 
 - `enabled`: Turns email subscription handling and daily email delivery on or off.
 - `smtp_server` / `smtp_port`: SMTP server used to send emails.
-- `imap_server` / `imap_port`: IMAP server used to scan incoming subscription requests.
+- `smtp_username`: Optional SMTP login username. If omitted, Horizon uses `email_address`.
+- `imap_enabled`: Turns IMAP subscribe/unsubscribe checks on or off. Set it to `false` for send-only SMTP providers.
+- `imap_server` / `imap_port`: IMAP server used to scan incoming subscription requests when `imap_enabled` is `true`.
 - `email_address`: Sender account and mailbox checked for subscription requests.
 - `password_env`: Environment variable containing the email password or app password. Defaults to `EMAIL_PASSWORD`.
 - `sender_name`: Display name shown in sent emails.
 - `subscribe_keyword` / `unsubscribe_keyword`: Keywords Horizon looks for in incoming email subjects.
+
+Resend SMTP example:
+
+```json
+{
+  "email": {
+    "enabled": true,
+    "smtp_server": "smtp.resend.com",
+    "smtp_port": 465,
+    "smtp_username": "resend",
+    "password_env": "RESEND_API_KEY",
+    "imap_enabled": false,
+    "imap_server": "",
+    "imap_port": 993,
+    "email_address": "noreply@example.com",
+    "sender_name": "Horizon Daily"
+  }
+}
+```
+
+Set `RESEND_API_KEY` in `.env`. Recipients are loaded from `data/subscribers.json`.
 
 ## Webhook Notification
 

--- a/src/models.py
+++ b/src/models.py
@@ -172,8 +172,10 @@ class EmailConfig(BaseModel):
     """Email configuration for updates/subscriptions."""
     imap_server: str
     imap_port: int = 993
+    imap_enabled: bool = True
     smtp_server: str
     smtp_port: int = 465
+    smtp_username: Optional[str] = None
     email_address: str
     password_env: str = "EMAIL_PASSWORD"
     sender_name: str = "Horizon Daily"

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -54,7 +54,12 @@ class HorizonOrchestrator:
         self.console.print("[bold cyan]🌅 Horizon - Starting aggregation...[/bold cyan]\n")
 
         # Check email subscriptions if configured
-        if self.email_manager and self.config.email and self.config.email.enabled:
+        if (
+            self.email_manager
+            and self.config.email
+            and self.config.email.enabled
+            and self.config.email.imap_enabled
+        ):
             self.console.print("📧 Checking for new email subscriptions...")
             self.email_manager.check_subscriptions(self.storage)
 

--- a/src/services/email.py
+++ b/src/services/email.py
@@ -46,7 +46,7 @@ class EmailManager:
 
     def check_subscriptions(self, storage_manager):
         """Checks inbox for subscription requests and updates subscriber list."""
-        if not self.config.enabled:
+        if not self.config.enabled or not self.config.imap_enabled:
             return
 
         try:
@@ -179,7 +179,7 @@ class EmailManager:
             with smtplib.SMTP_SSL(
                 self.config.smtp_server, self.config.smtp_port
             ) as server:
-                server.login(self.config.email_address, self.pwd)
+                server.login(self.config.smtp_username or self.config.email_address, self.pwd)
 
                 for subscriber in subscribers:
                     msg = MIMEMultipart("alternative")
@@ -208,7 +208,7 @@ class EmailManager:
             with smtplib.SMTP_SSL(
                 self.config.smtp_server, self.config.smtp_port
             ) as server:
-                server.login(self.config.email_address, self.pwd)
+                server.login(self.config.smtp_username or self.config.email_address, self.pwd)
 
                 msg = MIMEText(body)
                 msg["Subject"] = subject

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -1,0 +1,92 @@
+from email.mime.multipart import MIMEMultipart
+
+from src.models import EmailConfig
+from src.services.email import EmailManager
+
+
+class FakeSMTP:
+    instances = []
+
+    def __init__(self, server, port):
+        self.server = server
+        self.port = port
+        self.login_calls = []
+        self.messages = []
+        FakeSMTP.instances.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def login(self, username, password):
+        self.login_calls.append((username, password))
+
+    def send_message(self, message):
+        self.messages.append(message)
+
+
+class FakeIMAP:
+    instances = []
+
+    def __init__(self, server, port):
+        FakeIMAP.instances.append((server, port))
+
+
+def _email_config(**overrides):
+    data = {
+        "enabled": True,
+        "smtp_server": "smtp.example.com",
+        "smtp_port": 465,
+        "imap_server": "imap.example.com",
+        "imap_port": 993,
+        "email_address": "noreply@example.com",
+        "password_env": "EMAIL_PASSWORD",
+    }
+    data.update(overrides)
+    return EmailConfig(**data)
+
+
+def test_send_daily_summary_uses_smtp_username_when_configured(monkeypatch):
+    monkeypatch.setenv("EMAIL_PASSWORD", "secret")
+    monkeypatch.setattr("src.services.email.smtplib.SMTP_SSL", FakeSMTP)
+    FakeSMTP.instances = []
+
+    config = _email_config(smtp_username="resend")
+    manager = EmailManager(config)
+
+    manager.send_daily_summary("# Hello", "Daily", ["user@example.com"])
+
+    smtp = FakeSMTP.instances[0]
+    assert smtp.login_calls == [("resend", "secret")]
+    assert len(smtp.messages) == 1
+    assert isinstance(smtp.messages[0], MIMEMultipart)
+    assert smtp.messages[0]["From"] == "Horizon Daily <noreply@example.com>"
+    assert smtp.messages[0]["To"] == "user@example.com"
+
+
+def test_send_daily_summary_falls_back_to_email_address_for_smtp_login(monkeypatch):
+    monkeypatch.setenv("EMAIL_PASSWORD", "secret")
+    monkeypatch.setattr("src.services.email.smtplib.SMTP_SSL", FakeSMTP)
+    FakeSMTP.instances = []
+
+    config = _email_config()
+    manager = EmailManager(config)
+
+    manager.send_daily_summary("# Hello", "Daily", ["user@example.com"])
+
+    assert FakeSMTP.instances[0].login_calls == [("noreply@example.com", "secret")]
+
+
+def test_check_subscriptions_skips_imap_when_disabled(monkeypatch):
+    monkeypatch.setenv("EMAIL_PASSWORD", "secret")
+    monkeypatch.setattr("src.services.email.imaplib.IMAP4_SSL", FakeIMAP)
+    FakeIMAP.instances = []
+
+    config = _email_config(imap_enabled=False)
+    manager = EmailManager(config)
+
+    manager.check_subscriptions(storage_manager=object())
+
+    assert FakeIMAP.instances == []


### PR DESCRIPTION
## Summary

  - Add optional `smtp_username` for SMTP providers where the login username differs from the sender address.
  - Add `imap_enabled` so send-only SMTP providers can skip subscription inbox checks.
  - Document Resend SMTP configuration.
  - Add email delivery tests covering custom SMTP username, fallback login behavior, and disabled IMAP checks.

  ## Tests

  - `pytest tests/test_email.py` passed.
  - Full `pytest` was run: 126 passed, 1 existing MCP smoke test failed unrelated to this change.
