### PR TITLE
feat(storage): expand ${VAR} env-var references in loaded config

### DIFF
--- a/src/storage/manager.py
+++ b/src/storage/manager.py
@@ -1,12 +1,47 @@
 """Storage manager for configuration and state persistence."""
 
 import json
+import os
+import re
 import shutil
 from pathlib import Path
+from typing import Any
 
 from pydantic import ValidationError
 
 from ..models import Config
+
+
+# Matches ${VAR_NAME} in string config values. Names follow env-var rules
+# (ASCII letters, digits, underscore; must not start with a digit).
+_ENV_VAR_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def _expand_env_vars(value: Any) -> Any:
+    """Recursively expand ``${VAR}`` references inside any string leaves.
+
+    Containers (dicts, lists, tuples) are walked; non-string leaves are
+    returned unchanged. Strings with no ``${...}`` tokens are returned
+    unchanged. References to unset variables are **left as-is**, so
+    ``${MISSING}`` round-trips to ``${MISSING}`` and surfaces as a clear
+    downstream error rather than a silent empty string.
+
+    This is intentionally identical to the behaviour ``RSSScraper`` uses
+    for RSS feed URLs, so a single ``${VAR}`` convention works everywhere
+    in the config (AI ``base_url``, feed URLs, webhook URLs, ...).
+    """
+    if isinstance(value, str):
+        return _ENV_VAR_PATTERN.sub(
+            lambda m: os.environ.get(m.group(1), m.group(0)),
+            value,
+        )
+    if isinstance(value, dict):
+        return {k: _expand_env_vars(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_expand_env_vars(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_expand_env_vars(v) for v in value)
+    return value
 
 
 class ConfigError(ValueError):
@@ -40,6 +75,11 @@ class StorageManager:
             raise ConfigError(
                 f"Invalid JSON in configuration file: {self.config_path}\n" f"Error: {e}"
             ) from e
+
+        # Expand ${VAR} references in every string value before pydantic
+        # validation. Keeps credentials / private endpoints / tenant IDs
+        # out of the JSON file so it is safe to commit to a public repo.
+        data = _expand_env_vars(data)
 
         try:
             return Config.model_validate(data)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 from pathlib import Path
-from src.storage.manager import StorageManager, ConfigError
+from src.storage.manager import StorageManager, ConfigError, _expand_env_vars
 
 def test_load_config_missing_file(tmp_path):
     storage = StorageManager(data_dir=str(tmp_path))
@@ -52,3 +52,77 @@ def test_load_config_success(tmp_path):
     config = storage.load_config()
     assert config.version == "1.0"
     assert config.ai.provider == "anthropic"
+
+
+class TestExpandEnvVars:
+    """Recursive ${VAR} expansion on config dicts/lists/strings."""
+
+    def test_expands_simple_reference(self, monkeypatch):
+        monkeypatch.setenv("FOO", "bar")
+        assert _expand_env_vars("prefix-${FOO}-suffix") == "prefix-bar-suffix"
+
+    def test_expands_multiple_references_in_one_string(self, monkeypatch):
+        monkeypatch.setenv("A", "1")
+        monkeypatch.setenv("B", "2")
+        assert _expand_env_vars("${A}/${B}") == "1/2"
+
+    def test_leaves_unset_var_as_placeholder(self, monkeypatch):
+        monkeypatch.delenv("MISSING", raising=False)
+        assert _expand_env_vars("${MISSING}") == "${MISSING}"
+
+    def test_ignores_non_matching_patterns(self):
+        assert _expand_env_vars("no braces here") == "no braces here"
+        assert _expand_env_vars("$FOO without braces") == "$FOO without braces"
+        assert _expand_env_vars("${123INVALID}") == "${123INVALID}"
+
+    def test_recurses_into_dict(self, monkeypatch):
+        monkeypatch.setenv("HOST", "api.example.com")
+        result = _expand_env_vars({"url": "https://${HOST}/v1", "port": 443})
+        assert result == {"url": "https://api.example.com/v1", "port": 443}
+
+    def test_recurses_into_list(self, monkeypatch):
+        monkeypatch.setenv("X", "hi")
+        assert _expand_env_vars(["${X}", "plain", 7]) == ["hi", "plain", 7]
+
+    def test_preserves_non_string_leaves(self):
+        assert _expand_env_vars(42) == 42
+        assert _expand_env_vars(3.14) == 3.14
+        assert _expand_env_vars(True) is True
+        assert _expand_env_vars(None) is None
+
+    def test_deeply_nested(self, monkeypatch):
+        monkeypatch.setenv("TOKEN", "secret")
+        value = {
+            "a": [
+                {"b": "Bearer ${TOKEN}"},
+                {"b": ["${TOKEN}", 1]},
+            ],
+        }
+        out = _expand_env_vars(value)
+        assert out["a"][0]["b"] == "Bearer secret"
+        assert out["a"][1]["b"] == ["secret", 1]
+
+
+def test_load_config_expands_env_vars_in_ai_base_url(tmp_path, monkeypatch):
+    """Integration: proves base_url is env-expandable end-to-end.
+
+    This is exactly the use case that keeps private/tenant endpoint
+    URLs out of version control.
+    """
+    monkeypatch.setenv("HORIZON_AI_BASE_URL", "https://private-proxy.example/v1")
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({
+        "version": "1.0",
+        "ai": {
+            "provider": "openai",
+            "model": "gpt-4o",
+            "api_key_env": "OPENAI_API_KEY",
+            "base_url": "${HORIZON_AI_BASE_URL}",
+        },
+        "sources": {"hackernews": {"enabled": True}},
+        "filtering": {"ai_score_threshold": 6.0, "time_window_hours": 24},
+    }), encoding="utf-8")
+
+    storage = StorageManager(data_dir=str(tmp_path))
+    config = storage.load_config()
+    assert config.ai.base_url == "https://private-proxy.example/v1"


### PR DESCRIPTION
## Summary

`RSSScraper` already supports `${VAR}` syntax in RSS feed URLs so users can keep tokens out of git (e.g. `${LWN_KEY}`). This PR extends exactly the same convention to **every** string value in `data/config.json`, including `ai.base_url`, webhook URLs, and nested request-body templates.

The practical motivation: keeping tenant/proxy endpoints and pre-production URLs out of a repo is important for privacy, enterprise hygiene, and some compliance regimes. Today users either hand-edit `config.json` per machine or check potentially sensitive values into git. With this change they can write:

```json
"ai": {
  "provider": "openai",
  "model": "...",
  "base_url": "${HORIZON_AI_BASE_URL}",
  "api_key_env": "OPENAI_API_KEY"
}
```

and let the real endpoint live in `.env` next to the key it is paired with.

## Scope

- [x] This PR contains **one feature / one fix / one focused change**
- [x] This PR does **not** combine multiple unrelated features

## Changes

- `src/storage/manager.py`:
  - Add `_expand_env_vars(value)`, a pure helper that recursively walks dicts/lists/tuples and rewrites `${NAME}` tokens in string leaves.
  - Call it from `StorageManager.load_config()` right after `json.load` and before `Config.model_validate`, so the rest of the codebase keeps consuming a fully-resolved `Config` with no changes.
- `tests/test_storage.py`: 9 new tests (`TestExpandEnvVars` + integration case).

## Behaviour details for reviewers

- **Unset variables are preserved verbatim** (`${MISSING}` → `${MISSING}`). This is deliberate: a typo should surface as an obvious downstream error, not a silent empty string.
- **Only valid identifiers match.** `${123bad}` and bare `$FOO` are untouched.
- **Non-string leaves are never touched** — ints, bools, `None`, and floats round-trip unchanged so numeric fields like `fetch_limit` or `ai_score_threshold` are safe.
- Recursion covers dicts, lists, and tuples, so deeply nested webhook `request_body` templates (with their many string placeholders) resolve correctly.
- The helper is imported as `_expand_env_vars` in the test file to keep it testable without making it a public API.

## Checklist

- [x] I explained the change clearly
- [x] I kept the PR focused and easy to review
- [x] I tested the change locally when applicable (full suite goes from 137 to 146 passing; `tests/test_storage.py` goes from 4 to 13)
