### PR TITLE
feat: add OSS Insight trending repos scraper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ ENV/
 data/seen.json
 data/summaries/*.md
 data/subscribers.json
+data/mcp.secrets.json
+data/mcp-secrets.json
+data/mcp-runs/
 
 docs/_posts/*.md
 

--- a/data/config.example.json
+++ b/data/config.example.json
@@ -99,6 +99,14 @@
           "symbols": ["AAPL", "MSFT", "NVDA", "GOOGL", "AMZN", "META", "TSLA"]
         }
       ]
+    },
+    "ossinsight": {
+      "enabled": false,
+      "period": "past_24_hours",
+      "languages": ["All", "Python", "TypeScript"],
+      "keywords": [],
+      "min_stars": 10,
+      "max_items": 30
     }
   },
   "filtering": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -320,6 +320,33 @@ uv pip install --only-binary=:all: openbb openbb-benzinga
 
 OpenBB provider credentials are handled by the OpenBB SDK itself, using its own environment variables or user settings. Horizon does not pass those secrets through `data/config.json`.
 
+### OSS Insight (Trending GitHub Repos)
+
+Pulls top star-gain repositories from the [OSS Insight](https://ossinsight.io) public API, which aggregates GitHub WatchEvents. Useful for surfacing repos that are gaining stars right now without needing to scrape GitHub Trending or query BigQuery.
+
+```json
+{
+  "sources": {
+    "ossinsight": {
+      "enabled": true,
+      "period": "past_24_hours",
+      "languages": ["All", "Python", "TypeScript"],
+      "keywords": [],
+      "min_stars": 10,
+      "max_items": 30
+    }
+  }
+}
+```
+
+- `period` — time window for star-gain ranking. Supported: `past_24_hours`, `past_28_days`. (`past_7_days` is currently broken upstream.)
+- `languages` — primary language buckets to query. Use `"All"` for the full ranking, or any GitHub language label such as `"Python"`, `"TypeScript"`, `"Rust"`, `"Jupyter Notebook"`. The scraper fans out one request per language and merges results.
+- `keywords` — optional case-insensitive substrings matched against `description`, `collection_names`, and `repo_name`. Only repos containing at least one keyword pass through. Leave empty to ingest everything trending.
+- `min_stars` — drop repos with fewer than this many stars gained in the period.
+- `max_items` — final cap after merging and sorting by `stars_gained` descending.
+
+No API key is required.
+
 ## Filtering
 
 Content is scored 0-10:

--- a/src/models.py
+++ b/src/models.py
@@ -16,6 +16,7 @@ class SourceType(str, Enum):
     TELEGRAM = "telegram"
     TWITTER = "twitter"
     OPENBB = "openbb"
+    OSSINSIGHT = "ossinsight"
 
 
 class ContentItem(BaseModel):
@@ -189,6 +190,27 @@ class OpenBBConfig(BaseModel):
     filings_provider: str = "sec"
 
 
+class OSSInsightConfig(BaseModel):
+    """OSS Insight trending repos source configuration.
+
+    Pulls top star-gain repositories from the OSS Insight public API and
+    emits them as ContentItems. Optional `keywords` filter limits results
+    to repos whose description, repo name, or collection names contain at
+    least one of the listed substrings (case-insensitive). Leave
+    `keywords` empty to ingest everything trending in the configured
+    languages.
+    """
+
+    enabled: bool = False
+    period: str = "past_24_hours"  # past_24_hours, past_28_days
+    languages: List[str] = Field(
+        default_factory=lambda: ["All", "Python", "TypeScript"]
+    )
+    keywords: List[str] = Field(default_factory=list)
+    min_stars: int = 5
+    max_items: int = 30
+
+
 class SourcesConfig(BaseModel):
     """All sources configuration."""
 
@@ -199,6 +221,7 @@ class SourcesConfig(BaseModel):
     telegram: TelegramConfig = Field(default_factory=TelegramConfig)
     twitter: Optional[TwitterConfig] = None
     openbb: Optional[OpenBBConfig] = None
+    ossinsight: OSSInsightConfig = Field(default_factory=OSSInsightConfig)
 
 
 class WebhookConfig(BaseModel):

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -19,6 +19,7 @@ from .scrapers.reddit import RedditScraper
 from .scrapers.telegram import TelegramScraper
 from .scrapers.twitter import TwitterScraper
 from .scrapers.openbb import OpenBBScraper
+from .scrapers.ossinsight import OSSInsightScraper
 from .ai.client import create_ai_client
 from .ai.analyzer import ContentAnalyzer
 from .ai.summarizer import DailySummarizer
@@ -273,6 +274,11 @@ class HorizonOrchestrator:
                 openbb_scraper = OpenBBScraper(self.config.sources.openbb, client)
                 tasks.append(self._fetch_with_progress("OpenBB", openbb_scraper, since))
 
+            # OSS Insight trending repos
+            if self.config.sources.ossinsight and self.config.sources.ossinsight.enabled:
+                oss_scraper = OSSInsightScraper(self.config.sources.ossinsight, client)
+                tasks.append(self._fetch_with_progress("OSS Insight", oss_scraper, since))
+
             # Fetch all concurrently
             results = await asyncio.gather(*tasks, return_exceptions=True)
 
@@ -321,6 +327,8 @@ class HorizonOrchestrator:
             return meta["feed_name"]
         if meta.get("channel"):
             return f"@{meta['channel']}"
+        if meta.get("period") and meta.get("repo"):
+            return f"ossinsight:{meta.get('primary_language', 'all')}"
         if meta.get("repo"):
             return meta["repo"]
         if meta.get("watchlist"):

--- a/src/scrapers/ossinsight.py
+++ b/src/scrapers/ossinsight.py
@@ -1,0 +1,153 @@
+"""OSS Insight trending repos scraper.
+
+Fetches star-gain rankings from api.ossinsight.io and emits them as
+ContentItems. An optional keyword filter narrows results to repos whose
+description, repo name, or collection names match at least one configured
+substring (case-insensitive). Without keywords, all trending repos in the
+configured languages flow through.
+"""
+
+from datetime import datetime, timezone
+from typing import List, Optional
+
+import httpx
+
+from ..models import ContentItem, OSSInsightConfig, SourceType
+from .base import BaseScraper
+
+
+class OSSInsightScraper(BaseScraper):
+    """Scraper for OSS Insight trending repositories endpoint."""
+
+    BASE_URL = "https://api.ossinsight.io/v1/trends/repos"
+
+    def __init__(self, config: OSSInsightConfig, http_client: httpx.AsyncClient):
+        """Initialize scraper.
+
+        Args:
+            config: OSS Insight source configuration
+            http_client: Shared async HTTP client
+        """
+        super().__init__(config, http_client)
+        self.cfg: OSSInsightConfig = config
+        self._keywords_lower = [kw.lower() for kw in self.cfg.keywords if kw]
+
+    async def fetch(self, since: datetime) -> List[ContentItem]:
+        """Fetch trending repos for each configured language and apply filters."""
+        if not self.cfg.enabled:
+            return []
+
+        items: List[ContentItem] = []
+        seen_ids: set[str] = set()
+
+        for lang in self.cfg.languages:
+            rows = await self._fetch_period(self.cfg.period, lang)
+            for row in rows:
+                item = self._row_to_item(row, lang)
+                if item is None:
+                    continue
+                if item.id in seen_ids:
+                    continue
+                if self.cfg.min_stars and self._stars_int(row) < self.cfg.min_stars:
+                    continue
+                if self._keywords_lower and not self._matches_keywords(row):
+                    continue
+                seen_ids.add(item.id)
+                items.append(item)
+
+        items.sort(key=lambda x: x.metadata.get("stars_gained", 0), reverse=True)
+        return items[: self.cfg.max_items]
+
+    async def _fetch_period(self, period: str, language: str) -> List[dict]:
+        """Call OSS Insight API for one (period, language) combo."""
+        params = {"period": period, "language": language}
+        try:
+            response = await self.client.get(
+                self.BASE_URL,
+                params=params,
+                headers={"Accept": "application/json", "User-Agent": "Horizon/1.0"},
+                timeout=20.0,
+            )
+            response.raise_for_status()
+        except httpx.HTTPError:
+            return []
+
+        payload = response.json()
+        data = payload.get("data") or {}
+        rows = data.get("rows") or []
+        return rows
+
+    def _row_to_item(self, row: dict, language: str) -> Optional[ContentItem]:
+        """Convert a raw OSS Insight row into a ContentItem."""
+        repo_name = row.get("repo_name")
+        repo_id = row.get("repo_id")
+        if not repo_name or not repo_id:
+            return None
+
+        stars_gained = self._stars_int(row)
+        description = (row.get("description") or "").strip()
+        primary_language = row.get("primary_language") or language
+
+        title = f"{repo_name} (+{stars_gained}⭐ {self.cfg.period})"
+        url = f"https://github.com/{repo_name}"
+
+        content_lines = [
+            f"Trending GitHub repo: {repo_name}",
+            f"Stars gained ({self.cfg.period}): {stars_gained}",
+            f"Forks gained: {row.get('forks', 0)}",
+            f"Pushes: {row.get('pushes', 0)}",
+            f"Pull requests: {row.get('pull_requests', 0)}",
+            f"Language: {primary_language}",
+        ]
+        if description:
+            content_lines.append("")
+            content_lines.append(description)
+        collections = row.get("collection_names")
+        if collections:
+            content_lines.append("")
+            content_lines.append(f"OSS Insight collections: {collections}")
+
+        return ContentItem(
+            id=self._generate_id(SourceType.OSSINSIGHT.value, "trending", str(repo_id)),
+            source_type=SourceType.OSSINSIGHT,
+            title=title,
+            url=url,
+            content="\n".join(content_lines),
+            author=repo_name.split("/")[0] if "/" in repo_name else None,
+            published_at=datetime.now(timezone.utc),
+            metadata={
+                "repo": repo_name,
+                "stars_gained": stars_gained,
+                "forks_gained": self._int(row.get("forks")),
+                "pushes": self._int(row.get("pushes")),
+                "pull_requests": self._int(row.get("pull_requests")),
+                "primary_language": primary_language,
+                "period": self.cfg.period,
+                "collection_names": collections,
+                "description": description,
+            },
+        )
+
+    @staticmethod
+    def _stars_int(row: dict) -> int:
+        """Pull star count out of a row, coercing to int."""
+        return OSSInsightScraper._int(row.get("stars"))
+
+    @staticmethod
+    def _int(value) -> int:
+        """Best-effort conversion to int, defaulting to 0."""
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
+
+    def _matches_keywords(self, row: dict) -> bool:
+        """Case-insensitive substring match against description, name, collections."""
+        haystack = " ".join(
+            [
+                (row.get("description") or "").lower(),
+                (row.get("collection_names") or "").lower(),
+                (row.get("repo_name") or "").lower(),
+            ]
+        )
+        return any(kw in haystack for kw in self._keywords_lower)


### PR DESCRIPTION
## Summary

Adds a new source type that surfaces GitHub repositories gaining the most stars right now, using the public [OSS Insight](https://ossinsight.io) API. This complements the existing `repo_releases` and `user_events` GitHub sources by capturing the *trending* signal Horizon currently misses (GitHub has no public Trending API, and the `mshibanami` RSS feeds are language-bucketed only).

The scraper:

- Hits `api.ossinsight.io/v1/trends/repos?period=...&language=...` per configured language and merges results.
- Optionally filters down via a user-supplied list of case-insensitive keywords matched against `description`, `collection_names`, and `repo_name`. Leave `keywords` empty to ingest everything trending — no domain bias is hardcoded into the scraper.
- Sorts by `stars_gained` desc and caps to `max_items`.
- Emits standard `ContentItem`s so the existing scoring / enrichment / summarization pipeline picks them up unchanged.

No API key is required. Disabled by default in `config.example.json`.

## Why

- Top-star-gain rankings are a high-signal source for "what's hot right now" digests, but Horizon previously had no way to ingest them.
- BigQuery / GHArchive works but adds infra and cost. OSS Insight gives the same signal over a free public endpoint.
- A configurable keyword filter keeps the source useful across very different briefings (AI/ML, DevOps, web, finance, gaming, etc.) without baking topic preferences into the code.

## Changes

- `src/models.py` — new `SourceType.OSSINSIGHT`, `OSSInsightConfig`, `SourcesConfig.ossinsight`.
- `src/scrapers/ossinsight.py` — new scraper with generic keyword filtering.
- `src/orchestrator.py` — register scraper in fetch loop and add a sub-source label.
- `data/config.example.json` — example block (disabled by default).
- `docs/configuration.md` — documents the new source type and parameters.
- `.gitignore` — exclude `data/mcp.secrets.json`, `data/mcp-secrets.json`, `data/mcp-runs/`.

## Configuration

```json
{
  "sources": {
    "ossinsight": {
      "enabled": true,
      "period": "past_24_hours",
      "languages": ["All", "Python", "TypeScript"],
      "keywords": [],
      "min_stars": 10,
      "max_items": 30
    }
  }
}
```

- `period` accepts `past_24_hours` or `past_28_days`. (`past_7_days` currently returns 500 from the upstream API; documented in the configuration guide.)
- `languages` accepts any GitHub language label or `"All"` for the unfiltered ranking; the scraper fans out one request per language and merges results.
- `keywords` is an optional list of case-insensitive substrings. Examples:
  - `[]` — keep everything trending (default).
  - `["ai", "llm", "agent", "rag"]` — narrow to AI-flavoured repos.
  - `["devops", "kubernetes", "terraform"]` — narrow to infra repos.
  - `["finance", "trading", "quant"]` — narrow to fintech repos.

## Verification

- Live API call against `api.ossinsight.io` returned 100 trending Python repos.
  - With no keywords + `min_stars: 20`: top of the list included `CloakHQ/CloakBrowser`, `datawhalechina/hello-agents`, `anthropics/financial-services-plugins`.
  - With `keywords: ["ai", "llm"]`: filtered to `HKUDS/AI-Trader`, `hugohe3/ppt-master`, `safishamsi/graphify`, etc.
- `Config.model_validate(...)` accepts the new source block.
- Existing test suite (`tests/test_mcp_service_smoke.py`, `tests/test_storage.py`) — 18 tests still pass.
- Branch is rebased onto current `upstream/main` (post `feat(scrapers): add OpenBB Platform source`); no merge conflicts.