### PR TITLE
Featrue/webhook error handle

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from enum import Enum
 from typing import Optional, List, Dict, Any, Union
-from pydantic import BaseModel, HttpUrl, Field
+from pydantic import BaseModel, HttpUrl, Field, field_validator
 
 
 class SourceType(str, Enum):
@@ -204,6 +204,46 @@ class WebhookConfig(BaseModel):
     fallback_layout: str = "markdown"      # Layout to use when the requested layout is unsupported
     languages: Optional[List[str]] = None  # Optional language filter for webhook delivery; defaults to all AI languages
     enabled: bool = False
+
+    @field_validator("delivery")
+    @classmethod
+    def validate_delivery(cls, v: str) -> str:
+        allowed = {"summary", "summary_and_items"}
+        if v not in allowed:
+            raise ValueError(f"webhook.delivery must be one of {allowed}, got '{v}'")
+        return v
+
+    @field_validator("platform")
+    @classmethod
+    def validate_platform(cls, v: str) -> str:
+        allowed = {"generic", "feishu", "lark", "dingtalk", "slack", "discord"}
+        if v not in allowed:
+            raise ValueError(f"webhook.platform must be one of {allowed}, got '{v}'")
+        return v
+
+    @field_validator("layout")
+    @classmethod
+    def validate_layout(cls, v: str) -> str:
+        allowed = {"markdown", "collapsible"}
+        if v not in allowed:
+            raise ValueError(f"webhook.layout must be one of {allowed}, got '{v}'")
+        return v
+
+    @field_validator("fallback_layout")
+    @classmethod
+    def validate_fallback_layout(cls, v: str) -> str:
+        allowed = {"markdown", "collapsible"}
+        if v not in allowed:
+            raise ValueError(f"webhook.fallback_layout must be one of {allowed}, got '{v}'")
+        return v
+
+    @field_validator("overview_position")
+    @classmethod
+    def validate_overview_position(cls, v: str) -> str:
+        allowed = {"first", "last"}
+        if v not in allowed:
+            raise ValueError(f"webhook.overview_position must be one of {allowed}, got '{v}'")
+        return v
 
 
 class EmailConfig(BaseModel):

--- a/src/services/webhook.py
+++ b/src/services/webhook.py
@@ -7,6 +7,7 @@ import os
 import re
 from datetime import datetime, timezone
 from typing import Any, List, Optional, Union
+from urllib.parse import urlparse
 import httpx
 
 from ..models import ContentItem, WebhookConfig
@@ -240,7 +241,6 @@ class WebhookNotifier:
 
     def __init__(self, config: WebhookConfig, console=None):
         self.config = config
-        self.url = os.getenv(config.url_env or "") if config.url_env else None
         if console is None:
             try:
                 from rich.console import Console
@@ -252,6 +252,76 @@ class WebhookNotifier:
                 self.console = DummyConsole()
         else:
             self.console = console
+        self.url = None
+        self._validate_config()  # sets self.url or raises ValueError
+
+    def _validate_url(self, url: str) -> str:
+        """Validate webhook URL has a valid scheme (http/https) and hostname.
+
+        Strips common shell escape artifacts (e.g. \\?, \\=, \\&) that may
+        appear when users copy-paste URLs from terminal output.
+
+        Raises:
+            ValueError: If the URL is empty, has wrong scheme, no hostname,
+                        or is structurally invalid
+        """
+        url = url.strip()
+        # Remove shell escape artifacts: \? \= \& \% before query chars
+        url = re.sub(r"\\([?=&%])", r"\1", url)
+        if not url:
+            raise ValueError(
+                f"Webhook URL is empty (env var '{self.config.url_env}' is set but empty)"
+            )
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(
+                f"Webhook URL must use http or https scheme, got '{parsed.scheme or 'none'}' "
+                f"(env var '{self.config.url_env}')"
+            )
+        if not parsed.hostname:
+            raise ValueError(
+                f"Webhook URL has no hostname: '{url}' "
+                f"(env var '{self.config.url_env}')"
+            )
+        try:
+            httpx.URL(url)
+        except httpx.InvalidURL as e:
+            raise ValueError(
+                f"Webhook URL is structurally invalid: '{url}' — {e} "
+                f"(env var '{self.config.url_env}')"
+            ) from e
+        return url
+
+    def _validate_config(self) -> None:
+        """Validate webhook URL configuration and print warnings for skip scenarios.
+
+        Raises ValueError when URL is present but invalid.
+        Sets self.url to the validated URL, or leaves it None for skip scenarios.
+        """
+        if not self.config.url_env:
+            # url_env not configured at all
+            logger.warning("Webhook enabled but url_env is not configured, skipping notification.")
+            self.console.print(
+                "[yellow]Webhook enabled but 'url_env' is not set in config. "
+                "No notification URL available, skipping.[/yellow]"
+            )
+            return
+
+        raw_url = os.getenv(self.config.url_env)
+        if raw_url is None:
+            # env var name configured, but the env var itself doesn't exist
+            logger.warning(
+                "Webhook enabled but env var '%s' is not set, skipping notification.",
+                self.config.url_env,
+            )
+            self.console.print(
+                f"[yellow]Webhook enabled but env var '{self.config.url_env}' is not set "
+                f"in your environment. Skipping notification.[/yellow]"
+            )
+            return
+
+        # env var exists — validate the URL value (strip + scheme + hostname + httpx check)
+        self.url = self._validate_url(raw_url)
 
     def _render_request_components(self, variables: dict) -> tuple[str, str | None, dict[str, str]]:
         """Render the final request URL, body, and headers for the given variables."""
@@ -490,10 +560,15 @@ class WebhookNotifier:
                        in URL, request_body, and headers.
         """
         if not self.config.enabled:
+            self.console.print("[yellow]Webhook is disabled, skipping notification.[/yellow]")
             return
 
         if not self.url:
             logger.warning("Webhook enabled but URL is empty (env var %s not set), skipping notification.", self.config.url_env)
+            self.console.print(
+                f"[yellow]Webhook enabled but URL is empty — "
+                f"env var '{self.config.url_env}' is not set. Skipping notification.[/yellow]"
+            )
             return
 
         method = "GET"
@@ -514,27 +589,71 @@ class WebhookNotifier:
                         headers=headers,
                     )
 
-            if response.status_code == 200:
-                logger.info(
-                    "Webhook sent OK. URL: %s, body: %s",
-                    request_url,
-                    response.text[:500],
-                )
-            else:
-                self.console.print(
-                    f"[red]Webhook failed! status={response.status_code} "
-                    f"response={response.text[:500]}[/red]"
-                )
-                logger.error(
-                    "Webhook failed! URL: %s, status: %d, body: %s",
-                    request_url,
-                    response.status_code,
-                    response.text[:500],
-                )
+            self._handle_response_status(response, request_url)
 
+        except httpx.InvalidURL as e:
+            self.console.print(
+                f"[red]Webhook URL is invalid: {e}[/red]"
+            )
+            logger.error("Webhook URL invalid: %s, env var: %s", e, self.config.url_env)
+        except httpx.ConnectError as e:
+            self.console.print(
+                f"[red]Webhook connection failed: {e}[/red]"
+            )
+            logger.error("Webhook connection failed: URL=%s, error=%s", request_url, e)
+        except httpx.TimeoutException as e:
+            self.console.print(
+                f"[red]Webhook request timed out: {e}[/red]"
+            )
+            logger.error("Webhook timeout: URL=%s, error=%s", request_url, e)
         except Exception as e:
-            self.console.print(f"[red]Webhook call failed! Exception: {e}[/red]")
-            logger.error("Webhook call failed! URL: %s, exception: %s", request_url, e)
+            self.console.print(
+                f"[red]Webhook call failed unexpectedly: {type(e).__name__}: {e}[/red]"
+            )
+            logger.error("Webhook unexpected error: URL=%s, type=%s, error=%s", request_url, type(e).__name__, e)
+
+    def _handle_response_status(self, response: httpx.Response, request_url: str) -> None:
+        """Log and display HTTP response status by category."""
+        status = response.status_code
+
+        if 200 <= status < 300:
+            logger.info(
+                "Webhook sent OK. URL: %s, body: %s",
+                request_url,
+                response.text[:500],
+            )
+            return
+
+        if 300 <= status < 400:
+            location = response.headers.get("location", "")
+            self.console.print(
+                f"[yellow]Webhook received redirect (status={status})[/yellow]"
+            )
+            logger.warning(
+                "Webhook redirect: URL=%s, status=%d, location=%s",
+                request_url, status, location,
+            )
+        elif 400 <= status < 500:
+            self.console.print(
+                f"[red]Webhook client error (status={status}): {response.text[:500]}[/red]"
+            )
+            logger.error(
+                "Webhook client error: URL=%s, status=%d, body=%s",
+                request_url, status, response.text[:500],
+            )
+        elif 500 <= status < 600:
+            self.console.print(
+                f"[red]Webhook server error (status={status}): {response.text[:500]}[/red]"
+            )
+            logger.error(
+                "Webhook server error: URL=%s, status=%d, body=%s",
+                request_url, status, response.text[:500],
+            )
+        else:
+            self.console.print(
+                f"[red]Webhook unexpected status={status}: {response.text[:500]}[/red]"
+            )
+            logger.error("Webhook unexpected status: URL=%s, status=%d", request_url, status)
 
     async def send_daily_summary(
         self,

--- a/src/services/webhook.py
+++ b/src/services/webhook.py
@@ -257,10 +257,6 @@ class WebhookNotifier:
 
     def _validate_url(self, url: str) -> str:
         """Validate webhook URL has a valid scheme (http/https) and hostname.
-
-        Strips common shell escape artifacts (e.g. \\?, \\=, \\&) that may
-        appear when users copy-paste URLs from terminal output.
-
         Raises:
             ValueError: If the URL is empty, has wrong scheme, no hostname,
                         or is structurally invalid
@@ -612,16 +608,67 @@ class WebhookNotifier:
             )
             logger.error("Webhook unexpected error: URL=%s, type=%s, error=%s", request_url, type(e).__name__, e)
 
+    def _check_body_error_code(self, body: str) -> Optional[str]:
+        """Check if a 2xx response body contains a platform-specific error code.
+
+        Returns a descriptive string if an error is detected, or None if the
+        response appears successful.
+
+        Checked patterns:
+        - Feishu/Lark: {"code": non-zero, "msg": "..."} or {"StatusCode": non-zero}
+        - DingTalk: {"errcode": non-zero, "errmsg": "..."}
+        - Slack/Discord: {"ok": false}
+        """
+        try:
+            data = json.loads(body)
+        except (json.JSONDecodeError, ValueError):
+            return None
+
+        # Feishu/Lark: "code" or "StatusCode" field
+        feishu_code = data.get("code") or data.get("StatusCode")
+        if feishu_code is not None and feishu_code != 0:
+            msg = data.get("msg") or data.get("StatusMessage") or ""
+            return f"Feishu/Lark error (code={feishu_code}): {msg}"
+
+        # DingTalk: "errcode" field
+        dingtalk_code = data.get("errcode")
+        if dingtalk_code is not None and dingtalk_code != 0:
+            msg = data.get("errmsg") or ""
+            return f"DingTalk error (errcode={dingtalk_code}): {msg}"
+
+        # Slack/Discord: "ok" field
+        if data.get("ok") is False:
+            error = data.get("error") or ""
+            return f"Slack/Discord error: {error}"
+
+        return None
+
     def _handle_response_status(self, response: httpx.Response, request_url: str) -> None:
-        """Log and display HTTP response status by category."""
+        """Log and display HTTP response status by category.
+
+        Even 2xx responses may contain platform-specific error codes
+        in the JSON body (e.g. Feishu code=19001, DingTalk errcode=400,
+        Slack ok=false).
+        """
         status = response.status_code
+        body = response.text[:500]
 
         if 200 <= status < 300:
-            logger.info(
-                "Webhook sent OK. URL: %s, body: %s",
-                request_url,
-                response.text[:500],
-            )
+            error_hint = self._check_body_error_code(body)
+            if error_hint:
+                logger.warning(
+                    "Webhook 2xx but body contains error: URL=%s, status=%d, body=%s",
+                    request_url, status, body,
+                )
+                self.console.print(
+                    f"[yellow]Webhook response (status={status}): {body}[/yellow]\n"
+                    f"[yellow]{error_hint}[/yellow]"
+                )
+            else:
+                logger.info("Webhook sent OK. URL: %s, body: %s", request_url, body)
+                self.console.print(
+                    f"[green]Webhook response (status={status}): {body}[/green]"
+                )
             return
 
         if 300 <= status < 400:

--- a/src/services/webhook_cli.py
+++ b/src/services/webhook_cli.py
@@ -136,7 +136,6 @@ async def _run_test(webhook_config, lang: str, dry_run: bool, delivery_override:
         lang=lang,
         summarizer=summarizer,
     )
-    console.print("[green]Test notification sent.[/green]")
 
 
 def main() -> None:

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1073,12 +1073,20 @@ class TestURLValidation:
         del os.environ[_TEST_URL_ENV]
 
     def test_no_hostname_raises_value_error(self):
-        """Bare strings and URLs without a hostname raise ValueError."""
-        for bad_url in ["not-a-url", "http://", "://"]:
+        """URLs without a hostname raise ValueError."""
+        os.environ[_TEST_URL_ENV] = "http://"
+        config = WebhookConfig(enabled=True, url_env=_TEST_URL_ENV)
+        with pytest.raises(ValueError, match="no hostname"):
+            WebhookNotifier(config)
+        del os.environ[_TEST_URL_ENV]
+
+    def test_wrong_scheme_raises_value_error(self):
+        """URLs with non-http/https scheme raise ValueError."""
+        for bad_url in ["ftp://example.com", "not-a-url", "://"]:
             os.environ[_TEST_URL_ENV] = bad_url
             config = WebhookConfig(enabled=True, url_env=_TEST_URL_ENV)
             try:
-                with pytest.raises(ValueError, match="no hostname"):
+                with pytest.raises(ValueError, match="http or https"):
                     WebhookNotifier(config)
             finally:
                 del os.environ[_TEST_URL_ENV]

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -3,10 +3,12 @@
 import asyncio
 import json
 import os
+import pytest
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
+from pydantic import ValidationError
 
 from src.models import ContentItem, SourceType, WebhookConfig
 from src.services.webhook import (
@@ -999,31 +1001,6 @@ class TestSendDailySummary:
             assert before <= ts <= after
         del os.environ[_TEST_URL_ENV]
 
-    def test_summary_and_items_zh_overview_title(self):
-        """summary_and_items with zh lang uses '总览' in overview title."""
-        os.environ[_TEST_URL_ENV] = _TEST_URL
-        config = WebhookConfig(
-            enabled=True,
-            url_env=_TEST_URL_ENV,
-            delivery="summary_and_items",
-        )
-        notifier = WebhookNotifier(config)
-        summarizer = DailySummarizer()
-        items = [_make_item()]
-
-        with patch.object(notifier, "notify", new_callable=AsyncMock) as mock_notify:
-            _run_async(notifier.send_daily_summary(
-                summary="中文摘要",
-                important_items=items,
-                all_items_count=10,
-                date="2026-04-24",
-                lang="zh",
-                summarizer=summarizer,
-            ))
-            overview_vars = mock_notify.call_args_list[0][0][0]
-            assert overview_vars["message_title"] == "Horizon 2026-04-24 总览"
-        del os.environ[_TEST_URL_ENV]
-
 
 # ── send_failure_notification ──
 
@@ -1075,3 +1052,342 @@ class TestSendFailureNotification:
             ts = int(vars["timestamp"])
             assert before <= ts <= after
         del os.environ[_TEST_URL_ENV]
+
+
+# ── URL validation ──
+
+
+class TestURLValidation:
+    def test_valid_https_url_passes(self):
+        os.environ[_TEST_URL_ENV] = "https://example.com/webhook"
+        config = WebhookConfig(enabled=True, url_env=_TEST_URL_ENV)
+        notifier = WebhookNotifier(config)
+        assert notifier.url == "https://example.com/webhook"
+        del os.environ[_TEST_URL_ENV]
+
+    def test_valid_http_url_passes(self):
+        os.environ[_TEST_URL_ENV] = "http://localhost:8080/hook"
+        config = WebhookConfig(enabled=True, url_env=_TEST_URL_ENV)
+        notifier = WebhookNotifier(config)
+        assert notifier.url == "http://localhost:8080/hook"
+        del os.environ[_TEST_URL_ENV]
+
+    def test_no_hostname_raises_value_error(self):
+        """Bare strings and URLs without a hostname raise ValueError."""
+        for bad_url in ["not-a-url", "http://", "://"]:
+            os.environ[_TEST_URL_ENV] = bad_url
+            config = WebhookConfig(enabled=True, url_env=_TEST_URL_ENV)
+            try:
+                with pytest.raises(ValueError, match="no hostname"):
+                    WebhookNotifier(config)
+            finally:
+                del os.environ[_TEST_URL_ENV]
+
+    def test_invalid_port_raises_value_error(self):
+        """httpx.URL catches structurally invalid ports like 'abc'."""
+        os.environ[_TEST_URL_ENV] = "http://example.com:abc"
+        config = WebhookConfig(enabled=True, url_env=_TEST_URL_ENV)
+        with pytest.raises(ValueError, match="structurally invalid"):
+            WebhookNotifier(config)
+        del os.environ[_TEST_URL_ENV]
+
+    def test_empty_env_var_value_raises_value_error(self):
+        """Env var exists but is empty string → ValueError."""
+        os.environ[_TEST_URL_ENV] = ""
+        config = WebhookConfig(enabled=True, url_env=_TEST_URL_ENV)
+        with pytest.raises(ValueError, match="empty"):
+            WebhookNotifier(config)
+        del os.environ[_TEST_URL_ENV]
+
+    def test_env_var_not_set_sets_url_none(self):
+        """url_env configured but env var doesn't exist → url=None + console warning."""
+        config = WebhookConfig(enabled=True, url_env=_TEST_URL_ENV)
+        os.environ.pop(_TEST_URL_ENV, None)
+        notifier = WebhookNotifier(config)
+        assert notifier.url is None
+
+    def test_url_env_null_sets_url_none(self):
+        """url_env=None in config → url=None + console warning."""
+        config = WebhookConfig(enabled=True, url_env=None)
+        notifier = WebhookNotifier(config)
+        assert notifier.url is None
+
+    def test_whitespace_url_stripped_and_validated(self):
+        """URL with surrounding whitespace is stripped before validation."""
+        os.environ[_TEST_URL_ENV] = "  https://example.com/webhook  "
+        config = WebhookConfig(enabled=True, url_env=_TEST_URL_ENV)
+        notifier = WebhookNotifier(config)
+        assert notifier.url == "https://example.com/webhook"
+        del os.environ[_TEST_URL_ENV]
+
+    def test_shell_escape_artifacts_stripped(self):
+        """Shell escape artifacts like \\? and \\= are auto-stripped from URL."""
+        os.environ[_TEST_URL_ENV] = "https://oapi.dingtalk.com/robot/send\\?access_token\\=abc123"
+        config = WebhookConfig(enabled=True, url_env=_TEST_URL_ENV)
+        notifier = WebhookNotifier(config)
+        assert notifier.url == "https://oapi.dingtalk.com/robot/send?access_token=abc123"
+        del os.environ[_TEST_URL_ENV]
+
+
+# ── HTTP status code handling ──
+
+
+class TestHTTPStatusHandling:
+    def _make_notifier(self):
+        os.environ[_TEST_URL_ENV] = _TEST_URL
+        config = WebhookConfig(enabled=True, url_env=_TEST_URL_ENV)
+        notifier = WebhookNotifier(config)
+        return notifier
+
+    def _cleanup(self):
+        del os.environ[_TEST_URL_ENV]
+
+    def test_2xx_success(self):
+        notifier = self._make_notifier()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "OK"
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            _run_async(notifier.notify({"date": "2026-04-24"}))
+        self._cleanup()
+
+    def test_3xx_redirect_prints_warning(self):
+        notifier = self._make_notifier()
+        mock_response = MagicMock()
+        mock_response.status_code = 301
+        mock_response.text = ""
+        mock_response.headers = {"location": "https://new-url.com"}
+
+        mock_console = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            notifier.console = mock_console
+            _run_async(notifier.notify({"date": "2026-04-24"}))
+
+            printed = " ".join(str(c) for c in mock_console.print.call_args_list)
+            assert "redirect" in printed.lower()
+        self._cleanup()
+
+    def test_4xx_client_error_prints_warning(self):
+        notifier = self._make_notifier()
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.text = "Bad request"
+
+        mock_console = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            notifier.console = mock_console
+            _run_async(notifier.notify({"date": "2026-04-24"}))
+
+            printed = " ".join(str(c) for c in mock_console.print.call_args_list)
+            assert "client error" in printed.lower()
+        self._cleanup()
+
+    def test_5xx_server_error_prints_warning(self):
+        notifier = self._make_notifier()
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal server error"
+
+        mock_console = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            notifier.console = mock_console
+            _run_async(notifier.notify({"date": "2026-04-24"}))
+
+            printed = " ".join(str(c) for c in mock_console.print.call_args_list)
+            assert "server error" in printed.lower()
+        self._cleanup()
+
+
+# ── Exception classification ──
+
+
+class TestExceptionClassification:
+    def _make_notifier(self):
+        os.environ[_TEST_URL_ENV] = _TEST_URL
+        config = WebhookConfig(enabled=True, url_env=_TEST_URL_ENV)
+        notifier = WebhookNotifier(config)
+        return notifier
+
+    def _cleanup(self):
+        del os.environ[_TEST_URL_ENV]
+
+    def test_connect_error_prints_warning(self):
+        notifier = self._make_notifier()
+        mock_console = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            notifier.console = mock_console
+            _run_async(notifier.notify({"date": "2026-04-24"}))
+
+            printed = " ".join(str(c) for c in mock_console.print.call_args_list)
+            assert "connection failed" in printed.lower()
+        self._cleanup()
+
+    def test_timeout_exception_prints_warning(self):
+        notifier = self._make_notifier()
+        mock_console = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(side_effect=httpx.TimeoutException("Timed out"))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            notifier.console = mock_console
+            _run_async(notifier.notify({"date": "2026-04-24"}))
+
+            printed = " ".join(str(c) for c in mock_console.print.call_args_list)
+            assert "timed out" in printed.lower()
+        self._cleanup()
+
+    def test_invalid_url_exception_prints_warning(self):
+        notifier = self._make_notifier()
+        mock_console = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(side_effect=httpx.InvalidURL("Bad URL"))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            notifier.console = mock_console
+            _run_async(notifier.notify({"date": "2026-04-24"}))
+
+            printed = " ".join(str(c) for c in mock_console.print.call_args_list)
+            assert "invalid" in printed.lower()
+        self._cleanup()
+
+    def test_generic_exception_prints_type_name(self):
+        notifier = self._make_notifier()
+        mock_console = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(side_effect=RuntimeError("Something unexpected"))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            notifier.console = mock_console
+            _run_async(notifier.notify({"date": "2026-04-24"}))
+
+            printed = " ".join(str(c) for c in mock_console.print.call_args_list)
+            assert "RuntimeError" in printed
+            assert "unexpectedly" in printed.lower()
+        self._cleanup()
+
+
+# ── Config field validation ──
+
+
+class TestWebhookConfigFieldValidation:
+    def test_invalid_delivery_raises_validation_error(self):
+        with pytest.raises(ValidationError, match="delivery"):
+            WebhookConfig(enabled=True, delivery="invalid_mode")
+
+    def test_invalid_platform_raises_validation_error(self):
+        with pytest.raises(ValidationError, match="platform"):
+            WebhookConfig(enabled=True, platform="unknown_platform")
+
+    def test_invalid_layout_raises_validation_error(self):
+        with pytest.raises(ValidationError, match="layout"):
+            WebhookConfig(enabled=True, layout="html")
+
+    def test_invalid_fallback_layout_raises_validation_error(self):
+        with pytest.raises(ValidationError, match="fallback_layout"):
+            WebhookConfig(enabled=True, fallback_layout="html")
+
+    def test_invalid_overview_position_raises_validation_error(self):
+        with pytest.raises(ValidationError, match="overview_position"):
+            WebhookConfig(enabled=True, overview_position="middle")
+
+    def test_all_valid_values_pass(self):
+        config = WebhookConfig(
+            enabled=True,
+            delivery="summary_and_items",
+            platform="feishu",
+            layout="collapsible",
+            fallback_layout="markdown",
+            overview_position="last",
+        )
+        assert config.delivery == "summary_and_items"
+        assert config.platform == "feishu"
+        assert config.layout == "collapsible"
+        assert config.fallback_layout == "markdown"
+        assert config.overview_position == "last"
+
+    def test_each_valid_platform(self):
+        for p in ["generic", "feishu", "lark", "dingtalk", "slack", "discord"]:
+            config = WebhookConfig(enabled=True, platform=p)
+            assert config.platform == p
+
+
+# ── Skip console output ──
+
+
+class TestSkipConsoleOutput:
+    def test_disabled_webhook_prints_warning(self):
+        """When webhook is disabled, notify() prints a yellow warning."""
+        os.environ[_TEST_URL_ENV] = _TEST_URL
+        config = WebhookConfig(enabled=False, url_env=_TEST_URL_ENV)
+        notifier = WebhookNotifier(config)
+        mock_console = MagicMock()
+        notifier.console = mock_console
+
+        _run_async(notifier.notify({"date": "2026-04-24"}))
+
+        mock_console.print.assert_called_once()
+        printed = str(mock_console.print.call_args)
+        assert "disabled" in printed.lower()
+        del os.environ[_TEST_URL_ENV]
+
+    def test_empty_url_prints_warning(self):
+        """When URL is empty (env var not set), notify() prints a yellow warning."""
+        config = WebhookConfig(enabled=True, url_env=_TEST_URL_ENV)
+        os.environ.pop(_TEST_URL_ENV, None)
+        notifier = WebhookNotifier(config)
+        mock_console = MagicMock()
+        notifier.console = mock_console
+
+        _run_async(notifier.notify({"date": "2026-04-24"}))
+
+        # notify() prints warning when URL is empty
+        assert mock_console.print.call_count >= 1
+        printed = " ".join(str(c) for c in mock_console.print.call_args_list)
+        assert "not set" in printed.lower() or "empty" in printed.lower()

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1150,11 +1150,13 @@ class TestHTTPStatusHandling:
     def _cleanup(self):
         del os.environ[_TEST_URL_ENV]
 
-    def test_2xx_success(self):
+    def test_2xx_success_prints_response(self):
         notifier = self._make_notifier()
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.text = "OK"
+        mock_response.text = '{"code":0,"msg":"ok"}'
+
+        mock_console = MagicMock()
 
         with patch("httpx.AsyncClient") as mock_client_cls:
             mock_client = AsyncMock()
@@ -1163,7 +1165,112 @@ class TestHTTPStatusHandling:
             mock_client.__aexit__ = AsyncMock(return_value=False)
             mock_client_cls.return_value = mock_client
 
+            notifier.console = mock_console
             _run_async(notifier.notify({"date": "2026-04-24"}))
+
+            printed = " ".join(str(c) for c in mock_console.print.call_args_list)
+            assert "status=200" in printed
+            assert '"code":0' in printed
+            # Success response should be green, not yellow
+            assert "[green]" in printed
+        self._cleanup()
+
+    def test_2xx_feishu_error_code_prints_yellow_warning(self):
+        """Feishu returns HTTP 200 with code=19001 in body — should be yellow warning."""
+        notifier = self._make_notifier()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = '{"code":19001,"msg":"param invalid: incoming webhook access token invalid"}'
+
+        mock_console = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            notifier.console = mock_console
+            _run_async(notifier.notify({"date": "2026-04-24"}))
+
+            printed = " ".join(str(c) for c in mock_console.print.call_args_list)
+            assert "19001" in printed
+            assert "Feishu/Lark" in printed
+            assert "[yellow]" in printed
+        self._cleanup()
+
+    def test_2xx_dingtalk_error_code_prints_yellow_warning(self):
+        """DingTalk returns HTTP 200 with errcode=400 in body — should be yellow warning."""
+        notifier = self._make_notifier()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = '{"errcode":400,"errmsg":"invalid token"}'
+
+        mock_console = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            notifier.console = mock_console
+            _run_async(notifier.notify({"date": "2026-04-24"}))
+
+            printed = " ".join(str(c) for c in mock_console.print.call_args_list)
+            assert "errcode=400" in printed
+            assert "DingTalk" in printed
+            assert "[yellow]" in printed
+        self._cleanup()
+
+    def test_2xx_slack_ok_false_prints_yellow_warning(self):
+        """Slack returns HTTP 200 with ok=false — should be yellow warning."""
+        notifier = self._make_notifier()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = '{"ok":false,"error":"invalid_token"}'
+
+        mock_console = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            notifier.console = mock_console
+            _run_async(notifier.notify({"date": "2026-04-24"}))
+
+            printed = " ".join(str(c) for c in mock_console.print.call_args_list)
+            assert "Slack/Discord" in printed
+            assert "[yellow]" in printed
+        self._cleanup()
+
+    def test_2xx_non_json_body_prints_green(self):
+        """Non-JSON 2xx response body prints as green (no error code check possible)."""
+        notifier = self._make_notifier()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "OK"
+
+        mock_console = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            notifier.console = mock_console
+            _run_async(notifier.notify({"date": "2026-04-24"}))
+
+            printed = " ".join(str(c) for c in mock_console.print.call_args_list)
+            assert "status=200" in printed
+            assert "[green]" in printed
         self._cleanup()
 
     def test_3xx_redirect_prints_warning(self):


### PR DESCRIPTION
## Summary

增强 webhook 通知的错误处理健壮性：在初始化时增加 URL 验证、对 httpx 异常进行分类处理、细分 HTTP 状态码（3xx/4xx/5xx）、检测 2xx 响应体中的平台错误码（飞书/钉钉/Slack）、为 WebhookConfig 添加 Pydantic 字段校验、以及在跳过场景中显示控制台警告。

此前，webhook 错误全部被泛型 `except Exception` 捕获，仅 `status_code == 200` 被视为成功，非法 URL 在实际请求时才失败且无提前提示，跳过场景仅记录到 `logger` 而不在 Horizon 控制台输出，总之不够鲁棒

## Scope

- [x] This PR contains **one feature / one fix / one focused change**
- [x] This PR does **not** combine multiple unrelated features

## Changes

- **URL 前置验证**：检查验证 URL 的 scheme（http/https）、hostname 和结构合法性。同时去除前后空白字符及 shell 转义残留字符（`\?`、`\=`、`\&`、`\%`），解决从终端输出复制 URL 时常见的转义问题，并统一处理相关URL_ENV的配置验证
- **错误状态码细分** ：增加完整的 2xx/3xx/4xx/5xx 分类处理，每种状态码类别输出相应的控制台消息和日志；同时正确处理飞书、钉钉、Slack/Discord可能返回 HTTP 200 但 JSON body 中包含错误码
- **Pydantic 字段校验**：为 `delivery`、`platform`、`layout`、`fallback_layout`、`overview_position`添加 `field_validator`

## Notes for Reviewers

- `_validate_url` 方法去除 shell 转义残留字符（`\?`、`\=` 等），因为用户经常从终端输出中复制包含 shell 转义查询字符的WebHook URL，这可能导致原有webhook异常
- `_check_body_error_code` 方法目前仅处理飞书、钉钉和 Slack/Discord 的2xx错误模式。其他平台若存在类似的 2xx-with-error-body 行为，可在未来补充

## Checklist

- [x] I explained the change clearly
- [x] I kept the PR focused and easy to review
- [x] I tested the change locally when applicable
