### PR TITLE
[Bug Fix]Update Deepseek api key

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -4,7 +4,7 @@
     "provider": "deepseek",
     "model": "deepseek-v4-flash",
     "base_url": "https://api.deepseek.com",
-    "api_key_env": "OPENAI_API_KEY",
+    "api_key_env": "DEEPSEEK_API_KEY",
     "temperature": 0.3,
     "max_tokens": 8192,
     "languages": [


### PR DESCRIPTION
## Summary
data/config.json里面的默认模型是deepseek，但是api_key_env环境变量是openai
