### PR TITLE
chore: modernize CI and Docker Compose configuration

### DIFF
--- a/.github/workflows/daily-summary.yml
+++ b/.github/workflows/daily-summary.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -211,10 +211,10 @@ cp data/config.example.json data/config.json
 # Edit .env and data/config.json with your API keys and preferences
 
 # Run with Docker Compose
-docker-compose run --rm horizon
+docker compose run --rm horizon
 
 # Or run with custom time window
-docker-compose run --rm horizon --hours 48
+docker compose run --rm horizon --hours 48
 ```
 
 ### 2. Configure
@@ -270,8 +270,8 @@ uv run horizon --hours 48  # Fetch from last 48 hours
 #### With Docker
 
 ```bash
-docker-compose run --rm horizon           # Run with default 24h window
-docker-compose run --rm horizon --hours 48  # Fetch from last 48 hours
+docker compose run --rm horizon           # Run with default 24h window
+docker compose run --rm horizon --hours 48  # Fetch from last 48 hours
 ```
 
 The generated report will be saved to `data/summaries/`.

--- a/README_zh.md
+++ b/README_zh.md
@@ -211,10 +211,10 @@ cp data/config.example.json data/config.json
 # 编辑 .env 和 data/config.json，填入你的 API 密钥和偏好设置
 
 # 使用 Docker Compose 运行
-docker-compose run --rm horizon
+docker compose run --rm horizon
 
 # 或自定义时间窗口
-docker-compose run --rm horizon --hours 48
+docker compose run --rm horizon --hours 48
 ```
 
 ### 2. 配置
@@ -270,8 +270,8 @@ uv run horizon --hours 48   # 抓取最近 48 小时的内容
 #### 使用 Docker
 
 ```bash
-docker-compose run --rm horizon              # 使用默认 24 小时窗口
-docker-compose run --rm horizon --hours 48   # 抓取最近 48 小时的内容
+docker compose run --rm horizon              # 使用默认 24 小时窗口
+docker compose run --rm horizon --hours 48   # 抓取最近 48 小时的内容
 ```
 
 生成的日报将保存在 `data/summaries/` 目录中。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   horizon:
     build: .
@@ -11,5 +9,5 @@ services:
       - TZ=UTC
     restart: unless-stopped
     # Run daily at 8:00 AM UTC (adjust as needed)
-    # For one-time run, use: docker-compose run --rm horizon
+    # For one-time run, use: docker compose run --rm horizon
     command: ["--hours", "24"]


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` from v4 to v6 in `daily-summary.yml` to match `deploy-docs.yml` and use the latest version
- Remove deprecated `version` field from `docker-compose.yml` (obsolete in [Docker Compose V2](https://docs.docker.com/compose/releases/migrate/))
- Replace legacy `docker-compose` command with `docker compose` (V2 subcommand style) in `docker-compose.yml`, `README.md`, and `README_zh.md`

## Why

1. **`actions/checkout@v4`** uses Node.js 20, which is [being deprecated by GitHub](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). `@v6` uses Node.js 24 and is already adopted in `deploy-docs.yml` — this PR aligns `daily-summary.yml` to the same version.

2. The **`version` field** in `docker-compose.yml` has been obsolete since Docker Compose V2 and produces a warning:
   > `WARN[0000] .../docker-compose.yml: 'version' is obsolete`

3. The **`docker-compose`** standalone binary has been replaced by the `docker compose` plugin subcommand since Docker Compose V2 (July 2023). The old command is no longer installed by default in newer Docker distributions.

## Test Plan

- [x] Verified `actions/checkout@v6` is the [latest release](https://github.com/actions/checkout/releases) (v6.0.2)
- [x] Confirmed no other workflow files reference `actions/checkout@v4`
- [x] Verified `docker compose` is the current recommended command
- [x] All changes are documentation/config only — no runtime code affected