### PR TITLE
fix: clean generated markdown for email summaries

### DIFF
--- a/src/ai/markdown_utils.py
+++ b/src/ai/markdown_utils.py
@@ -1,0 +1,103 @@
+"""Utilities for normalizing app-generated Markdown."""
+
+import html
+import re
+from urllib.parse import urlsplit
+
+
+_DETAILS_RE = re.compile(
+    r"<details>\s*<summary>(.*?)</summary>\s*(.*?)\s*</details>",
+    re.IGNORECASE | re.DOTALL,
+)
+_ANCHOR_LINK_RE = re.compile(
+    r"^\s*<a\s+[^>]*href=[\"']([^\"']+)[\"'][^>]*>(.*?)</a>\s*$",
+    re.IGNORECASE | re.DOTALL,
+)
+_LI_RE = re.compile(r"<li>\s*(.*?)\s*</li>", re.IGNORECASE | re.DOTALL)
+_ANCHOR_ID_RE = re.compile(
+    r"<a\s+[^>]*id=[\"'][^\"']+[\"'][^>]*>\s*</a>", re.IGNORECASE
+)
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_MARKDOWN_SPECIAL_RE = re.compile(r"([\\`*_{}\[\]<>()#+!|])")
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
+_UNSAFE_MARKDOWN_URL_CHAR_RE = re.compile(r"[\s<>\[\]\\]")
+_SAFE_URL_SCHEMES = {"http", "https", "mailto"}
+
+
+def _strip_html_tags(value: str) -> str:
+    """Remove simple HTML tags and decode HTML entities."""
+    return html.unescape(_HTML_TAG_RE.sub("", value)).strip()
+
+
+def _escape_markdown_text(value: str) -> str:
+    """Escape user-controlled text before embedding it in generated Markdown."""
+    clean_value = re.sub(r"\s+", " ", value).strip()
+    return _MARKDOWN_SPECIAL_RE.sub(r"\\\1", clean_value)
+
+
+def _is_safe_markdown_link_url(value: str) -> bool:
+    """Return True when a URL can be emitted as an active Markdown link."""
+    if _CONTROL_CHAR_RE.search(value):
+        return False
+    if _UNSAFE_MARKDOWN_URL_CHAR_RE.search(value):
+        return False
+    if value.count("(") != value.count(")"):
+        return False
+
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return False
+
+    scheme = parsed.scheme.lower()
+    if scheme not in _SAFE_URL_SCHEMES:
+        return False
+
+    if scheme in {"http", "https"}:
+        return bool(parsed.netloc)
+
+    return bool(parsed.path)
+
+
+def _convert_details_to_markdown(value: str) -> str:
+    """Convert HTML details blocks into plain Markdown sections."""
+
+    def _replace(match: re.Match) -> str:
+        title = _escape_markdown_text(_strip_html_tags(match.group(1)) or "References")
+        body = match.group(2)
+        items: list[str] = []
+
+        for item in _LI_RE.findall(body):
+            link_match = _ANCHOR_LINK_RE.match(item)
+            if link_match:
+                href, label = link_match.groups()
+                clean_label = _strip_html_tags(label)
+                escaped_label = _escape_markdown_text(clean_label)
+                clean_href = html.unescape(href).strip()
+                if escaped_label and clean_href and _is_safe_markdown_link_url(clean_href):
+                    items.append(f"- [{escaped_label}]({clean_href})")
+                elif escaped_label:
+                    items.append(f"- {escaped_label}")
+                continue
+
+            clean_item = _escape_markdown_text(_strip_html_tags(item))
+            if clean_item:
+                items.append(f"- {clean_item}")
+
+        if not items:
+            fallback = _escape_markdown_text(_strip_html_tags(body))
+            return f"**{title}**\n\n{fallback}" if fallback else f"**{title}**"
+
+        return f"**{title}**\n\n" + "\n".join(items)
+
+    return _DETAILS_RE.sub(_replace, value)
+
+
+def clean_app_summary_markdown(value: str) -> str:
+    """Flatten app-generated HTML snippets embedded in summary Markdown.
+
+    Unknown raw HTML is intentionally left in place so callers can choose their
+    own safety boundary. Email, for example, escapes after this cleanup step.
+    """
+    value = _ANCHOR_ID_RE.sub("", value)
+    return _convert_details_to_markdown(value)

--- a/src/ai/summarizer.py
+++ b/src/ai/summarizer.py
@@ -25,6 +25,8 @@ LABELS = {
         "discussion": "Discussion",
         "references": "References",
         "tags": "Tags",
+        "selected_items": "From {total} items, {selected} important content pieces were selected",
+        "empty_analyzed": "Analyzed {total} items, but none met the importance threshold.",
         "empty_body": (
             "No significant developments today. This might indicate:\n"
             "- A quiet day in your tracked sources\n"
@@ -43,6 +45,8 @@ LABELS = {
         "discussion": "社区讨论",
         "references": "参考链接",
         "tags": "标签",
+        "selected_items": "从 {total} 条内容中筛选出 {selected} 条重要资讯。",
+        "empty_analyzed": "已分析 {total} 条内容，但没有达到重要性阈值的条目。",
         "empty_body": (
             "今日暂无重要动态，可能原因：\n"
             "- 今天关注的信息源较平静\n"
@@ -90,7 +94,7 @@ class DailySummarizer:
 
         header = (
             f"# {labels['header']} - {date}\n\n"
-            f"> From {total_fetched} items, {len(items)} important content pieces were selected\n\n"
+            f"> {labels['selected_items'].format(total=total_fetched, selected=len(items))}\n\n"
             "---\n\n"
         )
 
@@ -193,8 +197,14 @@ class DailySummarizer:
         else:
             source_parts.append(item.author or "unknown")
         if item.published_at:
-            day = item.published_at.strftime("%d").lstrip("0")
-            source_parts.append(item.published_at.strftime(f"%b {day}, %H:%M"))
+            if language == "zh":
+                source_parts.append(
+                    f"{item.published_at.month}月{item.published_at.day}日 "
+                    f"{item.published_at:%H:%M}"
+                )
+            else:
+                day = item.published_at.strftime("%d").lstrip("0")
+                source_parts.append(item.published_at.strftime(f"%b {day}, %H:%M"))
         source_line = " \u00b7 ".join(source_parts)  # ·
 
         discussion_url = meta.get("discussion_url")
@@ -242,6 +252,6 @@ class DailySummarizer:
         """Generate summary when no high-scoring items were found."""
         return (
             f"# {labels['header']} - {date}\n\n"
-            f"> Analyzed {total_fetched} items, but none met the importance threshold.\n\n"
+            f"> {labels['empty_analyzed'].format(total=total_fetched)}\n\n"
             + labels["empty_body"]
         )

--- a/src/services/email.py
+++ b/src/services/email.py
@@ -16,6 +16,7 @@ try:
 except ImportError:
     markdown = None
 
+from ..ai.markdown_utils import clean_app_summary_markdown
 from ..models import EmailConfig
 
 logger = logging.getLogger(__name__)
@@ -155,7 +156,8 @@ class EmailManager:
         if not self.config.enabled or not subscribers:
             return
 
-        safe_summary = html.escape(summary_md)
+        cleaned_summary = clean_app_summary_markdown(summary_md)
+        safe_summary = html.escape(cleaned_summary)
         html_content = (
             markdown.markdown(safe_summary)
             if markdown
@@ -202,7 +204,7 @@ class EmailManager:
                     )
                     msg["To"] = subscriber
 
-                    text_part = MIMEText(summary_md, "plain")
+                    text_part = MIMEText(cleaned_summary, "plain")
                     html_part = MIMEText(html_body, "html")
 
                     msg.attach(text_part)

--- a/src/services/webhook.py
+++ b/src/services/webhook.py
@@ -1,6 +1,5 @@
 """Webhook notification service for Horizon."""
 
-import html
 import json
 import logging
 import os
@@ -11,6 +10,7 @@ from typing import Any, List, Optional, Union, cast
 from urllib.parse import urlparse
 import httpx
 
+from ..ai.markdown_utils import clean_app_summary_markdown
 from ..models import ContentItem, WebhookConfig
 from ..ai.summarizer import DailySummarizer
 
@@ -19,19 +19,6 @@ logger = logging.getLogger(__name__)
 
 # Pattern: #{key} or #{key?param1=val1&param2=val2}
 _PLACEHOLDER_RE = re.compile(r"#\{(\w+)(\?\w+=[^}]+)?\}")
-_DETAILS_RE = re.compile(
-    r"<details>\s*<summary>(.*?)</summary>\s*(.*?)\s*</details>",
-    re.IGNORECASE | re.DOTALL,
-)
-_LI_LINK_RE = re.compile(
-    r"<li>\s*<a\s+[^>]*href=[\"']([^\"']+)[\"'][^>]*>(.*?)</a>\s*</li>",
-    re.IGNORECASE | re.DOTALL,
-)
-_LI_RE = re.compile(r"<li>\s*(.*?)\s*</li>", re.IGNORECASE | re.DOTALL)
-_ANCHOR_ID_RE = re.compile(
-    r"<a\s+[^>]*id=[\"'][^\"']+[\"'][^>]*>\s*</a>", re.IGNORECASE
-)
-_HTML_TAG_RE = re.compile(r"<[^>]+>")
 _SENSITIVE_HEADER_RE = re.compile(
     r"(authorization|token|secret|signature|key|password)", re.IGNORECASE
 )
@@ -124,48 +111,9 @@ def _render(
     return template
 
 
-def _strip_html_tags(value: str) -> str:
-    """Remove simple HTML tags and decode HTML entities."""
-    return html.unescape(_HTML_TAG_RE.sub("", value)).strip()
-
-
-def _convert_details_to_markdown(value: str) -> str:
-    """Convert HTML details blocks into plain Markdown sections.
-
-    Feishu card Markdown does not render HTML disclosure widgets, so references
-    are flattened to a heading plus Markdown links before webhook delivery.
-    """
-
-    def _replace(match: re.Match) -> str:
-        title = _strip_html_tags(match.group(1)) or "References"
-        body = match.group(2)
-        items: list[str] = []
-
-        for href, label in _LI_LINK_RE.findall(body):
-            clean_label = _strip_html_tags(label)
-            clean_href = html.unescape(href).strip()
-            if clean_label and clean_href:
-                items.append(f"- [{clean_label}]({clean_href})")
-
-        if not items:
-            for item in _LI_RE.findall(body):
-                clean_item = _strip_html_tags(item)
-                if clean_item:
-                    items.append(f"- {clean_item}")
-
-        if not items:
-            fallback = _strip_html_tags(body)
-            return f"**{title}**\n\n{fallback}" if fallback else f"**{title}**"
-
-        return f"**{title}**\n\n" + "\n".join(items)
-
-    return _DETAILS_RE.sub(_replace, value)
-
-
 def _format_markdown_for_webhook(value: str) -> str:
     """Flatten HTML constructs that chat/webhook Markdown often cannot render."""
-    value = _ANCHOR_ID_RE.sub("", value)
-    return _convert_details_to_markdown(value)
+    return clean_app_summary_markdown(value)
 
 
 def _prepare_variables_for_body(

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -97,6 +97,72 @@ def test_send_daily_summary_escapes_raw_html(monkeypatch):
     assert "&lt;img src=x" in html_body
 
 
+def test_send_daily_summary_cleans_app_generated_markdown_html(monkeypatch):
+    monkeypatch.setenv("EMAIL_PASSWORD", "secret")
+    monkeypatch.setattr("src.services.email.smtplib.SMTP_SSL", FakeSMTP)
+    FakeSMTP.instances = []
+
+    manager = EmailManager(_email_config())
+    summary = """# Daily
+
+<a id="item-1"></a>
+## Item
+
+<details><summary>参考链接</summary>
+<ul>
+<li><a href="https://example.com/a">Example A</a></li>
+<li><a href="https://example.com/b">Example B</a></li>
+</ul>
+</details>
+"""
+
+    manager.send_daily_summary(summary, "Daily", ["user@example.com"])
+
+    message = FakeSMTP.instances[0].messages[0]
+    text_body = message.get_payload()[0].get_payload(decode=True).decode()
+    html_body = message.get_payload()[1].get_payload(decode=True).decode()
+
+    assert '<a id="item-1"></a>' not in text_body
+    assert "<details>" not in text_body
+    assert "<summary>" not in text_body
+    assert "**参考链接**" in text_body
+    assert "- [Example A](https://example.com/a)" in text_body
+
+    assert '&lt;a id="item-1"&gt;&lt;/a&gt;' not in html_body
+    assert "&lt;details&gt;" not in html_body
+    assert "&lt;summary&gt;" not in html_body
+    assert "<strong>参考链接</strong>" in html_body
+    assert '<a href="https://example.com/a">Example A</a>' in html_body
+    assert '<a href="https://example.com/b">Example B</a>' in html_body
+
+
+def test_send_daily_summary_does_not_link_unsafe_details_href(monkeypatch):
+    monkeypatch.setenv("EMAIL_PASSWORD", "secret")
+    monkeypatch.setattr("src.services.email.smtplib.SMTP_SSL", FakeSMTP)
+    FakeSMTP.instances = []
+
+    manager = EmailManager(_email_config())
+    summary = """# Daily
+
+<details><summary>References</summary>
+<ul>
+<li><a href="javascript:alert(1)">click [me](https://evil.example)</a></li>
+</ul>
+</details>
+"""
+
+    manager.send_daily_summary(summary, "Daily", ["user@example.com"])
+
+    message = FakeSMTP.instances[0].messages[0]
+    text_body = message.get_payload()[0].get_payload(decode=True).decode()
+    html_body = message.get_payload()[1].get_payload(decode=True).decode()
+
+    assert 'href="javascript:alert(1)"' not in html_body
+    assert "[click](javascript:alert(1))" not in text_body
+    assert "- click \\[me\\]\\(https://evil.example\\)" in text_body
+    assert "click [me](https://evil.example)" in html_body
+
+
 def test_check_subscriptions_skips_imap_when_disabled(monkeypatch):
     monkeypatch.setenv("EMAIL_PASSWORD", "secret")
     monkeypatch.setattr("src.services.email.imaplib.IMAP4_SSL", FakeIMAP)

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1,9 +1,14 @@
 """Unit tests for daily summary rendering."""
 
+import asyncio
 from datetime import datetime, timezone
 
 from src.ai.summarizer import DailySummarizer
 from src.models import ContentItem, SourceType
+
+
+def _run_async(coro):
+    return asyncio.run(coro)
 
 
 def _make_item(idx: int) -> ContentItem:
@@ -98,3 +103,38 @@ def test_generate_webhook_item_uses_localized_discussion_label():
     )
 
     assert "[社区讨论](https://www.reddit.com/r/python/comments/abc123/test/)" in result
+
+
+def test_generate_summary_zh_uses_localized_selection_header_and_numeric_date():
+    summarizer = DailySummarizer()
+    item = _make_item(1)
+
+    result = _run_async(
+        summarizer.generate_summary(
+            [item],
+            date="2026-04-25",
+            total_fetched=10,
+            language="zh",
+        )
+    )
+
+    assert "> 从 10 条内容中筛选出 1 条重要资讯。" in result
+    assert "rss · tester · 4月25日 08:00" in result
+    assert "From 10 items" not in result
+    assert "Apr 25, 08:00" not in result
+
+
+def test_generate_empty_summary_zh_uses_localized_analyzed_line():
+    summarizer = DailySummarizer()
+
+    result = _run_async(
+        summarizer.generate_summary(
+            [],
+            date="2026-04-25",
+            total_fetched=10,
+            language="zh",
+        )
+    )
+
+    assert "> 已分析 10 条内容，但没有达到重要性阈值的条目。" in result
+    assert "Analyzed 10 items" not in result

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -224,6 +224,55 @@ class TestWebhookMarkdownFormatting:
         assert "- [Example A](https://example.com/a)" in result
         assert "- [Example B](https://example.com/b)" in result
 
+    def test_details_references_with_unsafe_href_remain_plain_text(self):
+        summary = """## Item
+
+<details><summary>References</summary>
+<ul>
+<li><a href="javascript:alert(1)">click [me](https://evil.example)</a></li>
+</ul>
+</details>
+"""
+
+        result = _format_markdown_for_webhook(summary)
+
+        assert "javascript:alert(1)" not in result
+        assert "[click](javascript:alert(1))" not in result
+        assert "- click \\[me\\]\\(https://evil.example\\)" in result
+
+    def test_details_references_with_malformed_http_href_remain_plain_text(self):
+        summary = """## Item
+
+<details><summary>References</summary>
+<ul>
+<li><a href="https://safe.example/) [bad](javascript:alert(1))">click</a></li>
+</ul>
+</details>
+"""
+
+        result = _format_markdown_for_webhook(summary)
+
+        assert "javascript:alert(1)" not in result
+        assert "[click](https://safe.example/)" not in result
+        assert "- click" in result
+
+    def test_details_references_allow_balanced_parentheses_in_href(self):
+        summary = """## Item
+
+<details><summary>References</summary>
+<ul>
+<li><a href="https://en.wikipedia.org/wiki/Colossus_(supercomputer)">Colossus</a></li>
+</ul>
+</details>
+"""
+
+        result = _format_markdown_for_webhook(summary)
+
+        assert (
+            "- [Colossus](https://en.wikipedia.org/wiki/Colossus_(supercomputer))"
+            in result
+        )
+
     def test_prepare_variables_changes_summary_for_any_post_body(self):
         summary = "<details><summary>References</summary><ul><li>Plain item</li></ul></details>"
         variables = {"summary": summary, "date": "2026-04-24"}


### PR DESCRIPTION
## Summary
- Clean generated anchor/details HTML before rendering email summaries
- Share summary Markdown cleanup with webhook delivery
- Localize Chinese summary boilerplate and source dates
- Keep unsafe details links as plain text instead of active Markdown links

## Test Plan
- `uv run --extra dev pytest -q`
- Verified the updated Docker image locally and confirmed email rendering looks correct