### PR TITLE
fix(ai): clarify API key env configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,8 @@ AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
 GOOGLE_API_KEY=xxx
 MINIMAX_API_KEY=xxx
 DASHSCOPE_API_KEY=xxx
+DOUBAO_API_KEY=xxx
+DEEPSEEK_API_KEY=xxx
 
 # WebHook Url (optional for sending notifications)
 HORIZON_WEBHOOK_URL=https://xxx

--- a/README.md
+++ b/README.md
@@ -254,6 +254,25 @@ Minimal manual configuration:
 }
 ```
 
+`api_key_env` must be the name of an environment variable, not the API key
+itself. Put the real secret in `.env`:
+
+```bash
+OPENAI_API_KEY=sk-your-key
+```
+
+For Gemini, use `GOOGLE_API_KEY`:
+
+```jsonc
+{
+  "ai": {
+    "provider": "gemini",
+    "model": "gemini-2.0-flash",
+    "api_key_env": "GOOGLE_API_KEY"
+  }
+}
+```
+
 Any string value in `data/config.json` can reference environment variables with `${VAR_NAME}`. This is useful for values such as `ai.base_url`, private RSS feed URLs, webhook endpoints, or custom header templates.
 
 For the full reference, see the [Configuration Guide](docs/configuration.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,32 @@ Horizon is configured through two files: a `.env` file for API keys and a `data/
 
 Configure which AI model scores and summarizes your content.
 
+`api_key_env` is always an environment variable name, not the API key value.
+Store secrets in `.env` or your shell environment, then point `api_key_env` at
+that variable:
+
+```bash
+OPENAI_API_KEY=sk-your-key
+GOOGLE_API_KEY=your-gemini-key
+```
+
+When Horizon starts, environment variables have priority because
+`data/config.json` does not store the secret. For local VS Code runs, create
+`.env` in the repository root and launch Horizon from that same root directory.
+
+Common API key variable names:
+
+| Provider | `api_key_env` value |
+| --- | --- |
+| Anthropic | `ANTHROPIC_API_KEY` |
+| OpenAI | `OPENAI_API_KEY` |
+| Azure OpenAI | `AZURE_OPENAI_API_KEY` |
+| Gemini | `GOOGLE_API_KEY` |
+| MiniMax | `MINIMAX_API_KEY` |
+| Aliyun DashScope | `DASHSCOPE_API_KEY` |
+| Doubao | `DOUBAO_API_KEY` |
+| DeepSeek | `DEEPSEEK_API_KEY` |
+
 **Anthropic Claude**:
 
 ```json
@@ -32,6 +58,19 @@ Configure which AI model scores and summarizes your content.
     "provider": "openai",
     "model": "gpt-4",
     "api_key_env": "OPENAI_API_KEY",
+    "throttle_sec": 0
+  }
+}
+```
+
+**Gemini**:
+
+```json
+{
+  "ai": {
+    "provider": "gemini",
+    "model": "gemini-2.0-flash",
+    "api_key_env": "GOOGLE_API_KEY",
     "throttle_sec": 0
   }
 }

--- a/src/ai/client.py
+++ b/src/ai/client.py
@@ -1,6 +1,7 @@
 """AI client abstraction supporting multiple providers."""
 
 import os
+import re
 from abc import ABC, abstractmethod
 from typing import Optional
 from openai import AsyncAzureOpenAI, AsyncOpenAI
@@ -11,6 +12,62 @@ from google.genai import types
 
 from ..models import AIConfig, AIProvider
 from .tokens import record_usage
+
+
+_ENV_VAR_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SECRET_PREFIXES = (
+    "sk-",
+    "sk_",
+    "AIza",
+    "xai-",
+    "gsk_",
+    "hf_",
+)
+_DEFAULT_API_KEY_ENVS = {
+    AIProvider.ANTHROPIC: "ANTHROPIC_API_KEY",
+    AIProvider.OPENAI: "OPENAI_API_KEY",
+    AIProvider.AZURE: "AZURE_OPENAI_API_KEY",
+    AIProvider.ALI: "DASHSCOPE_API_KEY",
+    AIProvider.GEMINI: "GOOGLE_API_KEY",
+    AIProvider.DOUBAO: "DOUBAO_API_KEY",
+    AIProvider.MINIMAX: "MINIMAX_API_KEY",
+    AIProvider.DEEPSEEK: "DEEPSEEK_API_KEY",
+}
+
+
+def _resolve_api_key(config: AIConfig, *, fallback: Optional[str] = None) -> str:
+    api_key = os.getenv(config.api_key_env)
+    if api_key:
+        return api_key
+    if fallback is not None:
+        return fallback
+    raise ValueError(_missing_api_key_message(config))
+
+
+def _missing_api_key_message(config: AIConfig) -> str:
+    expected_env = _DEFAULT_API_KEY_ENVS.get(config.provider, config.api_key_env)
+    setup_hint = (
+        f"Set {expected_env}=your_api_key in .env or your shell, then set "
+        f'ai.api_key_env to "{expected_env}" in data/config.json.'
+    )
+
+    if _looks_like_api_key_value(config.api_key_env):
+        return (
+            "Missing API key: ai.api_key_env must be an environment variable "
+            f"name, not the API key value. {setup_hint}"
+        )
+
+    return (
+        f"Missing API key environment variable: {config.api_key_env}. "
+        "ai.api_key_env should contain the environment variable name, not the "
+        f"key value. {setup_hint}"
+    )
+
+
+def _looks_like_api_key_value(value: str) -> bool:
+    if value.startswith(_SECRET_PREFIXES):
+        return True
+    return not bool(_ENV_VAR_RE.fullmatch(value))
 
 
 class AIClient(ABC):
@@ -49,12 +106,7 @@ class AnthropicClient(AIClient):
         """
         self.config = config
 
-        api_key = os.getenv(config.api_key_env)
-        if not api_key:
-            if config.provider.value == "ollama":
-                api_key = "ollama"
-            else:
-                raise ValueError(f"Missing API key: {config.api_key_env}")
+        api_key = _resolve_api_key(config)
 
         kwargs = {"api_key": api_key}
         if config.base_url:
@@ -129,12 +181,8 @@ class OpenAIClient(AIClient):
         """
         self.config = config
 
-        api_key = os.getenv(config.api_key_env)
-        if not api_key:
-            if config.provider == AIProvider.OLLAMA:
-                api_key = "no_key"  # Ollama doesn't require an API key
-            else:
-                raise ValueError(f"Missing API key: {config.api_key_env}")
+        fallback = "no_key" if config.provider == AIProvider.OLLAMA else None
+        api_key = _resolve_api_key(config, fallback=fallback)
 
         kwargs = {"api_key": api_key}
         base_url = config.base_url or self._DEFAULT_BASE_URLS.get(config.provider.value)
@@ -260,12 +308,7 @@ class AzureOpenAIClient(AIClient):
         """
         self.config = config
 
-        api_key = os.getenv(config.api_key_env)
-        if not api_key:
-            if config.provider.value == "ollama":
-                api_key = "ollama"
-            else:
-                raise ValueError(f"Missing API key: {config.api_key_env}")
+        api_key = _resolve_api_key(config)
         if not config.azure_endpoint_env:
             raise ValueError("azure_endpoint_env is required for azure provider")
         azure_endpoint = os.getenv(config.azure_endpoint_env)
@@ -385,12 +428,7 @@ class GeminiClient(AIClient):
         """
         self.config = config
 
-        api_key = os.getenv(config.api_key_env)
-        if not api_key:
-            if config.provider.value == "ollama":
-                api_key = "ollama"
-            else:
-                raise ValueError(f"Missing API key: {config.api_key_env}")
+        api_key = _resolve_api_key(config)
 
         self.client = genai.Client(api_key=api_key)
         self.model = config.model

--- a/src/ai/client.py
+++ b/src/ai/client.py
@@ -45,11 +45,17 @@ def _resolve_api_key(config: AIConfig, *, fallback: Optional[str] = None) -> str
 
 
 def _missing_api_key_message(config: AIConfig) -> str:
-    expected_env = _DEFAULT_API_KEY_ENVS.get(config.provider, config.api_key_env)
-    setup_hint = (
-        f"Set {expected_env}=your_api_key in .env or your shell, then set "
-        f'ai.api_key_env to "{expected_env}" in data/config.json.'
-    )
+    expected_env = _DEFAULT_API_KEY_ENVS.get(config.provider)
+    if expected_env:
+        setup_hint = (
+            f"Set {expected_env}=your_api_key in .env or your shell, then set "
+            f'ai.api_key_env to "{expected_env}" in data/config.json.'
+        )
+    else:
+        setup_hint = (
+            "Set the provider API key in .env or your shell, then set "
+            "ai.api_key_env to that environment variable name in data/config.json."
+        )
 
     if _looks_like_api_key_value(config.api_key_env):
         return (
@@ -58,7 +64,7 @@ def _missing_api_key_message(config: AIConfig) -> str:
         )
 
     return (
-        f"Missing API key environment variable: {config.api_key_env}. "
+        "Missing API key environment variable configured by ai.api_key_env. "
         "ai.api_key_env should contain the environment variable name, not the "
         f"key value. {setup_hint}"
     )

--- a/tests/test_minimax_client.py
+++ b/tests/test_minimax_client.py
@@ -50,6 +50,18 @@ class TestOpenAIClientInit:
         assert "environment variable name" in message
         assert "MINIMAX_API_KEY" in message
 
+    def test_does_not_echo_identifier_shaped_api_key(self, monkeypatch):
+        literal_key = "a2c9f1b4e6d7a3c0b5e8d1f9a4c2e6b8"
+        monkeypatch.delenv(literal_key, raising=False)
+
+        with pytest.raises(ValueError) as exc:
+            OpenAIClient(_make_config(api_key_env=literal_key))
+
+        message = str(exc.value)
+        assert literal_key not in message
+        assert "api_key_env" in message
+        assert "MINIMAX_API_KEY" in message
+
     def test_uses_provider_default_base_url(self, monkeypatch):
         monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
         client = OpenAIClient(_make_config())

--- a/tests/test_minimax_client.py
+++ b/tests/test_minimax_client.py
@@ -37,6 +37,19 @@ class TestOpenAIClientInit:
         with pytest.raises(ValueError, match="Missing API key"):
             OpenAIClient(_make_config())
 
+    def test_rejects_literal_api_key_in_api_key_env_without_leaking_it(self, monkeypatch):
+        literal_key = "sk-test1234567890"
+        monkeypatch.delenv(literal_key, raising=False)
+
+        with pytest.raises(ValueError) as exc:
+            OpenAIClient(_make_config(api_key_env=literal_key))
+
+        message = str(exc.value)
+        assert literal_key not in message
+        assert "api_key_env" in message
+        assert "environment variable name" in message
+        assert "MINIMAX_API_KEY" in message
+
     def test_uses_provider_default_base_url(self, monkeypatch):
         monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
         client = OpenAIClient(_make_config())


### PR DESCRIPTION
## Summary
- centralize API key environment-variable resolution across AI providers
- avoid echoing literal API key values when api_key_env is misconfigured
- document local .env setup, Gemini GOOGLE_API_KEY, and common provider env var names

## Why
Users can accidentally put the API key itself in data/config.json under ai.api_key_env. Horizon expects that field to contain the environment variable name, which made startup failures confusing and could leak the key in the error text.

Closes #76

## Tests
- UV_CACHE_DIR=/private/tmp/uv-cache uv run --extra dev pytest tests/test_minimax_client.py tests/test_azure_client.py
- cp data/config.example.json data/config.json && UV_CACHE_DIR=/private/tmp/uv-cache uv run --extra dev pytest

## Review
- Claude Code review found one blocking leak path for identifier-shaped literal keys. Fixed in follow-up commit b0d35f7.
- Claude Code re-review found no blocking issues remaining; residual notes are non-blocking coverage/UX improvements.