### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,14 +99,14 @@ Set `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_ENDPOINT` in your `.env`. The `mode
 {
   "ai": {
     "provider": "minimax",
-    "model": "MiniMax-M2.7",
+    "model": "MiniMax-M3",
     "api_key_env": "MINIMAX_API_KEY",
     "throttle_sec": 0
   }
 }
 ```
 
-Available models: `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`
+Available models: `MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`
 
 **Aliyun DashScope** (OpenAI-compatible):
 

--- a/tests/test_minimax_client.py
+++ b/tests/test_minimax_client.py
@@ -15,7 +15,7 @@ from src.models import AIConfig, AIProvider
 def _make_config(**overrides) -> AIConfig:
     defaults = {
         "provider": AIProvider.MINIMAX,
-        "model": "MiniMax-M2.7",
+        "model": "MiniMax-M3",
         "api_key_env": "MINIMAX_API_KEY",
         "temperature": 0.3,
         "max_tokens": 4096,
@@ -28,7 +28,7 @@ class TestOpenAIClientInit:
     def test_creates_instance_with_valid_config(self, monkeypatch):
         monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
         client = OpenAIClient(_make_config())
-        assert client.model == "MiniMax-M2.7"
+        assert client.model == "MiniMax-M3"
         assert client.max_tokens == 4096
         assert client.provider == "minimax"
 
@@ -100,7 +100,7 @@ class TestOpenAIClientComplete:
 
         assert result == '{"score": 8}'
         call_kwargs = mock_create.call_args[1]
-        assert call_kwargs["model"] == "MiniMax-M2.7"
+        assert call_kwargs["model"] == "MiniMax-M3"
         # response_format should NOT be present (MiniMax doesn't support it)
         assert "response_format" not in call_kwargs
 


### PR DESCRIPTION
## Summary

Upgrade the documented default MiniMax model from `MiniMax-M2.7` to the newer `MiniMax-M3`, and clean the legacy M2.5 generation out of the published model list.

## Changes

- `docs/configuration.md`
  - Switch the example `model` value from `MiniMax-M2.7` to `MiniMax-M3`
  - Reorder the *Available models* line to put `MiniMax-M3` first and drop `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` (still keeping `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as compatible options)
- `tests/test_minimax_client.py`
  - Update the shared `_make_config` default and the two model-name assertions from `MiniMax-M2.7` to `MiniMax-M3`

No other code paths reference the model ID (the `OpenAIClient` uses `config.model` opaquely), so the runtime behavior for users who already set `model` explicitly is unchanged. Only the documented default and the test fixture are updated.

## Notes

- Provider routing, base URL (`api.minimax.io/v1`), API key env var (`MINIMAX_API_KEY`), `_NO_RESPONSE_FORMAT` and `_TEMP_CLAMP` lists are untouched — M3 inherits the same OpenAI-compatible quirks as M2.7.
- TTS / speech configs are not affected by this PR.

## Test plan

- [x] `pytest tests/test_minimax_client.py` — 21 passed (all OpenAIClient init / completion / factory tests green after the model-name update)