### PR TITLE
feat(scoring): add personal scoring profile config

### DIFF
--- a/data/config.example.json
+++ b/data/config.example.json
@@ -113,6 +113,14 @@
     "ai_score_threshold": 6.0,
     "time_window_hours": 24
   },
+  "scoring": {
+    "profile_name": "default",
+    "primary": [],
+    "secondary": [],
+    "boost": [],
+    "downrank": [],
+    "notes": null
+  },
   "webhook": {
     "enabled": false,
     "url_env": "HORIZON_WEBHOOK_URL",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -451,6 +451,8 @@ Horizon's default scorer uses a generic technical-news rubric. You can optionall
 - `downrank`: Qualities that should lower an item's score.
 - `notes`: Free-form preference guidance.
 
+All fields except `profile_name` are optional; empty arrays and `null` notes are ignored.
+
 The profile refines the default rubric; it does not replace basic quality checks such as novelty, substance, relevance, and discussion quality.
 
 ## Environment Variable Substitution

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -451,7 +451,7 @@ Horizon's default scorer uses a generic technical-news rubric. You can optionall
 - `downrank`: Qualities that should lower an item's score.
 - `notes`: Free-form preference guidance.
 
-All fields except `profile_name` are optional; empty arrays and `null` notes are ignored.
+All fields except `profile_name` are optional; empty arrays, blank strings, and `null` notes are ignored. Each preference list accepts up to 12 non-empty items, each item can be up to 160 characters, `notes` can be up to 600 characters, and `profile_name` can be up to 80 characters.
 
 The profile refines the default rubric; it does not replace basic quality checks such as novelty, substance, relevance, and discussion quality.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -408,6 +408,51 @@ Content is scored 0-10:
 - `ai_score_threshold`: Only include content scoring >= this value
 - `time_window_hours`: Fetch content from last N hours
 
+## Personal Scoring Profile
+
+Horizon's default scorer uses a generic technical-news rubric. You can optionally add a top-level `scoring` block to refine that rubric toward your own interests without changing the output schema.
+
+```json
+{
+  "scoring": {
+    "profile_name": "personal",
+    "primary": [
+      "cognitive value",
+      "paradigm shifts",
+      "transferable insights"
+    ],
+    "secondary": [
+      "engineering usefulness",
+      "automation workflows",
+      "developer productivity"
+    ],
+    "boost": [
+      "changes how I think about AI, products, engineering, or work",
+      "contains durable mental models or decision frameworks",
+      "reveals a structural trend or shift",
+      "has actionable engineering or automation lessons"
+    ],
+    "downrank": [
+      "generic AI hype",
+      "thin product announcements",
+      "funding news without technical or strategic signal",
+      "tutorials without novelty",
+      "engagement without substance"
+    ],
+    "notes": "Prefer cognitive value first, practical engineering value second."
+  }
+}
+```
+
+- `profile_name`: Human-readable name for the profile.
+- `primary`: Strongest signals for 8-10 scores.
+- `secondary`: Supporting signals for high scores.
+- `boost`: Specific qualities that should raise an item's score.
+- `downrank`: Qualities that should lower an item's score.
+- `notes`: Free-form preference guidance.
+
+The profile refines the default rubric; it does not replace basic quality checks such as novelty, substance, relevance, and discussion quality.
+
 ## Environment Variable Substitution
 
 Any string value in `data/config.json` supports `${VAR_NAME}` syntax. Variables are expanded at runtime from the environment (including values loaded from `.env`). This lets you keep secrets, tenant-specific endpoints, and private URLs out of the checked-in JSON file.

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -54,7 +54,7 @@ Items scoring 9.0 or above are featured in the "Today's Highlights" section of t
 
 ## Optional Personal Scoring
 
-If `data/config.json` includes a top-level `scoring` block, Horizon appends that profile to the AI scoring prompt. The model still returns the same fields: `score`, `reason`, `summary`, and `tags`.
+If `data/config.json` includes a top-level `scoring` block with non-empty preferences, Horizon appends that profile to the AI scoring prompt. Empty arrays and `null` notes keep the base prompt unchanged. The model still returns the same fields: `score`, `reason`, `summary`, and `tags`.
 
 Personal scoring is useful when your daily brief should optimize for a specific lens, such as cognitive value, product strategy, engineering usefulness, or automation ideas. The `reason` field should mention the preference that affected the score when relevant.
 

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -52,6 +52,12 @@ After scoring, items are filtered by `filtering.ai_score_threshold` (default: `7
 
 Items scoring 9.0 or above are featured in the "Today's Highlights" section of the summary.
 
+## Optional Personal Scoring
+
+If `data/config.json` includes a top-level `scoring` block, Horizon appends that profile to the AI scoring prompt. The model still returns the same fields: `score`, `reason`, `summary`, and `tags`.
+
+Personal scoring is useful when your daily brief should optimize for a specific lens, such as cognitive value, product strategy, engineering usefulness, or automation ideas. The `reason` field should mention the preference that affected the score when relevant.
+
 ## Enrichment
 
 Items that pass the score threshold go through a second AI pass for enrichment (`src/ai/enricher.py`):

--- a/docs/superpowers/plans/2026-06-02-personal-scoring.md
+++ b/docs/superpowers/plans/2026-06-02-personal-scoring.md
@@ -1,0 +1,564 @@
+# Personal Scoring Configuration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add optional personal scoring preferences to Horizon so AI scoring can be tuned from `data/config.json` without changing code.
+
+**Architecture:** Add a top-level `ScoringConfig` model, render it into a compact scoring-profile prompt section, and pass it explicitly into `ContentAnalyzer` from the main orchestrator and MCP service. Keep the current score output contract unchanged.
+
+**Tech Stack:** Python 3.11, Pydantic v2, pytest, Horizon `StorageManager`, Horizon AI analyzer/orchestrator/MCP service.
+
+---
+
+## File Structure
+
+- Modify `src/models.py`: define `ScoringConfig` and add optional `Config.scoring`.
+- Modify `src/ai/analyzer.py`: accept optional scoring config and append it to the analysis system prompt.
+- Modify `src/orchestrator.py`: pass `self.config.scoring` to `ContentAnalyzer` for normal analysis and Twitter reply re-analysis.
+- Modify `src/mcp/service.py`: pass `ctx.config.scoring` to `ContentAnalyzer` in staged MCP scoring.
+- Modify `tests/test_storage.py`: cover config loading with and without `scoring`.
+- Modify `tests/test_analyzer.py`: cover prompt rendering and unchanged default prompt behavior.
+- Modify `tests/test_mcp_service_smoke.py`: cover MCP scoring constructor wiring with a fake runtime analyzer.
+- Modify `data/config.example.json`: add a neutral example scoring block.
+- Modify `docs/configuration.md`: document scoring configuration.
+- Modify `docs/scoring.md`: document how personal scoring refines the generic rubric.
+
+## Task 1: Add ScoringConfig Model
+
+**Files:**
+- Modify: `src/models.py`
+- Modify: `tests/test_storage.py`
+
+- [ ] **Step 1: Write failing storage/model test**
+
+Append this test to `tests/test_storage.py`:
+
+```python
+def test_load_config_accepts_scoring_profile(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({
+        "version": "1.0",
+        "ai": {
+            "provider": "openai",
+            "model": "gpt-4o",
+            "api_key_env": "OPENAI_API_KEY",
+        },
+        "sources": {"hackernews": {"enabled": True}},
+        "filtering": {"ai_score_threshold": 7.0, "time_window_hours": 24},
+        "scoring": {
+            "profile_name": "personal",
+            "primary": ["cognitive value", "paradigm shifts"],
+            "secondary": ["engineering usefulness"],
+            "boost": ["durable mental models"],
+            "downrank": ["generic AI hype"],
+            "notes": "Prefer cognitive value first.",
+        },
+    }), encoding="utf-8")
+
+    storage = StorageManager(data_dir=str(tmp_path))
+    config = storage.load_config()
+
+    assert config.scoring is not None
+    assert config.scoring.profile_name == "personal"
+    assert config.scoring.primary == ["cognitive value", "paradigm shifts"]
+    assert config.scoring.secondary == ["engineering usefulness"]
+    assert config.scoring.boost == ["durable mental models"]
+    assert config.scoring.downrank == ["generic AI hype"]
+    assert config.scoring.notes == "Prefer cognitive value first."
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+uv run pytest tests/test_storage.py::test_load_config_accepts_scoring_profile -q
+```
+
+Expected: FAIL because `Config` has no `scoring` field or because extra fields are ignored and `config.scoring` is missing.
+
+- [ ] **Step 3: Add model types**
+
+In `src/models.py`, add this class after `FilteringConfig`:
+
+```python
+class ScoringConfig(BaseModel):
+    """Optional user preferences that refine AI content scoring."""
+
+    profile_name: str = "default"
+    primary: List[str] = Field(default_factory=list)
+    secondary: List[str] = Field(default_factory=list)
+    boost: List[str] = Field(default_factory=list)
+    downrank: List[str] = Field(default_factory=list)
+    notes: Optional[str] = None
+```
+
+Then update `Config`:
+
+```python
+class Config(BaseModel):
+    """Main configuration model."""
+
+    version: str = "1.0"
+    ai: AIConfig
+    sources: SourcesConfig
+    filtering: FilteringConfig
+    scoring: Optional[ScoringConfig] = None
+    email: Optional[EmailConfig] = None
+    webhook: Optional[WebhookConfig] = None
+```
+
+- [ ] **Step 4: Run storage tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_storage.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/models.py tests/test_storage.py
+git commit -m "feat(scoring): add scoring config model" -m "AI: Codex"
+```
+
+## Task 2: Add Analyzer Prompt Rendering
+
+**Files:**
+- Modify: `src/ai/analyzer.py`
+- Modify: `tests/test_analyzer.py`
+
+- [ ] **Step 1: Write failing prompt tests**
+
+Add imports to `tests/test_analyzer.py`:
+
+```python
+from src.ai.prompts import CONTENT_ANALYSIS_SYSTEM
+from src.models import ScoringConfig
+```
+
+Append these tests:
+
+```python
+def test_build_system_prompt_without_scoring_uses_base_prompt():
+    analyzer = ContentAnalyzer(SimpleNamespace())
+
+    assert analyzer._build_system_prompt() == CONTENT_ANALYSIS_SYSTEM
+
+
+def test_build_system_prompt_includes_personal_scoring_profile():
+    scoring = ScoringConfig(
+        profile_name="personal",
+        primary=["cognitive value", "paradigm shifts"],
+        secondary=["engineering usefulness"],
+        boost=["durable mental models"],
+        downrank=["generic AI hype"],
+        notes="Prefer cognitive value first.",
+    )
+    analyzer = ContentAnalyzer(SimpleNamespace(), scoring_config=scoring)
+
+    prompt = analyzer._build_system_prompt()
+
+    assert CONTENT_ANALYSIS_SYSTEM in prompt
+    assert "Personal scoring profile: personal" in prompt
+    assert "Primary high-score signals" in prompt
+    assert "- cognitive value" in prompt
+    assert "- paradigm shifts" in prompt
+    assert "Secondary high-score signals" in prompt
+    assert "- engineering usefulness" in prompt
+    assert "Boost when content matches" in prompt
+    assert "- durable mental models" in prompt
+    assert "Downrank when content is" in prompt
+    assert "- generic AI hype" in prompt
+    assert "Prefer cognitive value first." in prompt
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/test_analyzer.py::test_build_system_prompt_without_scoring_uses_base_prompt tests/test_analyzer.py::test_build_system_prompt_includes_personal_scoring_profile -q
+```
+
+Expected: FAIL because `ContentAnalyzer` does not accept `scoring_config` and has no `_build_system_prompt`.
+
+- [ ] **Step 3: Update ContentAnalyzer constructor and prompt builder**
+
+In `src/ai/analyzer.py`, update imports:
+
+```python
+from ..models import ContentItem, ScoringConfig
+```
+
+Replace the constructor with:
+
+```python
+    def __init__(self, ai_client: AIClient, scoring_config: ScoringConfig | None = None):
+        self.client = ai_client
+        self.scoring_config = scoring_config
+```
+
+Add these methods to `ContentAnalyzer`:
+
+```python
+    @staticmethod
+    def _format_list_section(title: str, values: List[str]) -> str:
+        cleaned = [value.strip() for value in values if value and value.strip()]
+        if not cleaned:
+            return ""
+        lines = "\n".join(f"- {value}" for value in cleaned)
+        return f"{title}:\n{lines}"
+
+    def _build_system_prompt(self) -> str:
+        """Return the analysis prompt, optionally refined by user scoring preferences."""
+        scoring = self.scoring_config
+        if not scoring:
+            return CONTENT_ANALYSIS_SYSTEM
+
+        sections = [
+            f"Personal scoring profile: {scoring.profile_name}",
+            "Use this profile to refine, not replace, the generic rubric above.",
+            "Primary high-score signals should be treated as the strongest reasons to score content 8-10.",
+            self._format_list_section("Primary high-score signals", scoring.primary),
+            "Secondary high-score signals can raise a good item when quality and relevance are also strong.",
+            self._format_list_section("Secondary high-score signals", scoring.secondary),
+            self._format_list_section("Boost when content matches", scoring.boost),
+            self._format_list_section("Downrank when content is", scoring.downrank),
+        ]
+        if scoring.notes and scoring.notes.strip():
+            sections.append(f"Additional preference notes: {scoring.notes.strip()}")
+        sections.append(
+            "When these preferences affect the score, mention the matched cognitive or practical signal in the JSON reason field."
+        )
+        profile_text = "\n\n".join(section for section in sections if section)
+        return f"{CONTENT_ANALYSIS_SYSTEM.rstrip()}\n\n{profile_text}\n"
+```
+
+- [ ] **Step 4: Use prompt builder in AI call**
+
+In `_analyze_item`, replace:
+
+```python
+            system=CONTENT_ANALYSIS_SYSTEM,
+```
+
+with:
+
+```python
+            system=self._build_system_prompt(),
+```
+
+- [ ] **Step 5: Run analyzer tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_analyzer.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ai/analyzer.py tests/test_analyzer.py
+git commit -m "feat(scoring): inject scoring profile into analysis prompt" -m "AI: Codex"
+```
+
+## Task 3: Wire Scoring Config Through Main and MCP Flows
+
+**Files:**
+- Modify: `src/orchestrator.py`
+- Modify: `src/mcp/service.py`
+- Modify: `tests/test_mcp_service_smoke.py`
+
+- [ ] **Step 1: Update MCP test imports**
+
+In `tests/test_mcp_service_smoke.py`, replace:
+
+```python
+from src.mcp.service import HorizonPipelineService
+```
+
+with:
+
+```python
+from src.mcp.service import HorizonPipelineService, PipelineContext
+```
+
+- [ ] **Step 2: Add MCP scoring wiring test**
+
+Append this exact test to `tests/test_mcp_service_smoke.py`:
+
+```python
+def test_score_items_passes_scoring_config_to_analyzer(tmp_path, monkeypatch):
+    captured = {}
+
+    class FakeAnalyzer:
+        def __init__(self, ai_client, scoring_config=None):
+            captured["ai_client"] = ai_client
+            captured["scoring_config"] = scoring_config
+
+        async def analyze_batch(self, items):
+            for item in items:
+                item.ai_score = 8.0
+            return items
+
+    scoring = SimpleNamespace(profile_name="personal")
+    config = SimpleNamespace(
+        ai=SimpleNamespace(),
+        scoring=scoring,
+        filtering=SimpleNamespace(ai_score_threshold=7.0),
+    )
+    runtime = SimpleNamespace(
+        create_ai_client=lambda ai: "client",
+        ContentAnalyzer=FakeAnalyzer,
+    )
+
+    service = HorizonPipelineService(runs_root=tmp_path / "runs")
+    run_id = service.run_store.create_run("test-run")
+    service.run_store.save_items(run_id, "raw", [make_item("item-1").model_dump(mode="json")])
+
+    monkeypatch.setattr(
+        service,
+        "_load_stage_items",
+        lambda **kwargs: ([make_item("item-1")], PipelineContext(
+            horizon_path=tmp_path,
+            config_path=tmp_path / "config.json",
+            runtime=runtime,
+            config=config,
+        )),
+    )
+
+    result = asyncio.run(service.score_items(run_id=run_id))
+
+    assert result["scored"] == 1
+    assert captured["ai_client"] == "client"
+    assert captured["scoring_config"] is scoring
+```
+- [ ] **Step 3: Run MCP test to verify it fails**
+
+Run:
+
+```bash
+uv run pytest tests/test_mcp_service_smoke.py::test_score_items_passes_scoring_config_to_analyzer -q
+```
+
+Expected: FAIL because `score_items` currently calls `ContentAnalyzer(ai_client)` without scoring config.
+
+- [ ] **Step 4: Wire orchestrator analysis**
+
+In `src/orchestrator.py`, update `_analyze_content`:
+
+```python
+        analyzer = ContentAnalyzer(ai_client, scoring_config=self.config.scoring)
+```
+
+Update `_expand_twitter_discussion` re-analysis:
+
+```python
+        analyzer = ContentAnalyzer(ai_client, scoring_config=self.config.scoring)
+```
+
+- [ ] **Step 5: Wire MCP scoring**
+
+In `src/mcp/service.py`, update `score_items`:
+
+```python
+        analyzer = ctx.runtime.ContentAnalyzer(
+            ai_client,
+            scoring_config=getattr(ctx.config, "scoring", None),
+        )
+```
+
+- [ ] **Step 6: Run focused MCP and analyzer tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_mcp_service_smoke.py::test_score_items_passes_scoring_config_to_analyzer tests/test_analyzer.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/orchestrator.py src/mcp/service.py tests/test_mcp_service_smoke.py
+git commit -m "feat(scoring): wire scoring profile through pipelines" -m "AI: Codex"
+```
+
+## Task 4: Update Docs and Example Config
+
+**Files:**
+- Modify: `data/config.example.json`
+- Modify: `docs/configuration.md`
+- Modify: `docs/scoring.md`
+
+- [ ] **Step 1: Add neutral scoring example to config example**
+
+In `data/config.example.json`, insert this top-level `scoring` block between the existing `filtering` block and the existing `webhook` block:
+
+```json
+  "filtering": {
+    "ai_score_threshold": 6.0,
+    "time_window_hours": 24
+  },
+  "scoring": {
+    "profile_name": "default",
+    "primary": [],
+    "secondary": [],
+    "boost": [],
+    "downrank": [],
+    "notes": null
+  },
+  "webhook": {
+```
+
+- [ ] **Step 2: Validate example JSON**
+
+Run:
+
+```bash
+uv run python -m json.tool data/config.example.json >/tmp/horizon-config-example.json
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 3: Add configuration docs section**
+
+In `docs/configuration.md`, add a section near filtering or AI configuration:
+
+````markdown
+## Personal Scoring Profile
+
+Horizon's default scorer uses a generic technical-news rubric. You can optionally add a top-level `scoring` block to refine that rubric toward your own interests without changing the output schema.
+
+```json
+{
+  "scoring": {
+    "profile_name": "personal",
+    "primary": [
+      "cognitive value",
+      "paradigm shifts",
+      "transferable insights"
+    ],
+    "secondary": [
+      "engineering usefulness",
+      "automation workflows",
+      "developer productivity"
+    ],
+    "boost": [
+      "changes how I think about AI, products, engineering, or work",
+      "contains durable mental models or decision frameworks",
+      "reveals a structural trend or shift",
+      "has actionable engineering or automation lessons"
+    ],
+    "downrank": [
+      "generic AI hype",
+      "thin product announcements",
+      "funding news without technical or strategic signal",
+      "tutorials without novelty",
+      "engagement without substance"
+    ],
+    "notes": "Prefer cognitive value first, practical engineering value second."
+  }
+}
+```
+
+- `profile_name`: Human-readable name for the profile.
+- `primary`: Strongest signals for 8-10 scores.
+- `secondary`: Supporting signals for high scores.
+- `boost`: Specific qualities that should raise an item's score.
+- `downrank`: Qualities that should lower an item's score.
+- `notes`: Free-form preference guidance.
+
+The profile refines the default rubric; it does not replace basic quality checks such as novelty, substance, relevance, and discussion quality.
+````
+
+- [ ] **Step 4: Add scoring docs explanation**
+
+In `docs/scoring.md`, add:
+
+```markdown
+## Optional Personal Scoring
+
+If `data/config.json` includes a top-level `scoring` block, Horizon appends that profile to the AI scoring prompt. The model still returns the same fields: `score`, `reason`, `summary`, and `tags`.
+
+Personal scoring is useful when your daily brief should optimize for a specific lens, such as cognitive value, product strategy, engineering usefulness, or automation ideas. The `reason` field should mention the preference that affected the score when relevant.
+```
+
+- [ ] **Step 5: Run docs/config validation**
+
+Run:
+
+```bash
+uv run python -m json.tool data/config.example.json >/tmp/horizon-config-example.json
+uv run pytest tests/test_storage.py tests/test_analyzer.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add data/config.example.json docs/configuration.md docs/scoring.md
+git commit -m "docs(scoring): document personal scoring config" -m "AI: Codex"
+```
+
+## Task 5: Final Verification
+
+**Files:**
+- Read only unless verification reveals a bug.
+
+- [ ] **Step 1: Run focused test suite**
+
+Run:
+
+```bash
+uv run pytest tests/test_storage.py tests/test_analyzer.py tests/test_mcp_service_smoke.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Validate example config load through StorageManager**
+
+Run:
+
+```bash
+tmpdir="$(mktemp -d)"
+cp data/config.example.json "$tmpdir/config.json"
+uv run python - <<PY
+from src.storage.manager import StorageManager
+cfg = StorageManager(data_dir="$tmpdir").load_config()
+print("ok", cfg.scoring.profile_name if cfg.scoring else "no-scoring")
+PY
+```
+
+Expected: prints `ok default`.
+
+- [ ] **Step 3: Inspect git history and status**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline --decorate -5
+```
+
+Expected: branch is `feat-personal-scoring`; working tree is clean; recent commits include the design and implementation commits.
+
+- [ ] **Step 4: Summarize for user**
+
+Report:
+
+- Branch name.
+- Files changed.
+- Test commands and results.
+- That no live AI scoring or Apify calls were run.
+
+No commit is needed in this task if the working tree is clean.

--- a/docs/superpowers/specs/2026-06-02-personal-scoring-design.md
+++ b/docs/superpowers/specs/2026-06-02-personal-scoring-design.md
@@ -1,0 +1,150 @@
+# Personal Scoring Configuration Design
+
+## Summary
+
+Horizon currently uses a fixed AI scoring rubric for technical and academic content. This design adds an optional `scoring` configuration block so users can tune scoring toward personal preferences without editing source code.
+
+For the first version, the target profile prioritizes cognitive value first and engineering usefulness second:
+
+- Cognitive value: content that changes judgment frameworks, reveals structural shifts, or creates durable mental models.
+- Engineering usefulness: content that improves automation workflows, developer productivity, architecture choices, or practical implementation decisions.
+
+When `scoring` is absent, Horizon keeps the current scoring behavior.
+
+## Goals
+
+- Let users express personal scoring preferences in `data/config.json`.
+- Keep the current `ai_score`, `ai_reason`, `ai_summary`, and `ai_tags` output shape.
+- Preserve existing configs and example configs through optional fields and defaults.
+- Make score reasons explain whether an item matched cognitive or practical value.
+- Document the new configuration in both configuration and scoring docs.
+
+## Non-Goals
+
+- Do not add multidimensional score fields such as `cognitive_score` or `practical_score` in the first version.
+- Do not change summary rendering, webhook payload shape, or MCP run artifact shape.
+- Do not add a UI for editing scoring profiles.
+- Do not run live scoring during implementation tests.
+
+## Configuration Shape
+
+Add an optional top-level `scoring` block:
+
+```json
+{
+  "scoring": {
+    "profile_name": "personal",
+    "primary": [
+      "cognitive value",
+      "paradigm shifts",
+      "transferable insights"
+    ],
+    "secondary": [
+      "engineering usefulness",
+      "automation workflows",
+      "developer productivity"
+    ],
+    "boost": [
+      "changes how I think about AI, products, engineering, or work",
+      "contains durable mental models or decision frameworks",
+      "reveals a structural trend or shift",
+      "has actionable engineering or automation lessons"
+    ],
+    "downrank": [
+      "generic AI hype",
+      "thin product announcements",
+      "funding news without technical or strategic signal",
+      "tutorials without novelty",
+      "engagement without substance"
+    ],
+    "notes": "Prefer cognitive value first, practical engineering value second."
+  }
+}
+```
+
+All fields except `profile_name` are optional. Empty arrays are allowed and ignored in prompt rendering.
+
+## Data Model
+
+Add `ScoringConfig` to `src/models.py`:
+
+- `profile_name: str = "default"`
+- `primary: List[str] = Field(default_factory=list)`
+- `secondary: List[str] = Field(default_factory=list)`
+- `boost: List[str] = Field(default_factory=list)`
+- `downrank: List[str] = Field(default_factory=list)`
+- `notes: Optional[str] = None`
+
+Add `scoring: Optional[ScoringConfig] = None` to `Config`.
+
+Using a top-level config keeps this separate from `filtering`, which controls thresholding, and from `ai`, which controls provider behavior.
+
+## Prompt Injection
+
+Keep the existing base `CONTENT_ANALYSIS_SYSTEM` rubric. When `config.scoring` is present, append a compact "Personal scoring profile" section to the system prompt before calling the AI model.
+
+The appended section should:
+
+- State that the configured preferences refine the generic rubric.
+- Treat `primary` dimensions as the strongest high-score signal.
+- Treat `secondary` dimensions as supporting high-score signals.
+- Ask the model to boost matching items and downrank low-signal items.
+- Ask the model to mention the matched preference in `reason` when it affects the score.
+
+If no `scoring` profile is configured, send the current prompt unchanged.
+
+## Analyzer Changes
+
+Update `ContentAnalyzer` so it can access scoring config through the AI client config:
+
+- Add `_build_system_prompt()` or equivalent method.
+- Read `getattr(self.client.config, "scoring", None)` if the AI client config can carry it, or pass scoring config into `ContentAnalyzer` explicitly.
+- Prefer explicit dependency injection if attaching `scoring` to `AIConfig` would blur model-provider settings.
+
+Recommended implementation: pass `scoring_config` into `ContentAnalyzer(ai_client, scoring_config=None)`. `HorizonOrchestrator` and MCP service already hold full `Config`, so they can pass `self.config.scoring`.
+
+## Compatibility
+
+Existing configs without `scoring` must still validate.
+
+Existing AI providers are unaffected because the output JSON contract is unchanged:
+
+```json
+{
+  "score": 8,
+  "reason": "Brief explanation",
+  "summary": "One-sentence summary",
+  "tags": ["tag"]
+}
+```
+
+MCP scoring, pipeline runs, enrichment, filtering, summaries, email, and webhook behavior continue to use the existing `ai_score` field.
+
+## Documentation
+
+Update:
+
+- `docs/configuration.md`: add `scoring` block reference and an example personal profile.
+- `docs/scoring.md`: explain generic rubric plus optional personal profile refinement.
+- `data/config.example.json`: include a neutral `scoring` block that demonstrates the supported fields without encoding the personal cognitive-first profile as the project default.
+
+## Tests
+
+Add focused tests without live AI calls:
+
+- Model validation accepts configs with and without `scoring`.
+- Analyzer prompt builder returns the original prompt when scoring config is absent.
+- Analyzer prompt builder includes primary, secondary, boost, downrank, and notes when provided.
+- Analyzer still parses normal AI JSON output into `ai_score`, `ai_reason`, `ai_summary`, and `ai_tags`.
+- MCP scoring path passes scoring config into `ContentAnalyzer` if the implementation uses explicit injection.
+
+## Risks
+
+- Overly long scoring profiles can bloat prompts. Keep rendering concise and preserve truncation of item content.
+- Personal preferences may make scores less comparable across users. This is acceptable for local Horizon runs, but global Hub telemetry should treat profiles as context if aggregated later.
+- If the model treats personal preferences as absolute rules, it may over-score niche content. The prompt should state that preferences refine, not replace, the generic quality rubric.
+
+## Implementation Decisions
+
+- Keep `data/config.example.json` neutral. Put the cognitive-first personal profile example in docs, not as the repository default.
+- Do not update the setup wizard in this iteration. The wizard can support scoring preferences later after the config path is stable.

--- a/src/ai/analyzer.py
+++ b/src/ai/analyzer.py
@@ -10,7 +10,7 @@ from rich.progress import Progress, SpinnerColumn, BarColumn, TextColumn, MofNCo
 from .client import AIClient
 from .prompts import CONTENT_ANALYSIS_SYSTEM, CONTENT_ANALYSIS_USER
 from .utils import parse_json_response
-from ..models import ContentItem
+from ..models import ContentItem, ScoringConfig
 
 DEFAULT_THROTTLE_SEC = 0.0
 
@@ -18,8 +18,41 @@ DEFAULT_THROTTLE_SEC = 0.0
 class ContentAnalyzer:
     """Analyzes content items using AI to determine importance."""
 
-    def __init__(self, ai_client: AIClient):
+    def __init__(self, ai_client: AIClient, scoring_config: ScoringConfig | None = None):
         self.client = ai_client
+        self.scoring_config = scoring_config
+
+    @staticmethod
+    def _format_list_section(title: str, values: List[str]) -> str:
+        cleaned = [value.strip() for value in values if value and value.strip()]
+        if not cleaned:
+            return ""
+        lines = "\n".join(f"- {value}" for value in cleaned)
+        return f"{title}:\n{lines}"
+
+    def _build_system_prompt(self) -> str:
+        """Return the analysis prompt, optionally refined by user scoring preferences."""
+        scoring = self.scoring_config
+        if not scoring:
+            return CONTENT_ANALYSIS_SYSTEM
+
+        sections = [
+            f"Personal scoring profile: {scoring.profile_name}",
+            "Use this profile to refine, not replace, the generic rubric above.",
+            "Primary high-score signals should be treated as the strongest reasons to score content 8-10.",
+            self._format_list_section("Primary high-score signals", scoring.primary),
+            "Secondary high-score signals can raise a good item when quality and relevance are also strong.",
+            self._format_list_section("Secondary high-score signals", scoring.secondary),
+            self._format_list_section("Boost when content matches", scoring.boost),
+            self._format_list_section("Downrank when content is", scoring.downrank),
+        ]
+        if scoring.notes and scoring.notes.strip():
+            sections.append(f"Additional preference notes: {scoring.notes.strip()}")
+        sections.append(
+            "When these preferences affect the score, mention the matched cognitive or practical signal in the JSON reason field."
+        )
+        profile_text = "\n\n".join(section for section in sections if section)
+        return f"{CONTENT_ANALYSIS_SYSTEM.rstrip()}\n\n{profile_text}\n"
 
     @staticmethod
     def _parse_json_response(response: str) -> Optional[dict]:
@@ -141,7 +174,7 @@ class ContentAnalyzer:
 
         # Get AI completion
         response = await self.client.complete(
-            system=CONTENT_ANALYSIS_SYSTEM,
+            system=self._build_system_prompt(),
             user=user_prompt,
         )
 

--- a/src/ai/analyzer.py
+++ b/src/ai/analyzer.py
@@ -30,10 +30,17 @@ class ContentAnalyzer:
         lines = "\n".join(f"- {value}" for value in cleaned)
         return f"{title}:\n{lines}"
 
+    @staticmethod
+    def _has_effective_scoring_preferences(scoring: ScoringConfig) -> bool:
+        list_fields = (scoring.primary, scoring.secondary, scoring.boost, scoring.downrank)
+        return any(value and value.strip() for values in list_fields for value in values) or bool(
+            scoring.notes and scoring.notes.strip()
+        )
+
     def _build_system_prompt(self) -> str:
         """Return the analysis prompt, optionally refined by user scoring preferences."""
         scoring = self.scoring_config
-        if not scoring:
+        if not scoring or not self._has_effective_scoring_preferences(scoring):
             return CONTENT_ANALYSIS_SYSTEM
 
         sections = [

--- a/src/mcp/service.py
+++ b/src/mcp/service.py
@@ -280,7 +280,10 @@ class HorizonPipelineService:
             raise HorizonMcpError(code="HZ_EMPTY_INPUT", message="No items available for scoring.")
 
         ai_client = ctx.runtime.create_ai_client(ctx.config.ai)
-        analyzer = ctx.runtime.ContentAnalyzer(ai_client)
+        analyzer = ctx.runtime.ContentAnalyzer(
+            ai_client,
+            scoring_config=getattr(ctx.config, "scoring", None),
+        )
         scored_items = await analyzer.analyze_batch(items)
 
         self.run_store.save_items(run_id, "scored", items_to_dicts(scored_items))

--- a/src/models.py
+++ b/src/models.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Optional, List, Dict, Any, Union
+from typing import Optional, List, Dict, Any, Union, ClassVar
 from pydantic import BaseModel, HttpUrl, Field, field_validator
 
 
@@ -319,12 +319,58 @@ class FilteringConfig(BaseModel):
 class ScoringConfig(BaseModel):
     """Optional user preferences that refine AI content scoring."""
 
+    MAX_PROFILE_NAME_LENGTH: ClassVar[int] = 80
+    MAX_LIST_ITEMS: ClassVar[int] = 12
+    MAX_LIST_ITEM_LENGTH: ClassVar[int] = 160
+    MAX_NOTES_LENGTH: ClassVar[int] = 600
+
     profile_name: str = "default"
     primary: List[str] = Field(default_factory=list)
     secondary: List[str] = Field(default_factory=list)
     boost: List[str] = Field(default_factory=list)
     downrank: List[str] = Field(default_factory=list)
     notes: Optional[str] = None
+
+    @field_validator("profile_name")
+    @classmethod
+    def validate_profile_name(cls, v: str) -> str:
+        value = v.strip()
+        if not value:
+            return "default"
+        if len(value) > cls.MAX_PROFILE_NAME_LENGTH:
+            raise ValueError(
+                f"scoring.profile_name must be at most {cls.MAX_PROFILE_NAME_LENGTH} characters"
+            )
+        return value
+
+    @field_validator("primary", "secondary", "boost", "downrank")
+    @classmethod
+    def validate_preference_list(cls, v: List[str]) -> List[str]:
+        cleaned = [item.strip() for item in v if item and item.strip()]
+        if len(cleaned) > cls.MAX_LIST_ITEMS:
+            raise ValueError(
+                f"scoring preference lists must contain at most {cls.MAX_LIST_ITEMS} non-empty items"
+            )
+        for item in cleaned:
+            if len(item) > cls.MAX_LIST_ITEM_LENGTH:
+                raise ValueError(
+                    f"scoring preference items must be at most {cls.MAX_LIST_ITEM_LENGTH} characters"
+                )
+        return cleaned
+
+    @field_validator("notes")
+    @classmethod
+    def validate_notes(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return None
+        value = v.strip()
+        if not value:
+            return None
+        if len(value) > cls.MAX_NOTES_LENGTH:
+            raise ValueError(
+                f"scoring.notes must be at most {cls.MAX_NOTES_LENGTH} characters"
+            )
+        return value
 
 
 class Config(BaseModel):

--- a/src/models.py
+++ b/src/models.py
@@ -316,6 +316,17 @@ class FilteringConfig(BaseModel):
     time_window_hours: int = 24
 
 
+class ScoringConfig(BaseModel):
+    """Optional user preferences that refine AI content scoring."""
+
+    profile_name: str = "default"
+    primary: List[str] = Field(default_factory=list)
+    secondary: List[str] = Field(default_factory=list)
+    boost: List[str] = Field(default_factory=list)
+    downrank: List[str] = Field(default_factory=list)
+    notes: Optional[str] = None
+
+
 class Config(BaseModel):
     """Main configuration model."""
 
@@ -323,5 +334,6 @@ class Config(BaseModel):
     ai: AIConfig
     sources: SourcesConfig
     filtering: FilteringConfig
+    scoring: Optional[ScoringConfig] = None
     email: Optional[EmailConfig] = None
     webhook: Optional[WebhookConfig] = None

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -511,7 +511,7 @@ class HorizonOrchestrator:
             f"   Re-analyzing {len(expanded)} Twitter items with reply context...\n"
         )
         ai_client = create_ai_client(self.config.ai)
-        analyzer = ContentAnalyzer(ai_client)
+        analyzer = ContentAnalyzer(ai_client, scoring_config=self.config.scoring)
         await analyzer.analyze_batch(expanded)
 
     async def _enrich_important_items(self, items: List[ContentItem]) -> None:
@@ -544,7 +544,7 @@ class HorizonOrchestrator:
         self.console.print("🤖 Analyzing content with AI...")
 
         ai_client = create_ai_client(self.config.ai)
-        analyzer = ContentAnalyzer(ai_client)
+        analyzer = ContentAnalyzer(ai_client, scoring_config=self.config.scoring)
 
         return await analyzer.analyze_batch(items)
 

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -4,7 +4,8 @@ from types import SimpleNamespace
 
 import src.ai.analyzer as analyzer_module
 from src.ai.analyzer import ContentAnalyzer
-from src.models import ContentItem, SourceType
+from src.ai.prompts import CONTENT_ANALYSIS_SYSTEM
+from src.models import ContentItem, ScoringConfig, SourceType
 
 
 def _make_item(item_id: str) -> ContentItem:
@@ -94,3 +95,36 @@ def test_analyze_batch_concurrent_preserves_order(monkeypatch):
     result = asyncio.run(analyzer.analyze_batch(items))
 
     assert [item.id for item in result] == [item.id for item in items]
+
+
+def test_build_system_prompt_without_scoring_uses_base_prompt():
+    analyzer = ContentAnalyzer(SimpleNamespace())
+
+    assert analyzer._build_system_prompt() == CONTENT_ANALYSIS_SYSTEM
+
+
+def test_build_system_prompt_includes_personal_scoring_profile():
+    scoring = ScoringConfig(
+        profile_name="personal",
+        primary=["cognitive value", "paradigm shifts"],
+        secondary=["engineering usefulness"],
+        boost=["durable mental models"],
+        downrank=["generic AI hype"],
+        notes="Prefer cognitive value first.",
+    )
+    analyzer = ContentAnalyzer(SimpleNamespace(), scoring_config=scoring)
+
+    prompt = analyzer._build_system_prompt()
+
+    assert CONTENT_ANALYSIS_SYSTEM in prompt
+    assert "Personal scoring profile: personal" in prompt
+    assert "Primary high-score signals" in prompt
+    assert "- cognitive value" in prompt
+    assert "- paradigm shifts" in prompt
+    assert "Secondary high-score signals" in prompt
+    assert "- engineering usefulness" in prompt
+    assert "Boost when content matches" in prompt
+    assert "- durable mental models" in prompt
+    assert "Downrank when content is" in prompt
+    assert "- generic AI hype" in prompt
+    assert "Prefer cognitive value first." in prompt

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -103,6 +103,13 @@ def test_build_system_prompt_without_scoring_uses_base_prompt():
     assert analyzer._build_system_prompt() == CONTENT_ANALYSIS_SYSTEM
 
 
+def test_build_system_prompt_with_empty_scoring_profile_uses_base_prompt():
+    scoring = ScoringConfig(profile_name="default")
+    analyzer = ContentAnalyzer(SimpleNamespace(), scoring_config=scoring)
+
+    assert analyzer._build_system_prompt() == CONTENT_ANALYSIS_SYSTEM
+
+
 def test_build_system_prompt_includes_personal_scoring_profile():
     scoring = ScoringConfig(
         profile_name="personal",

--- a/tests/test_mcp_service_smoke.py
+++ b/tests/test_mcp_service_smoke.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 
 from src.models import ContentItem, SourceType
 from src.mcp.server import hz_get_metrics
-from src.mcp.service import HorizonPipelineService
+from src.mcp.service import HorizonPipelineService, PipelineContext
 
 
 def make_item(item_id: str, score: float | None = None) -> ContentItem:
@@ -142,3 +142,49 @@ def test_filter_items_uses_public_topic_dedup_api(tmp_path: Path, monkeypatch) -
     assert result["kept"] == 1
     assert result["removed_by_topic_dedup"] == 1
     assert service.run_store.load_items("run-topic-dedup", "filtered")[0]["id"] == "item-1"
+
+
+def test_score_items_passes_scoring_config_to_analyzer(tmp_path, monkeypatch):
+    captured = {}
+
+    class FakeAnalyzer:
+        def __init__(self, ai_client, scoring_config=None):
+            captured["ai_client"] = ai_client
+            captured["scoring_config"] = scoring_config
+
+        async def analyze_batch(self, items):
+            for item in items:
+                item.ai_score = 8.0
+            return items
+
+    scoring = SimpleNamespace(profile_name="personal")
+    config = SimpleNamespace(
+        ai=SimpleNamespace(),
+        scoring=scoring,
+        filtering=SimpleNamespace(ai_score_threshold=7.0),
+    )
+    runtime = SimpleNamespace(
+        create_ai_client=lambda ai: "client",
+        ContentAnalyzer=FakeAnalyzer,
+    )
+
+    service = HorizonPipelineService(runs_root=tmp_path / "runs")
+    run_id = service.run_store.create_run("test-run")
+    service.run_store.save_items(run_id, "raw", [make_item("item-1").model_dump(mode="json")])
+
+    monkeypatch.setattr(
+        service,
+        "_load_stage_items",
+        lambda **kwargs: ([make_item("item-1")], PipelineContext(
+            horizon_path=tmp_path,
+            config_path=tmp_path / "config.json",
+            runtime=runtime,
+            config=config,
+        )),
+    )
+
+    result = asyncio.run(service.score_items(run_id=run_id))
+
+    assert result["scored"] == 1
+    assert captured["ai_client"] == "client"
+    assert captured["scoring_config"] is scoring

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -126,3 +126,36 @@ def test_load_config_expands_env_vars_in_ai_base_url(tmp_path, monkeypatch):
     storage = StorageManager(data_dir=str(tmp_path))
     config = storage.load_config()
     assert config.ai.base_url == "https://private-proxy.example/v1"
+
+
+def test_load_config_accepts_scoring_profile(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({
+        "version": "1.0",
+        "ai": {
+            "provider": "openai",
+            "model": "gpt-4o",
+            "api_key_env": "OPENAI_API_KEY",
+        },
+        "sources": {"hackernews": {"enabled": True}},
+        "filtering": {"ai_score_threshold": 7.0, "time_window_hours": 24},
+        "scoring": {
+            "profile_name": "personal",
+            "primary": ["cognitive value", "paradigm shifts"],
+            "secondary": ["engineering usefulness"],
+            "boost": ["durable mental models"],
+            "downrank": ["generic AI hype"],
+            "notes": "Prefer cognitive value first.",
+        },
+    }), encoding="utf-8")
+
+    storage = StorageManager(data_dir=str(tmp_path))
+    config = storage.load_config()
+
+    assert config.scoring is not None
+    assert config.scoring.profile_name == "personal"
+    assert config.scoring.primary == ["cognitive value", "paradigm shifts"]
+    assert config.scoring.secondary == ["engineering usefulness"]
+    assert config.scoring.boost == ["durable mental models"]
+    assert config.scoring.downrank == ["generic AI hype"]
+    assert config.scoring.notes == "Prefer cognitive value first."

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,7 +1,9 @@
 import json
 import pytest
 from pathlib import Path
+from pydantic import ValidationError
 from src.storage.manager import StorageManager, ConfigError, _expand_env_vars
+from src.models import ScoringConfig
 
 def test_load_config_missing_file(tmp_path):
     storage = StorageManager(data_dir=str(tmp_path))
@@ -159,3 +161,26 @@ def test_load_config_accepts_scoring_profile(tmp_path):
     assert config.scoring.boost == ["durable mental models"]
     assert config.scoring.downrank == ["generic AI hype"]
     assert config.scoring.notes == "Prefer cognitive value first."
+
+
+def test_scoring_profile_trims_blank_preferences():
+    scoring = ScoringConfig(
+        profile_name="  personal  ",
+        primary=[" cognitive value ", "", "   "],
+        notes="   ",
+    )
+
+    assert scoring.profile_name == "personal"
+    assert scoring.primary == ["cognitive value"]
+    assert scoring.notes is None
+
+
+def test_scoring_profile_rejects_unbounded_prompt_content():
+    with pytest.raises(ValidationError, match="at most 12"):
+        ScoringConfig(primary=[f"signal {i}" for i in range(13)])
+
+    with pytest.raises(ValidationError, match="at most 160"):
+        ScoringConfig(boost=["x" * 161])
+
+    with pytest.raises(ValidationError, match="at most 600"):
+        ScoringConfig(notes="x" * 601)


### PR DESCRIPTION
## Summary
- Add optional top-level `scoring` config for personal AI scoring preferences.
- Inject non-empty preferences into the analyzer prompt while keeping absent or empty scoring config behavior unchanged.
- Wire scoring config through orchestrator and MCP scoring paths, with docs and neutral example config.
- Bound scoring profile size to avoid unbounded prompt growth.

## Test Plan
- [x] `uv run pytest tests/test_storage.py tests/test_analyzer.py -q`
- [x] `uv run pytest -q`
- [x] Example config load check confirms neutral scoring keeps the base prompt unchanged.

AI: Codex
