### PR TITLE
feat(ai): add ChainedAIClient for automatic provider fallback

### DIFF
--- a/src/ai/client.py
+++ b/src/ai/client.py
@@ -3,7 +3,7 @@
 import os
 import re
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Any, Dict, List, Optional
 from openai import AsyncAzureOpenAI, AsyncOpenAI
 from anthropic import AsyncAnthropic
 from google import genai
@@ -11,6 +11,7 @@ from google.genai import types
 
 
 from ..models import AIConfig, AIProvider
+from rich import print as rich_print
 from .tokens import record_usage
 
 
@@ -481,18 +482,8 @@ class GeminiClient(AIClient):
         return response.text
 
 
-def create_ai_client(config: AIConfig) -> AIClient:
-    """Factory function to create appropriate AI client.
-
-    Args:
-        config: AI configuration
-
-    Returns:
-        AIClient: Initialized AI client
-
-    Raises:
-        ValueError: If provider is not supported
-    """
+def _create_single_client(config: AIConfig) -> AIClient:
+    """Create a single AI client instance."""
     if config.provider == AIProvider.ANTHROPIC:
         return AnthropicClient(config)
     elif config.provider == AIProvider.AZURE:
@@ -510,3 +501,121 @@ def create_ai_client(config: AIConfig) -> AIClient:
         return OpenAIClient(config)
     else:
         raise ValueError(f"Unsupported AI provider: {config.provider}")
+
+
+class ChainedAIClient(AIClient):
+    """Chain multiple AI clients with automatic fallback.
+
+    When a provider fails with a retryable error (rate limit, auth/quota,
+    service unavailable, or empty response), automatically falls back to
+    the next provider in the chain.
+
+    Clients are created lazily so that missing API keys for downstream
+    providers do not block startup when the primary provider works.
+    """
+
+    def __init__(
+        self,
+        configs: List[AIConfig],
+        clients: Optional[List[AIClient]] = None,
+        client_factory: Optional[Any] = None,
+    ):
+        self.configs = configs
+        self._client_factory = client_factory or _create_single_client
+        self._client_cache: Dict[int, AIClient] = {}
+        # Allow tests to inject pre-built clients directly
+        if clients is not None:
+            for idx, client in enumerate(clients):
+                self._client_cache[idx] = client
+
+    def _get_client(self, index: int) -> AIClient:
+        if index not in self._client_cache:
+            self._client_cache[index] = self._client_factory(self.configs[index])
+        return self._client_cache[index]
+
+    async def complete(
+        self,
+        system: str,
+        user: str,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+    ) -> str:
+        last_error: Optional[Exception] = None
+        for i in range(len(self.configs)):
+            try:
+                client = self._get_client(i)
+                result = await client.complete(system, user, temperature, max_tokens)
+                if not result or not result.strip():
+                    raise ValueError("Empty response from provider")
+                return result
+            except Exception as exc:
+                if not self._should_fallback(exc):
+                    raise
+                last_error = exc
+                if i < len(self.configs) - 1:
+                    rich_print(
+                        f"\n[yellow]Provider {self.configs[i].provider.value} failed ({exc}), "
+                        f"falling back to {self.configs[i + 1].provider.value}...[/yellow]"
+                    )
+        raise RuntimeError(f"All providers failed. Last error: {last_error}")
+
+    @staticmethod
+    def _should_fallback(exc: Exception) -> bool:
+        """Determine if an error warrants fallback to the next provider."""
+        msg = str(exc).lower()
+        if "429" in msg or "rate limit" in msg:
+            return True
+        if "401" in msg or "403" in msg or "quota" in msg or "exceeded" in msg:
+            return True
+        if "502" in msg or "503" in msg or "service unavailable" in msg:
+            return True
+        if "empty response" in msg:
+            return True
+        return False
+
+
+def _create_chained_client(config: AIConfig) -> ChainedAIClient:
+    """Build a ChainedAIClient from a comma-separated provider chain."""
+    from ..models import AI_PROVIDER_DEFAULTS
+
+    provider_names = [p.strip() for p in config.provider_chain.split(",") if p.strip()]
+    if not provider_names:
+        raise ValueError("provider_chain is empty")
+
+    chain_configs: List[AIConfig] = []
+    for name in provider_names:
+        try:
+            provider = AIProvider(name)
+        except ValueError:
+            raise ValueError(f"Unsupported AI provider in chain: {name}")
+
+        defaults = AI_PROVIDER_DEFAULTS.get(provider, {})
+        cfg = AIConfig(
+            provider=provider,
+            model=defaults.get("model", config.model),
+            api_key_env=defaults.get("api_key_env", config.api_key_env),
+            base_url=config.base_url,
+            temperature=config.temperature,
+            max_tokens=config.max_tokens,
+            languages=config.languages,
+        )
+        chain_configs.append(cfg)
+
+    return ChainedAIClient(chain_configs)
+
+
+def create_ai_client(config: AIConfig) -> AIClient:
+    """Factory function to create appropriate AI client.
+
+    Args:
+        config: AI configuration
+
+    Returns:
+        AIClient: Initialized AI client
+
+    Raises:
+        ValueError: If provider is not supported
+    """
+    if config.provider_chain:
+        return _create_chained_client(config)
+    return _create_single_client(config)

--- a/src/models.py
+++ b/src/models.py
@@ -53,10 +53,52 @@ class AIProvider(str, Enum):
     OLLAMA = "ollama"
 
 
+# Default models and API key env vars for each provider
+AI_PROVIDER_DEFAULTS = {
+    AIProvider.ANTHROPIC: {
+        "model": "claude-3-5-sonnet-20241022",
+        "api_key_env": "ANTHROPIC_API_KEY",
+    },
+    AIProvider.OPENAI: {
+        "model": "gpt-4",
+        "api_key_env": "OPENAI_API_KEY",
+    },
+    AIProvider.AZURE: {
+        "model": "gpt-4",
+        "api_key_env": "AZURE_OPENAI_API_KEY",
+    },
+    AIProvider.ALI: {
+        "model": "qwen-plus",
+        "api_key_env": "DASHSCOPE_API_KEY",
+    },
+    AIProvider.GEMINI: {
+        "model": "gemini-1.5-flash",
+        "api_key_env": "GOOGLE_API_KEY",
+    },
+    AIProvider.DOUBAO: {
+        "model": "doubao-pro-32k",
+        "api_key_env": "DOUBAO_API_KEY",
+    },
+    AIProvider.MINIMAX: {
+        "model": "MiniMax-Text-01",
+        "api_key_env": "MINIMAX_API_KEY",
+    },
+    AIProvider.DEEPSEEK: {
+        "model": "deepseek-chat",
+        "api_key_env": "DEEPSEEK_API_KEY",
+    },
+    AIProvider.OLLAMA: {
+        "model": "llama3.1",
+        "api_key_env": "",
+    },
+}
+
+
 class AIConfig(BaseModel):
     """AI client configuration."""
 
     provider: AIProvider
+    provider_chain: Optional[str] = None
     model: str
     base_url: Optional[str] = None
     api_key_env: str

--- a/tests/test_chained_client.py
+++ b/tests/test_chained_client.py
@@ -1,0 +1,187 @@
+"""Tests for ChainedAIClient fallback logic."""
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+
+from src.ai.client import ChainedAIClient, _create_chained_client
+from src.models import AIConfig, AIProvider, ContentItem, SourceType
+
+
+class _DummyClient:
+    """Mock AI client for testing."""
+
+    def __init__(self, result=None, exc=None):
+        self.result = result
+        self.exc = exc
+        self.calls = []
+
+    async def complete(self, system, user, temperature=None, max_tokens=None):
+        self.calls.append((system, user, temperature, max_tokens))
+        if self.exc:
+            raise self.exc
+        return self.result
+
+
+class _MockFactory:
+    """Factory that returns pre-built dummy clients in order."""
+
+    def __init__(self, *clients):
+        self.clients = list(clients)
+        self.calls = []
+        self.idx = 0
+
+    def __call__(self, cfg):
+        self.calls.append(cfg)
+        client = self.clients[self.idx]
+        self.idx += 1
+        return client
+
+
+def _make_config(provider: AIProvider, model: str = "m", api_key_env: str = "K") -> AIConfig:
+    return AIConfig(
+        provider=provider,
+        model=model,
+        api_key_env=api_key_env,
+    )
+
+
+def test_success_on_first_provider():
+    """When first provider succeeds, no fallback occurs."""
+    cfg1 = _make_config(AIProvider.OPENAI)
+    cfg2 = _make_config(AIProvider.OLLAMA)
+    client1 = _DummyClient(result="ok")
+    client2 = _DummyClient(result="also ok")
+
+    chained = ChainedAIClient([cfg1, cfg2], clients=[client1, client2])
+    result = asyncio.run(chained.complete("sys", "usr"))
+
+    assert result == "ok"
+    assert len(client1.calls) == 1
+    assert len(client2.calls) == 0
+
+
+def test_fallback_on_empty_response():
+    """When first provider returns empty/whitespace, fallback to second."""
+    cfg1 = _make_config(AIProvider.OPENAI)
+    cfg2 = _make_config(AIProvider.OLLAMA)
+    client1 = _DummyClient(result="   ")
+    client2 = _DummyClient(result="fallback ok")
+
+    chained = ChainedAIClient([cfg1, cfg2], clients=[client1, client2])
+    result = asyncio.run(chained.complete("sys", "usr"))
+
+    assert result == "fallback ok"
+    assert len(client1.calls) == 1
+    assert len(client2.calls) == 1
+
+
+def test_fallback_on_rate_limit():
+    """When first provider hits 429, fallback to second."""
+    cfg1 = _make_config(AIProvider.OPENAI)
+    cfg2 = _make_config(AIProvider.OLLAMA)
+    client1 = _DummyClient(exc=Exception("429 rate limit exceeded"))
+    client2 = _DummyClient(result="fallback ok")
+
+    chained = ChainedAIClient([cfg1, cfg2], clients=[client1, client2])
+    result = asyncio.run(chained.complete("sys", "usr"))
+
+    assert result == "fallback ok"
+    assert len(client1.calls) == 1
+    assert len(client2.calls) == 1
+
+
+def test_fallback_on_quota_exceeded():
+    """When first provider quota exhausted, fallback to second."""
+    cfg1 = _make_config(AIProvider.OPENAI)
+    cfg2 = _make_config(AIProvider.GEMINI)
+    client1 = _DummyClient(exc=Exception("403 quota exceeded"))
+    client2 = _DummyClient(result="fallback ok")
+
+    chained = ChainedAIClient([cfg1, cfg2], clients=[client1, client2])
+    result = asyncio.run(chained.complete("sys", "usr"))
+
+    assert result == "fallback ok"
+
+
+def test_all_providers_fail():
+    """When all providers fail, raise RuntimeError."""
+    cfg1 = _make_config(AIProvider.OPENAI)
+    cfg2 = _make_config(AIProvider.OLLAMA)
+    client1 = _DummyClient(exc=Exception("429 rate limit"))
+    client2 = _DummyClient(exc=Exception("503 service unavailable"))
+
+    chained = ChainedAIClient([cfg1, cfg2], clients=[client1, client2])
+    with pytest.raises(RuntimeError, match="All providers failed"):
+        asyncio.run(chained.complete("sys", "usr"))
+
+
+def test_no_fallback_on_unexpected_error():
+    """Non-retryable errors should not trigger fallback."""
+    cfg1 = _make_config(AIProvider.OPENAI)
+    cfg2 = _make_config(AIProvider.OLLAMA)
+    client1 = _DummyClient(exc=ValueError("Invalid JSON schema"))
+    client2 = _DummyClient(result="fallback ok")
+
+    chained = ChainedAIClient([cfg1, cfg2], clients=[client1, client2])
+    with pytest.raises(ValueError, match="Invalid JSON schema"):
+        asyncio.run(chained.complete("sys", "usr"))
+
+    assert len(client2.calls) == 0
+
+
+def test_should_fallback_detects_retryable_errors():
+    """_should_fallback correctly identifies retryable errors."""
+    assert ChainedAIClient._should_fallback(Exception("429 rate limit")) is True
+    assert ChainedAIClient._should_fallback(Exception("401 unauthorized")) is True
+    assert ChainedAIClient._should_fallback(Exception("403 forbidden")) is True
+    assert ChainedAIClient._should_fallback(Exception("quota exceeded")) is True
+    assert ChainedAIClient._should_fallback(Exception("502 bad gateway")) is True
+    assert ChainedAIClient._should_fallback(Exception("503 service unavailable")) is True
+    assert ChainedAIClient._should_fallback(Exception("Empty response from provider")) is True
+    assert ChainedAIClient._should_fallback(Exception("some random error")) is False
+
+
+def test_lazy_initialization():
+    """Downstream clients are not instantiated when the first provider succeeds."""
+    cfg1 = _make_config(AIProvider.OPENAI)
+    cfg2 = _make_config(AIProvider.OLLAMA)
+    client1 = _DummyClient(result="ok")
+    client2 = _DummyClient(result="also ok")
+
+    factory = _MockFactory(client1, client2)
+    chained = ChainedAIClient([cfg1, cfg2], client_factory=factory)
+    result = asyncio.run(chained.complete("sys", "usr"))
+
+    assert result == "ok"
+    assert len(factory.calls) == 1
+    assert factory.calls[0].provider == AIProvider.OPENAI
+
+
+def test_create_chained_client_parses_chain():
+    """_create_chained_client correctly parses provider chain string."""
+    config = AIConfig(
+        provider=AIProvider.OPENAI,
+        model="m1",
+        api_key_env="K1",
+        provider_chain="openai,ollama",
+    )
+    chained = _create_chained_client(config)
+    assert len(chained.configs) == 2
+    assert chained.configs[0].provider == AIProvider.OPENAI
+    assert chained.configs[1].provider == AIProvider.OLLAMA
+    assert chained.configs[1].model == "llama3.1"
+    assert chained.configs[1].api_key_env == ""
+
+
+def test_create_chained_client_rejects_unknown_provider():
+    """_create_chained_client rejects unknown providers in chain."""
+    config = AIConfig(
+        provider=AIProvider.OPENAI,
+        model="m1",
+        api_key_env="K1",
+        provider_chain="openai,unknownprovider",
+    )
+    with pytest.raises(ValueError, match="Unsupported AI provider in chain"):
+        _create_chained_client(config)


### PR DESCRIPTION
## Summary

Add `ChainedAIClient` that automatically falls back to the next provider in the chain when the current one fails with a retryable error.

## Motivation

Currently, Horizon uses a single AI provider. If that provider hits a rate limit, returns 401/403, or is temporarily unavailable, the entire run fails. This is painful for CI/automated runs.

## How it works

Configure `ai.provider_chain` as a comma-separated list:

```json
{
  "ai": {
    "provider": "deepseek",
    "provider_chain": "deepseek,openai,ollama",
    "model": "deepseek-chat",
    "api_key_env": "DEEPSEEK_API_KEY"
  }
}
```

When deepseek fails, it automatically tries openai, then ollama.

Features

- Lazy initialization: downstream clients are only created when needed, so missing API keys for backup providers don't block startup
- Retryable error detection: 429 rate limit, 401/403 auth/quota, 502/503esponse
- Per-provider defaults: each provider in the chain uses AI_PROVIDER_DEFAULTS for its model and api_key_env
- Perfect companion to Ollama: use local models as a free, always-availa

Tests

10 unit tests covering:
- success on first provider (no fallback)
- fallback on empty response
- fallback on rate limit / quota / service unavailable
- all providers fail (raises RuntimeError)
- non-retryable errors don't trigger fallback
- lazy initialization
- provider chain parsing
- unknown provider rejection

Checklist

- [x] Tests added (tests/test_chained_client.py)
- [x] No breaking changes to existing API
- [x] Works with all existing providers (Anthropic, OpenAI, Azure, Gemini, Ollama, etc.)
