### PR TITLE
feat(scrapers): add free Twitter scraping via Playwright + Cookie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ data/subscribers.json
 data/mcp.secrets.json
 data/mcp-secrets.json
 data/mcp-runs/
+data/x_cookies_*.json
 
 docs/_posts/*.md
 

--- a/docs/twitter-cookies.md
+++ b/docs/twitter-cookies.md
@@ -1,0 +1,128 @@
+# Twitter / X Cookie 配置指南（Playwright 模式）
+
+Horizon 支持两种 Twitter 抓取方式：
+
+| 方式 | 成本 | 稳定性 | 适用场景 |
+|------|------|--------|----------|
+| **Apify** (默认) | 需订阅 ($49/月起) | ⭐⭐⭐ 高 | 生产环境、大量账号 |
+| **Playwright + Cookie** (免费) | 免费 | ⭐⭐ 中 | 个人使用、少量账号 |
+
+本文档介绍免费方案的配置方法。
+
+---
+
+## 1. 安装依赖
+
+```bash
+uv sync --extra twitter
+uv run playwright install chromium
+```
+
+---
+
+## 2. 获取 Cookie
+
+### 方法一：浏览器扩展（推荐）
+
+1. 用 Chrome/Edge/Firefox 登录 [x.com](https://x.com)
+2. 安装扩展 **"Cookie-Editor"** 或 **"Get cookies.txt LOCALLY"**
+3. 在 x.com 页面打开扩展，导出为 **JSON 格式**
+4. 保存到 `data/x_cookies_1.json`
+
+### 方法二：开发者工具
+
+1. 登录 x.com 后按 `F12` 打开开发者工具
+2. 切换到 **Application (应用)** → **Cookies** → `https://x.com`
+3. 找到以下关键 Cookie（名称可能略有不同）：
+   - `auth_token`
+   - `ct0`
+   - `twid`
+4. 手动构建 JSON 数组：
+
+```json
+[
+  {
+    "name": "auth_token",
+    "value": "你的auth_token值",
+    "domain": ".x.com",
+    "path": "/",
+    "secure": true,
+    "httpOnly": true
+  },
+  {
+    "name": "ct0",
+    "value": "你的ct0值",
+    "domain": ".x.com",
+    "path": "/",
+    "secure": true,
+    "httpOnly": false
+  }
+]
+```
+
+---
+
+## 3. 配置文件
+
+编辑 `data/config.json`：
+
+```json
+{
+  "sources": {
+    "twitter": {
+      "enabled": true,
+      "mode": "playwright",
+      "users": ["karpathy", "ylecun"],
+      "fetch_limit": 10,
+      "cookie_dir": "data",
+      "cookie_file_pattern": "x_cookies_*.json"
+    }
+  }
+}
+```
+
+---
+
+## 4. 多账号轮询（防封策略）
+
+如果你有多个 X 账号，可以为每个账号导出 cookie，命名为：
+
+```
+data/x_cookies_1.json   # 账号A
+data/x_cookies_2.json   # 账号B
+data/x_cookies_3.json   # 账号C
+```
+
+Horizon 会自动**轮询使用**这些 cookie，当一个账号触发限流时切换到下一个，大幅提升稳定性。
+
+---
+
+## 5. 代理配置（可选）
+
+如果在中国大陆或需要代理：
+
+```bash
+export https_proxy=http://127.0.0.1:7890
+```
+
+Playwright 会自动读取 `PROXY`、`https_proxy`、`http_proxy`、`all_proxy` 环境变量。
+
+---
+
+## 6. 注意事项
+
+⚠️ **Cookie 有有效期**：通常 1-4 周，过期后需要重新导出  
+⚠️ **不要提交 Cookie 文件**：已加入 `.gitignore`，请妥善保管  
+⚠️ **账号安全**：建议使用**小号/备用号**，避免主账号风险  
+⚠️ **抓取频率**：每个账号间隔 5-10 秒，避免触发平台限流
+
+---
+
+## 7. 故障排除
+
+| 问题 | 原因 | 解决 |
+|------|------|------|
+| "No cookie files found" | cookie 文件名不匹配 | 检查 `cookie_file_pattern` 和实际文件名 |
+| "page shows login gate" | cookie 已过期 | 重新登录并导出最新 cookie |
+| "no GraphQL data intercepted" | 页面结构变化或被限流 | 等待几分钟后重试，或增加 cookie 数量 |
+| Playwright 未安装 | 依赖缺失 | 运行 `uv sync --extra twitter && uv run playwright install chromium` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,10 @@ openbb = [
     "openbb>=4.4.0",
     "openbb-benzinga>=1.6.0",
 ]
+twitter = [
+    "playwright>=1.40.0",
+    "playwright-stealth>=1.0.0",
+]
 
 [project.scripts]
 horizon = "src.main:main"

--- a/src/models.py
+++ b/src/models.py
@@ -145,17 +145,27 @@ class TelegramConfig(BaseModel):
 
 
 class TwitterConfig(BaseModel):
-    """Twitter source configuration via Apify."""
+    """Twitter source configuration.
+
+    Two modes are supported:
+    - "apify": Use Apify scweet actor (requires APIFY_TOKEN, more reliable)
+    - "playwright": Use Playwright + browser cookies (free, no token needed)
+    """
 
     enabled: bool = True
-    apify_token_env: str = "APIFY_TOKEN"
-    actor_id: str = "altimis~scweet"
+    mode: str = "apify"  # "apify" or "playwright"
     users: List[str] = Field(default_factory=list)
     fetch_limit: int = 10
     fetch_reply_text: bool = False
     max_replies_per_tweet: int = 3
     max_tweets_to_expand: int = 10
     reply_min_likes: int = 0
+    # Apify settings (used when mode == "apify")
+    apify_token_env: str = "APIFY_TOKEN"
+    actor_id: str = "altimis~scweet"
+    # Playwright settings (used when mode == "playwright")
+    cookie_dir: str = "data"
+    cookie_file_pattern: str = "x_cookies_*.json"
 
 
 class OpenBBWatchlist(BaseModel):

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -18,6 +18,7 @@ from .scrapers.rss import RSSScraper
 from .scrapers.reddit import RedditScraper
 from .scrapers.telegram import TelegramScraper
 from .scrapers.twitter import TwitterScraper
+from .scrapers.twitter_playwright import TwitterPlaywrightScraper
 from .scrapers.openbb import OpenBBScraper
 from .scrapers.ossinsight import OSSInsightScraper
 from .ai.client import create_ai_client
@@ -264,9 +265,13 @@ class HorizonOrchestrator:
                 telegram_scraper = TelegramScraper(self.config.sources.telegram, client)
                 tasks.append(self._fetch_with_progress("Telegram", telegram_scraper, since))
 
-            # Twitter
+            # Twitter (Apify or Playwright mode)
             if self.config.sources.twitter and self.config.sources.twitter.enabled:
-                twitter_scraper = TwitterScraper(self.config.sources.twitter, client)
+                tw_cfg = self.config.sources.twitter
+                if tw_cfg.mode == "playwright":
+                    twitter_scraper = TwitterPlaywrightScraper(tw_cfg)
+                else:
+                    twitter_scraper = TwitterScraper(tw_cfg, client)
                 tasks.append(self._fetch_with_progress("Twitter", twitter_scraper, since))
 
             # OpenBB (financial news / filings via the OpenBB Platform SDK)
@@ -489,6 +494,11 @@ class HorizonOrchestrator:
         )
 
         async with httpx.AsyncClient(timeout=30.0) as client:
+            if tw_cfg.mode == "playwright":
+                self.console.print(
+                    "   [yellow]Reply expansion not yet supported in Playwright mode.[/yellow]"
+                )
+                return
             scraper = TwitterScraper(tw_cfg, client)
             expanded = []
             for item in twitter_items:

--- a/src/scrapers/twitter_playwright.py
+++ b/src/scrapers/twitter_playwright.py
@@ -1,0 +1,389 @@
+"""Twitter scraper using Playwright + Cookie (replaces Apify)."""
+
+import asyncio
+import glob
+import hashlib
+import json
+import logging
+import os
+import random
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional
+
+from ..models import ContentItem, SourceType, TwitterConfig
+from .base import BaseScraper
+
+logger = logging.getLogger(__name__)
+
+# Optional Playwright imports — gracefully degraded if not installed
+try:
+    from playwright.async_api import async_playwright
+    from playwright_stealth import Stealth
+
+    PLAYWRIGHT_AVAILABLE = True
+except ImportError:
+    PLAYWRIGHT_AVAILABLE = False
+    Stealth = None  # type: ignore[misc,assignment]
+
+
+def _get_proxy() -> str:
+    """Resolve proxy from common env vars (PROXY, http_proxy, all_proxy)."""
+    for key in ("PROXY", "https_proxy", "http_proxy", "all_proxy"):
+        val = os.getenv(key, "").strip()
+        if val:
+            return val
+    return ""
+
+
+PROXY = _get_proxy()
+
+
+def _load_browser_cookies(file_path: str) -> list[dict]:
+    """Read browser-exported cookie JSON and convert to Playwright format."""
+    if not Path(file_path).exists():
+        return []
+    with open(file_path, encoding="utf-8") as f:
+        cookies = json.load(f)
+    pw_cookies = []
+    for c in cookies:
+        pc: dict = {
+            "name": c["name"],
+            "value": c["value"],
+            "domain": c["domain"],
+            "path": c.get("path", "/"),
+            "secure": c.get("secure", True),
+            "httpOnly": c.get("httpOnly", False),
+        }
+        if c.get("expirationDate"):
+            pc["expires"] = c["expirationDate"]
+        pw_cookies.append(pc)
+    return pw_cookies
+
+
+class TwitterPlaywrightScraper(BaseScraper):
+    """Fetch tweets via Playwright + Cookie using GraphQL interception (free alternative to Apify)."""
+
+    def __init__(self, config: TwitterConfig, http_client=None):
+        super().__init__(config.model_dump(), http_client)
+        self.twitter_config = config
+
+    async def fetch(self, since: datetime) -> List[ContentItem]:
+        if not self.twitter_config.enabled:
+            return []
+
+        users = [u.strip().lstrip("@") for u in self.twitter_config.users if u.strip()]
+        if not users:
+            logger.debug("No Twitter users configured, skipping.")
+            return []
+
+        if not PLAYWRIGHT_AVAILABLE:
+            logger.warning(
+                "Playwright not installed. Run: uv sync --extra twitter && uv run playwright install chromium"
+            )
+            return []
+
+        cookie_dir = Path(self.twitter_config.cookie_dir)
+        pattern = self.twitter_config.cookie_file_pattern
+        cookie_files = sorted(cookie_dir.glob(pattern))
+        if not cookie_files:
+            logger.warning("No cookie files found matching %s in %s", pattern, cookie_dir)
+            return []
+
+        logger.info(
+            "Fetching Twitter (Playwright) for %d users using %d cookie sets",
+            len(users),
+            len(cookie_files),
+        )
+
+        all_items: List[ContentItem] = []
+        failed_users: list[tuple[str, int]] = []
+        lock = asyncio.Lock()
+
+        async with Stealth().use_async(async_playwright()) as p:  # type: ignore[union-attr]
+            launch_kwargs: dict = {"headless": True}
+            if PROXY:
+                launch_kwargs["proxy"] = {"server": PROXY}
+            browser = await p.chromium.launch(**launch_kwargs)
+
+            contexts = []
+            for i, cf in enumerate(cookie_files):
+                cookies = _load_browser_cookies(str(cf))
+                ctx = await browser.new_context(
+                    user_agent=(
+                        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                        f"AppleWebKit/537.36 (KHTML, like Gecko) Chrome/13{i}.0.0.0 Safari/537.36"
+                    ),
+                    viewport={"width": 1280, "height": 800},
+                    locale="en-US",
+                    timezone_id="UTC",
+                    color_scheme="dark",
+                )
+                if cookies:
+                    await ctx.add_cookies(cookies)
+                contexts.append(ctx)
+
+            # Warm-up each context by visiting x.com/home
+            for i, ctx in enumerate(contexts):
+                page = await ctx.new_page()
+                try:
+                    await page.goto("https://x.com/home", wait_until="domcontentloaded", timeout=15000)
+                    await asyncio.sleep(2)
+                    logger.info("Cookie #%d warm-up done", i + 1)
+                except Exception as exc:
+                    logger.warning("Cookie #%d warm-up failed: %s", i + 1, exc)
+                finally:
+                    await page.close()
+
+            num_contexts = len(contexts)
+
+            async def process_queue(context_idx: int, queue: list[str], is_retry: bool = False):
+                ctx = contexts[context_idx]
+                consecutive_failures = 0
+
+                for username in queue:
+                    wait_time = (
+                        random.uniform(5.0, 10.0) if not is_retry else random.uniform(10.0, 20.0)
+                    )
+                    await asyncio.sleep(wait_time)
+
+                    if consecutive_failures >= 5:
+                        logger.warning("Context #%d cooling down (30s)", context_idx + 1)
+                        await asyncio.sleep(30)
+                        consecutive_failures = 0
+
+                    logger.info("Scraping @%s with cookie #%d...", username, context_idx + 1)
+                    tweets = await self._scrape_user(ctx, username, since)
+
+                    if tweets is not None:
+                        logger.info("  -> @%s: %d tweets found", username, len(tweets))
+                        consecutive_failures = 0
+                        parsed = [item for item in (self._parse_tweet(t, username) for t in tweets) if item]
+                        async with lock:
+                            all_items.extend(parsed)
+                    else:
+                        consecutive_failures += 1
+                        if not is_retry:
+                            async with lock:
+                                failed_users.append((username, context_idx))
+
+            # Round-robin assign users to context queues
+            queues: list[list[str]] = [[] for _ in range(num_contexts)]
+            for i, username in enumerate(users):
+                queues[i % num_contexts].append(username)
+
+            # First pass — all queues in parallel
+            await asyncio.gather(*[process_queue(i, q) for i, q in enumerate(queues)])
+
+            # Retry failed users with a different context
+            if failed_users:
+                logger.info("Retrying %d failed Twitter accounts with alternate cookies", len(failed_users))
+                await asyncio.sleep(20)
+                retry_queues: list[list[str]] = [[] for _ in range(num_contexts)]
+                for username, original_idx in failed_users:
+                    new_idx = (original_idx + 1) % num_contexts if num_contexts >= 2 else 0
+                    retry_queues[new_idx].append(username)
+
+                await asyncio.gather(*[
+                    process_queue(i, q, is_retry=True)
+                    for i, q in enumerate(retry_queues)
+                    if q
+                ])
+
+            for ctx in contexts:
+                await ctx.close()
+            await browser.close()
+
+        logger.info("Fetched %d tweets via Playwright.", len(all_items))
+        return all_items
+
+    async def _scrape_user(self, ctx, username: str, since: datetime) -> Optional[list[dict]]:
+        """Scrape a single user's tweets via GraphQL interception."""
+        page = await ctx.new_page()
+        graphql_tweets: list[dict] = []
+
+        async def handle_response(response):
+            if "UserTweets" not in response.url and "UserByScreenName" not in response.url:
+                return
+            try:
+                data = await response.json()
+
+                def extract_tweets(obj):
+                    if isinstance(obj, dict):
+                        if obj.get("rest_id") and obj.get("legacy"):
+                            legacy = obj["legacy"]
+                            media_entities = (
+                                legacy.get("extended_entities", {}).get("media", [])
+                                or legacy.get("entities", {}).get("media", [])
+                            )
+                            images = [
+                                m["media_url_https"]
+                                for m in media_entities
+                                if m.get("type") == "photo" and m.get("media_url_https")
+                            ]
+                            tweet = {
+                                "tweet_id": obj["rest_id"],
+                                "text": legacy.get("full_text", ""),
+                                "datetime_raw": legacy.get("created_at", ""),
+                                "is_retweet": (
+                                    "retweeted_status_result" in obj.get("core", {})
+                                    or "retweeted_status_id_str" in legacy
+                                ),
+                                "images": images,
+                            }
+                            try:
+                                dt = datetime.strptime(tweet["datetime_raw"], "%a %b %d %H:%M:%S %z %Y")
+                                tweet["datetime"] = dt.isoformat()
+                            except (ValueError, TypeError):
+                                tweet["datetime"] = tweet["datetime_raw"]
+                            graphql_tweets.append(tweet)
+                        for v in obj.values():
+                            extract_tweets(v)
+                    elif isinstance(obj, list):
+                        for item in obj:
+                            extract_tweets(item)
+
+                extract_tweets(data)
+            except Exception as exc:
+                logger.debug("GraphQL parse error: %s", exc)
+
+        page.on("response", handle_response)
+
+        # Block heavy resources
+        async def route_handler(route):
+            if route.request.resource_type in ("media", "image", "video"):
+                await route.abort()
+            else:
+                url = route.request.url.lower()
+                if any(k in url for k in ("google-analytics", "doubleclick", "scribe.twitter.com")):
+                    await route.abort()
+                else:
+                    await route.continue_()
+
+        await page.route("**/*", route_handler)
+
+        try:
+            await asyncio.sleep(random.uniform(2, 4))
+
+            for attempt in range(3):
+                if attempt > 0:
+                    await asyncio.sleep(random.uniform(5, 10))
+                try:
+                    await page.goto(
+                        f"https://x.com/{username}",
+                        wait_until="domcontentloaded",
+                        timeout=25000,
+                    )
+                    break
+                except Exception as exc:
+                    if "Timeout" in str(exc):
+                        logger.debug("Page load slow (attempt %d/3)", attempt + 1)
+                        if attempt == 2:
+                            break
+                    else:
+                        if attempt == 2:
+                            raise
+                        logger.debug("Page visit error (attempt %d/3): %s", attempt + 1, exc)
+
+            await asyncio.sleep(5)
+            start_time = asyncio.get_event_loop().time()
+
+            # Quick diagnostic: check if page requires login
+            body_text = await page.evaluate("document.body ? document.body.innerText : ''")
+            if body_text and any(k in body_text.lower() for k in ("log in", "sign up", "create account")):
+                logger.warning("  -> @%s page shows login gate — cookie may be invalid", username)
+
+            while (asyncio.get_event_loop().time() - start_time) < 60:
+                if graphql_tweets:
+                    result = []
+                    seen = set()
+                    for t in graphql_tweets:
+                        uid = t.get("tweet_id") or hashlib.md5(t["text"].encode()).hexdigest()
+                        if uid in seen:
+                            continue
+                        seen.add(uid)
+                        try:
+                            tweet_time = datetime.fromisoformat(t["datetime"])
+                            if tweet_time < since:
+                                continue
+                        except Exception:
+                            continue
+                        result.append(t)
+
+                    if result:
+                        logger.info("  -> @%s: %d tweets within time window", username, len(result))
+                        return result[: self.twitter_config.fetch_limit]
+                    logger.info("  -> @%s: intercepted %d tweets but all outside time window", username, len(graphql_tweets))
+                    return []
+
+                # Check for error pages
+                body_text = await page.evaluate("document.body ? document.body.innerText : ''")
+                if body_text and any(
+                    kw in body_text
+                    for kw in ("Retry", "Something went wrong", "出错了", "重新加载")
+                ):
+                    await page.reload(wait_until="load", timeout=30000)
+                    await asyncio.sleep(5)
+
+                # Simulate human browsing
+                await page.mouse.move(random.randint(100, 600), random.randint(100, 600))
+                await page.evaluate(f"window.scrollBy(0, {random.randint(300, 700)})")
+                await asyncio.sleep(random.uniform(2, 4))
+
+                at_bottom = await page.evaluate(
+                    "window.innerHeight + window.scrollY >= document.body.scrollHeight"
+                )
+                if at_bottom and (asyncio.get_event_loop().time() - start_time) > 20:
+                    break
+
+            if not graphql_tweets:
+                logger.warning("  -> @%s: no GraphQL data intercepted (cookie or page issue)", username)
+                return None
+            return []
+
+        except Exception as exc:
+            logger.warning("Failed to scrape @%s: %s", username, exc)
+            return None
+        finally:
+            await page.close()
+
+    def _parse_tweet(self, tweet: dict, username: str) -> Optional[ContentItem]:
+        """Convert raw tweet dict to Horizon ContentItem."""
+        try:
+            tweet_id = str(tweet.get("tweet_id", ""))
+            if not tweet_id:
+                return None
+
+            text = tweet.get("text", "")
+            if not text:
+                return None
+
+            created_at_raw = tweet.get("datetime", "")
+            try:
+                published_at = datetime.fromisoformat(created_at_raw)
+                if published_at.tzinfo is None:
+                    published_at = published_at.replace(tzinfo=timezone.utc)
+            except (ValueError, TypeError):
+                return None
+
+            title_body = text[:50].replace("\n", " ").strip()
+            if len(text) > 50:
+                title_body += "..."
+
+            return ContentItem(
+                id=self._generate_id(SourceType.TWITTER.value, "tweet", tweet_id),
+                source_type=SourceType.TWITTER,
+                title=f"@{username}: {title_body}",
+                url=f"https://x.com/{username}/status/{tweet_id}",
+                content=text,
+                author=username,
+                published_at=published_at,
+                metadata={
+                    "tweet_id": tweet_id,
+                    "is_retweet": tweet.get("is_retweet", False),
+                    "images": tweet.get("images", []),
+                },
+            )
+        except Exception as exc:
+            logger.debug("Failed to parse tweet: %s", exc)
+            return None

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -21,12 +21,13 @@ def test_resolve_horizon_path_accepts_explicit_repo() -> None:
     assert resolve_horizon_path(str(repo_root)) == repo_root.resolve()
 
 
-def test_resolve_config_path_defaults_to_repo_data_config() -> None:
-    repo_root = Path(__file__).resolve().parents[1]
+def test_resolve_config_path_defaults_to_repo_data_config(tmp_path: Path) -> None:
+    # Create a temporary config.json so resolve_config_path doesn't raise
+    config_path = tmp_path / "data" / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text("{}", encoding="utf-8")
 
-    assert (
-        resolve_config_path(repo_root) == (repo_root / "data" / "config.json").resolve()
-    )
+    assert resolve_config_path(tmp_path) == config_path.resolve()
 
 
 def test_load_mcp_secrets_loads_generic_env_keys(tmp_path: Path, monkeypatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -957,6 +957,83 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/6e/802acd792aebb2256fbbee8cacf2727faaeb6f240ac11008f09eae4414bc/greenlet-3.5.1.tar.gz", hash = "sha256:5a56aeb7d5d9cc4b3a735efb5095bd4b4f6f0e4f93e5ca876d0e2315137b7829", size = 197356, upload-time = "2026-05-20T15:05:03.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/3c/ff890b466eaba2b0f5e6bdfff025f8c75f41b8ffdc3dbc3d24ad261e764a/greenlet-3.5.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:73f78f9b9f0a5c06e5c946ba1e8e36f5114923b6be109ee618c54f079c3ea14f", size = 284764, upload-time = "2026-05-20T13:09:10.204Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0e/5e5457be3d256918f6a4756f073548a3f0190836e2cc94aa6d0d617a940b/greenlet-3.5.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a0cbed8bb44e23c5b199f888f4e4ce096b45ad9f25ff74a7ad0213875e936bb2", size = 603479, upload-time = "2026-05-20T14:00:04.757Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e1/f89a21d58d308298e6f275f13a1b472ed96c680b601a371b08be6a725989/greenlet-3.5.1-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a203a8bd0acb0701653d3bbb26e404854a68674139ed5cbb778830f42b09bb33", size = 615495, upload-time = "2026-05-20T14:05:40.87Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/8fd452fd81adb9ec79c8275c1375702ab0fd6bee4952da12eaa09b9508d8/greenlet-3.5.1-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ebeb75c81211f5c702576cf81f315e77e23cfdb2c7c6fcb9dd143e6de35c360", size = 623515, upload-time = "2026-05-20T14:09:07.853Z" },
+    { url = "https://files.pythonhosted.org/packages/75/de/af6cef182862d2ccd6975440d21c9058a77c3f9b469abf94e322dfd2e0e3/greenlet-3.5.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a271fcd66c74615cda6a964fda3f304267a12e50a084472218a39bb0376f563", size = 614754, upload-time = "2026-05-20T13:14:24.947Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bc/c318aa9f3ffc77320fddcee3d892be957b42e2ff947198d9450b004f3a38/greenlet-3.5.1-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:017a544f0385d441e88714160d089d6900ef46c9eff9d99b6715a5ef2d127747", size = 418439, upload-time = "2026-05-20T14:01:38.446Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c6/50e520283a9f19388a7326b05f9e8637e566003475eacaadad04f558c68d/greenlet-3.5.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ded7b068c7c31c1a8657d4fd42d886b3e051ae29f88b80c5ff9d502257b0f071", size = 1574097, upload-time = "2026-05-20T14:02:24.003Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1c/13abd1f4860d987fa5e1170a01930d6e6cd40d328de487a3c9fdaff0ffd0/greenlet-3.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d0932b81d72f552ded9d810d00021b64d89f2195a91ce115b893f943b7a4ab3c", size = 1641058, upload-time = "2026-05-20T13:14:31.83Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/56/5f332b7705545eac2dc01b4e9254d24a793f2656d55d5cc6b94ee59d22ae/greenlet-3.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:88e300d136eac057b2397aa1cfd7328b4c87c7eb66a09c7bc6a1292234db474e", size = 238089, upload-time = "2026-05-20T13:14:03.229Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a9/a3c2fa886c5b94863fb0e61b3bc14610b7aa94cf4f17f8741b11708305fc/greenlet-3.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:cc6ab7e555c8a112ad3a76e368e86e12a2754bcae1652a5602e133ec7b635523", size = 234989, upload-time = "2026-05-20T13:08:27.715Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:fa4f98af3a528f0c3fd592a26df7f376f93329c8f4d987f6bb979057af8bf5e2", size = 286220, upload-time = "2026-05-20T13:07:28.463Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ff/a4f436709716965eaab9f36ea7b906c8a927fbe32fb1372a2071d964f6b1/greenlet-3.5.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffea73584b216150eab159b6d12348fb253e68757974de1e2c40d8a318ac89ed", size = 601585, upload-time = "2026-05-20T14:00:06.141Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ad/54bc3fcee3ad368a61b19b67d88117f7a8c29727bf71fffdeda81fbd946e/greenlet-3.5.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1072b4f9edcc1e192d9283a66a3e68d6b84c561de33a83d7858beb9ba1effe10", size = 614215, upload-time = "2026-05-20T14:05:42.675Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/6c/de5b1b388cd2d9fbdfeab324863daba37d54e6e233ddbefd70b385a8c591/greenlet-3.5.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:89101bfd5011e069be974903cb3a4e4523845e4ece2d62dcd8d358933c0ef249", size = 620094, upload-time = "2026-05-20T14:09:09.18Z" },
+    { url = "https://files.pythonhosted.org/packages/40/69/b91cda0647df839483201545913514c2827ebea5e5ccdf931842763bc127/greenlet-3.5.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:add5217d68b31130f0beca584d7fef4878327d2e31642b66618a14eef312b63b", size = 611358, upload-time = "2026-05-20T13:14:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/43/1204baffab8a6476464795a7ccf394a3248d4f22c9f87173a15b36b6d971/greenlet-3.5.1-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:e6cd99ea59dd5d89f0c956606571d79bfe6f68c9eb7f4a4083a41a7f1587edee", size = 422782, upload-time = "2026-05-20T14:01:39.597Z" },
+    { url = "https://files.pythonhosted.org/packages/59/90/3cf77e080350cd02fa307bb2abf05df48f4482c240275bbd2c203ba8bb1c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a5ea42a752d47a145eae922b605cd1634665ac3d5ec1e72402d5048e8d60d207", size = 1570475, upload-time = "2026-05-20T14:02:25.29Z" },
+    { url = "https://files.pythonhosted.org/packages/65/2c/18cece62045e74598c3c393f70dce4a63f56222015ba29a5d4eeb04f764c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c5551170cf4f5ff5623e9af81323751979fee2c731e2287b61f73cd27257b823", size = 1635625, upload-time = "2026-05-20T13:14:34.027Z" },
+    { url = "https://files.pythonhosted.org/packages/30/f5/310d104ddf41eb5a70f4c268d22508dfb0c3c8e86fec152be34d0d2ed819/greenlet-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c8bb982ad117d29478ef8f5533e97df21f1e2befd17a299257b0c96d1371c0b", size = 238791, upload-time = "2026-05-20T13:10:39.018Z" },
+    { url = "https://files.pythonhosted.org/packages/62/90/ceca11f504cd23a8047a3dea31919adc48df9b626dd0c13f0d858734fdfd/greenlet-3.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:80eb4b04dadc4e67df3fae179a32c4706a3f495bc7f22fc8a81115d5f5512188", size = 235580, upload-time = "2026-05-20T13:08:45.056Z" },
+    { url = "https://files.pythonhosted.org/packages/27/69/7f7e5372d998b81001899b1c0823c957aa413ba0f2662e65821611cc31e4/greenlet-3.5.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:51518ff74664078fc51bffcc6fc529b0df5ae58da192691cee765d45ce944a2b", size = 285060, upload-time = "2026-05-20T13:08:51.899Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/bf/387f9b6b865fd2ae0d0be09e0004827295a01b71be76ed350dd1e28a91a4/greenlet-3.5.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ffdb3c0bb002c99cd8f298957e046c3dbf6006b5b7cdf11a4e19194624a0a0a", size = 604370, upload-time = "2026-05-20T14:00:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f5/169ce3d4e4c67291bd18f8cbe0299c9f3e45102c7f1fb3c14780c93e4532/greenlet-3.5.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7715a5a2c3378ba602c3a440558261e13a820bb53a82693aacd7b7f6d964e283", size = 616987, upload-time = "2026-05-20T14:05:44.237Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ba/c24110c55dffa55aa6e1d98b45310da33801aeba7686ff0190fe5d46fd32/greenlet-3.5.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d40a890035c0058cadbdc4af7569800fd28a0e527a0fdbb7b5f9418f176846ce", size = 622911, upload-time = "2026-05-20T14:09:10.598Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e5/7f2e41d5273be07e77560d61ea4e56485b4d6c316d2a84518c62d1364061/greenlet-3.5.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc71ff466927a201b08305acac451ebe1aedfcea002f62f1f2f2ac2ac1e6a135", size = 613911, upload-time = "2026-05-20T13:14:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/7b/d20db2e8a5ad6c038702f3179b136f93f0a3d1a21a0c0777f3e470cdf4b2/greenlet-3.5.1-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:67821bb03e4e98664490edb787ff6af501194c29bbee0f5c1dfdcf1dc3d9d436", size = 425228, upload-time = "2026-05-20T14:01:40.837Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a4/fbdc67579b73615a1f91615e814303cc71e06128f7baaba87be79b8fb90c/greenlet-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cd443683db272ebaaca03af98c0b063ab30db70ea8a31a1559f35e3f7b744ccd", size = 1570689, upload-time = "2026-05-20T14:02:27.225Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b4/77abbe35078be39718a46cd49caf16bceb35662f97a34101dca28aa98e47/greenlet-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:089fff7a6ce8d9316d1f65ebc00273a56be258c1725b32b94de90a3a979557e1", size = 1635602, upload-time = "2026-05-20T13:14:36.344Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f7/129f27ca700845b8ee8ca88ce7f43435a1239c2eddb7677fc938822762cf/greenlet-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:110a1ca7b49b014b097f6078272c3f4ed31af45b254de5228b79adba879f6af9", size = 238683, upload-time = "2026-05-20T13:11:50.57Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/5c/a485a36e87df8d8fd0632ee01511244f5156a20ed3746cc6599340326395/greenlet-3.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:f16ba1efc0715b680a18b8123d90dad887c6112ae3555b4b5c32c149540c6b4e", size = 235499, upload-time = "2026-05-20T13:12:42.028Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cb/c62454606daf5640369c94d8a9dd540599b1bfc090e2d2180cb77f4038d2/greenlet-3.5.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8ab31c9de8651a2facdd5c5bb0011f2380dd1a7af78ce2adf4b56095294fc07", size = 285579, upload-time = "2026-05-20T13:08:56.396Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/71/c4270398c2eba968a6071af1dfbdcaeee6ec1c24bc8b435b8cc452700da6/greenlet-3.5.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e300185139abc337ade480c327183adf42a875ac7181bfe66d7d4efea31fbea", size = 651106, upload-time = "2026-05-20T14:00:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ab/71e34b78a44ec271fb5f550c17bc46d301ddc5953890d935f270b0dcdb5a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7ffdb990dcaa0234cf9845aead5df2e3c3a8b6507d409274dd87e0d5ab05ffc2", size = 663478, upload-time = "2026-05-20T14:05:45.88Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2d/2d80842910da44f78c286532d084b8a5c3717c844ae80ceb3858738ae89a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c09df69dc1712d131332054a858a3e5cca400967fa3a672e2324fbb0971448c", size = 667767, upload-time = "2026-05-20T14:09:12.15Z" },
+    { url = "https://files.pythonhosted.org/packages/77/96/4efd6fa5c62c85426a0c19077a586258ebc3a2a146ff2493e4312a697a22/greenlet-3.5.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2f82b3597e9d83b63408affed0b48fd0f54935edac4302237b9a837be0dae33c", size = 660800, upload-time = "2026-05-20T13:14:29.129Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d3/dad2eecedfbb1ed7050a20dcfae40c1442b74bc7423608be2c7e03ee7133/greenlet-3.5.1-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:a4764e0bfc6a4d114c865b32520805c16a990ef5f286a514413b05d5ecd6a23d", size = 470786, upload-time = "2026-05-20T14:01:42.064Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e0/6c71401a25cac7000261304e866a2f2cc04dc74810d40e2f118aa4799495/greenlet-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c0141e37414c10164e702b8fb1473304221ad98f71600850c6ef7ff4880feba0", size = 1617518, upload-time = "2026-05-20T14:02:28.662Z" },
+    { url = "https://files.pythonhosted.org/packages/41/26/c5c06643e8c0af9e7bf18e16cb51d0ab7625155f0392e1c9015d66d556cd/greenlet-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:50ae25a67bea74ea41fb14b960bc532df73eb713417b2d61892dced82fe8d3bc", size = 1681593, upload-time = "2026-05-20T13:14:39.417Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/bd/e11a108317485075e68af9d23039619b86b28130c3b50d227d42edece64b/greenlet-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:8a17c42330e261299766b75ac1ea32caa437a9453c8f65d16a13140db378ecd3", size = 239800, upload-time = "2026-05-20T13:09:30.128Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/8e8e8417b7bf28639a5a56356ef934d0375e1d0c70a57e04d7701e870ffe/greenlet-3.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:7b5f5fae05b8ac6d176a61b60c394a8cbdc2b5b91b81793066e68745cf165e54", size = 236862, upload-time = "2026-05-20T13:09:10.498Z" },
+    { url = "https://files.pythonhosted.org/packages/90/12/41bf27fde4d3605d3773ae57751eda182b8be2f5398011c041173b1d9534/greenlet-3.5.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:ea8da1e900d758d078810d4255d8c6aa572181896a31ec79d779eb79c3adc9ad", size = 293637, upload-time = "2026-05-20T13:12:35.529Z" },
+    { url = "https://files.pythonhosted.org/packages/44/44/ba14b23e9757707050c2f397d305bbcae62e5d7cad122f8b6baec5ae4a1f/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a19570c52a21420dcbc94e661994bc325c0b5b11304540fed514586da5dc8f2e", size = 650840, upload-time = "2026-05-20T14:00:11.079Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/37/5ddc2b686a6844f91abecef43411842426da2e1573f60b49ecf2547f4ae1/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3d955c89b75eeca4723d7cc14135f393cd47c32e2a6cb4a8e4c6e760a26b0986", size = 656416, upload-time = "2026-05-20T14:05:47.118Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/5987dcd1a2570ba84f3b187536b2ca3ae97613387e57f5cfa99df068fe5e/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ea37d5a157eb9493820d3792ac4ece28619a394391d2b9f2f78057d396ff0f0f", size = 656607, upload-time = "2026-05-20T14:09:13.949Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f0/d17510297c35a2992712f0bf84de3779749999f7d3d63aa1f09db7c62dbe/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2daaaebd1a5aa88c49045b6baf9310b3263796bd88db713edf37cf53e7bb4e", size = 654397, upload-time = "2026-05-20T13:14:30.696Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c1/6da0a9ddcc29d7e51ef14883fa3dc1e53b3f4ffba00582106c7bf55da1d8/greenlet-3.5.1-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:8d8a23250ea3ec7b36de8fa4b541e9e2db3ee82915cc060ab0631609ad8b28de", size = 488287, upload-time = "2026-05-20T14:01:43.143Z" },
+    { url = "https://files.pythonhosted.org/packages/37/eb/147387705bb89092645b012586e7273cb5ed3c90ef7eaf3a69173eaf0209/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bfbd69cc349e43bf3a8ae1c85548ff0718efc887615c2db16c3833d7b0b072d", size = 1614469, upload-time = "2026-05-20T14:02:30.192Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/4e/37ee0da7732b7aa9896f17e15579a9df34b9fcb9dd494f0adfa749af6623/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4378720dd888136c27215a0214d32a4d37c3852765d45bc37aad0623423cfd78", size = 1675115, upload-time = "2026-05-20T13:14:40.972Z" },
+    { url = "https://files.pythonhosted.org/packages/57/f3/97dfcf4a6eb5077f8a672234216fb5923eb89f2cab7081cb10b2cf75b605/greenlet-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:45718441607f9325d948db98cbc691276059316d0358c188c246da4e1d4d23d2", size = 245246, upload-time = "2026-05-20T13:12:22.646Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/73/d7f72e34b582f694f4a9b248162db7b09cc458a259ba8f0c0bfa1a34ea7d/greenlet-3.5.1-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:2baee5ca02031757ffe8cc3d69f0cc0aec7065ce362622da74f32d3bcab1c541", size = 285575, upload-time = "2026-05-20T13:12:07.043Z" },
+    { url = "https://files.pythonhosted.org/packages/df/59/fa9c6e87dc8ad27a95dabe2f29f372b733d05a8a67470f6c901ed9975655/greenlet-3.5.1-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b1ec3274918a81d3ea778b9e75b56b72b33f300edb6cf7f3a7fe1dae56683de", size = 656428, upload-time = "2026-05-20T14:00:12.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f9/e753408871eaa61dfe35e619cfc67512b036fde99893685d50eea9e07146/greenlet-3.5.1-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:111e2390ffffc47d5840b01711dd7fac07d4c09283d0283e7f3264b14e284c64", size = 667064, upload-time = "2026-05-20T14:05:48.662Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/74/807a047255bf1e09303627c46dc043dca596b6958a354d904f32ab382005/greenlet-3.5.1-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:10a9a1c0bfbc93d41156ffcb90c75fbc05544054faf15dcc1fdf9765f8b607f0", size = 672962, upload-time = "2026-05-20T14:09:15.532Z" },
+    { url = "https://files.pythonhosted.org/packages/96/27/5565b5b40389f1c7753003a07e21892fda8660926787036d5bc0308b8113/greenlet-3.5.1-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e630136e905fe5ff43e86945ae41220b6d1470956a39220e708110ac48d01ea5", size = 665697, upload-time = "2026-05-20T13:14:32.943Z" },
+    { url = "https://files.pythonhosted.org/packages/76/32/19d4e13225193c29b13e308015223f7d75fd3d8623d49dd19040d2ce8ec1/greenlet-3.5.1-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:ef08c1567c78074b22d1a200183d52d04a14df447bf70bcbb6a3507a48e776fc", size = 476047, upload-time = "2026-05-20T14:01:44.39Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/82/e7de4178c0c2d1c9a5a3be3cc0b33e46a85b3ee4a77c071bf7ad8600e079/greenlet-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:975eac34b44a7077ca4d421348455b94f0f518246a7f14bc6d2fdcfe5b584368", size = 1621256, upload-time = "2026-05-20T14:02:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/00/10/f2dddcf7dacac17dfc68691809589adad06135eb28930429cf58a6467a2f/greenlet-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:9ab3c3a0b2ae6198e67c898dad5215a49f9ae0d0081b3c3ec59f333e39eeca26", size = 1685956, upload-time = "2026-05-20T13:14:42.55Z" },
+    { url = "https://files.pythonhosted.org/packages/22/17/4a232b32133230ada52f70e9d7f5b65b0caef8772f01849bd8d149e7e4ca/greenlet-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:cbfc69be86e10dcfef5b1e6269d1d6926552aa89ee39e1de3353360c1b6989ab", size = 239802, upload-time = "2026-05-20T13:13:15.481Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ae/4e623a7e6d4d2a5f4cb8e4c82de4169fc637942caae68d6e676b8a128ac5/greenlet-3.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:92fd6d44ac5e5a887c8a5dc4a8ba0ba908527c31c12f78c6bc7dcfe8aab279f6", size = 236853, upload-time = "2026-05-20T13:15:37.301Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/57/816d9cff29119da3505b3d6a5e14a8af89006ac36f47f891ff293ee05af1/greenlet-3.5.1-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:a6fdf2433a5441ef9a95464f7c3e674775da1c8c1177fff311cee1acad4626ed", size = 293877, upload-time = "2026-05-20T13:10:19.078Z" },
+    { url = "https://files.pythonhosted.org/packages/23/a1/59b0a7c7d140ff1a75626680b9a9899b79a9176cab298b394968fb023295/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7546556f0d649f99f6a361098a55f761181bb2ea12ff150bb16d26092ad88244", size = 655333, upload-time = "2026-05-20T14:00:14.758Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1b/5efe127597625042218939d01855109f352779050768b670b52edcc16a6c/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5ee3ea898009fa898f85f9982255d35278c477bebe185beca249cab42d4526c", size = 659443, upload-time = "2026-05-20T14:05:50.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/9d/1dcdf7b95ab3cf8c7b6d7277c18a5e167312f2b362ddfcc5d5e6d8d84b43/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a57b0d05a0448eed231d59c0ceb287dde984551e54cbc51ac2d4865712838e9c", size = 659998, upload-time = "2026-05-20T14:09:16.912Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/6d/c404246ea4d22d097a7426d0efb5b781bd7eb67715f09e79001bd552ab18/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5c81f74d204d3edd136ebfd50dce53acbb776995d721a0fe801626cfc93b8cd", size = 658356, upload-time = "2026-05-20T13:14:35.091Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/c4959664fc231d587d66d8e81f2095e98056ba1954beafdcbe635e251052/greenlet-3.5.1-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:b0703c2cef53e01baec47f7a3868009913ad71ec678bbecb42a6f40895e4ce62", size = 494470, upload-time = "2026-05-20T14:01:45.611Z" },
+    { url = "https://files.pythonhosted.org/packages/51/02/f8ee37fb6d2219329f350af241c27fcf12df57e723d11f6fc6d3bacdadaa/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:2c18ef16bf6d4dd410e4dd52996888ea1497be26892fe5bbc73580aba4287b8e", size = 1619216, upload-time = "2026-05-20T14:02:33.403Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c5/3dc9475ace2c7a3680da12372cddd7f1ac874eb410a1ac48d3e9dab83782/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:17d86354f0ae6b61bf9be5148d0dd34e06c3cb7c602c671f79f29ac3b150e659", size = 1678427, upload-time = "2026-05-20T13:14:43.71Z" },
+    { url = "https://files.pythonhosted.org/packages/df/4e/750c15c317a41ffb36f0bf40b933e3d744a7dede61889f74443ea69690cf/greenlet-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:e7516cf6ae6b8a582c2770a0caed47b8a48373ed732c33d69a72913ae6ac923e", size = 245225, upload-time = "2026-05-20T13:13:59.366Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/fd/d3baea2eeb7b617efd47e87ca06e2ec2c6118d303aa9e918e0ce16eadc10/greenlet-3.5.1-cp315-cp315t-win_arm64.whl", hash = "sha256:5028648bf2253ec4745add746129d3904121fa7fe871a76bed23c5720573ce0a", size = 239590, upload-time = "2026-05-20T13:13:37.382Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1008,6 +1085,10 @@ openbb = [
     { name = "openbb" },
     { name = "openbb-benzinga" },
 ]
+twitter = [
+    { name = "playwright" },
+    { name = "playwright-stealth" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1022,6 +1103,8 @@ requires-dist = [
     { name = "openai", specifier = ">=1.54.0" },
     { name = "openbb", marker = "extra == 'openbb'", specifier = ">=4.4.0" },
     { name = "openbb-benzinga", marker = "extra == 'openbb'", specifier = ">=1.6.0" },
+    { name = "playwright", marker = "extra == 'twitter'", specifier = ">=1.40.0" },
+    { name = "playwright-stealth", marker = "extra == 'twitter'", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.9.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
@@ -1030,7 +1113,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.9.0" },
     { name = "tenacity", specifier = ">=9.0.0" },
 ]
-provides-extras = ["dev", "openbb"]
+provides-extras = ["dev", "openbb", "twitter"]
 
 [[package]]
 name = "hpack"
@@ -2192,6 +2275,37 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.60.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/f0/832bd9677194908da118064eef20082f2791e3d18215cc6d9391ee2c5a67/playwright-1.60.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:6a8cd0fec171fb3089e95e898c8bc8a6f35dea0b78b399e12fcc19427e91b1d7", size = 43474635, upload-time = "2026-05-18T12:00:31.969Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7b/e1d32ae8a3ed937ec2be3721c5f728b13d731a0b7c6442e0b3bec5094ac0/playwright-1.60.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:39b5420ba6145045b69ced4c5c47d4d9fe5bddfc8ff816c518913afcb25ec7a5", size = 42261327, upload-time = "2026-05-18T12:00:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/bc/23de499ded6411c188a20c5a0dea6f0cd4ed5d2b3cc6042a5dbd3ed609aa/playwright-1.60.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:2581d0e6a3392c71f91b27460c7fd093356818dc430f48153896c8aeeaef7705", size = 43474636, upload-time = "2026-05-18T12:00:39.294Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7b/1d679f4fced4ea94efadd17103856d8c565384f68382a1681264e46f5925/playwright-1.60.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:1c2bfae7884fb3fb05b853290eab8f343d524e5016f2f1def702acbbdf14c93e", size = 47467220, upload-time = "2026-05-18T12:00:43.179Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c2/1528d267d4442bd2c6b8eaeab819dd52c2030bf80e89293f0ba1f687473b/playwright-1.60.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43e66564125ee31b07a58cefb21e256d62d67d8d1713e6858df7a3019d8ed353", size = 47154856, upload-time = "2026-05-18T12:00:46.715Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/4e/b008b6440a7a1624378041da94829956d4b8f7ab9ef5aad22d0dc3f2e26d/playwright-1.60.0-py3-none-win32.whl", hash = "sha256:ec94e416ea320711e0ad4bf185dcbf41833672961e90773e1885255d7db7b7e7", size = 37902157, upload-time = "2026-05-18T12:00:50.374Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f0/0541524133104f9cc20bf900870ff4a736b76a23483f3a55295ddfa58409/playwright-1.60.0-py3-none-win_amd64.whl", hash = "sha256:9566821ce6030a1f9e7146a24e19355ab0d98805fd0f9be50bb3d8fef1750c02", size = 37902159, upload-time = "2026-05-18T12:00:53.728Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c8/210f282d278e4709cdd71b12a31af45a30a22ab3207b387e29b37e478713/playwright-1.60.0-py3-none-win_arm64.whl", hash = "sha256:6e4f6700a4c2250efff8e690a81d66e3855754fb587b6b87cf5c784014f91537", size = 34037981, upload-time = "2026-05-18T12:00:57.584Z" },
+]
+
+[[package]]
+name = "playwright-stealth"
+version = "2.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "playwright" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/db/6ade5d539c7d151b9defc78fafa8b65aa52352617d0e7699b47008bd801f/playwright_stealth-2.0.3.tar.gz", hash = "sha256:1d8e488fbdd8f190f1269ea8cf5d57d14df3a9f1af1001c41ee3588b2aac3133", size = 25751, upload-time = "2026-04-04T02:50:33.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/10/607c409712c02a26c4cb794820514cb7fdaaeac15fb05bed917fb8a354b3/playwright_stealth-2.0.3-py3-none-any.whl", hash = "sha256:1887ade423ab7ff8ae16d363a30a38de0b5817e1e4a29d47b74bf3a0e3dbfcb4", size = 34385, upload-time = "2026-04-04T02:50:35.246Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2506,6 +2620,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add a free alternative to Apify for Twitter scraping using Playwright with browser cookies. Users can choose between two modes via config:

- apify (default): existing Apify scweet actor, requires APIFY_TOKEN
- playwright: new free mode, no token needed, uses browser cookies

Features:
- GraphQL interception for efficient data extraction
- Multi-account cookie rotation (load multiple x_cookies_*.json files)
- Automatic proxy detection from env vars
- Human-like browsing simulation (scrolling, mouse movement)
- Retry failed accounts with alternate cookies
- Graceful degradation if Playwright not installed

Also adds twitter optional dependency group, x_cookies_*.json to gitignore, and docs/twitter-cookies.md with setup guide.

Preserves backward compatibility: default mode is still apify.

## Summary

Describe clearly what this PR changes and why.

## Scope

- [ ] This PR contains **one feature / one fix / one focused change**
- [ ] This PR does **not** combine multiple unrelated features

## Changes

- 
- 
- 

## Notes for Reviewers

Anything reviewers should pay attention to?

## Checklist

- [ ] I explained the change clearly
- [ ] I kept the PR focused and easy to review
- [ ] I tested the change locally when applicable
