### PR TITLE
feat: add balanced digest filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,36 @@ Minimal manual configuration:
 }
 ```
 
+**Balanced digest (optional)**
+
+Limit the final digest size and prevent one category from dominating the
+results. Categories come from source configuration such as
+`sources.rss[].category`.
+
+```jsonc
+{
+  "filtering": {
+    "ai_score_threshold": 6.0,
+    "max_items": 20,
+    "category_groups": {
+      "ai": {
+        "limit": 5,
+        "categories": ["ai-news", "ai-tools", "machine-learning"]
+      },
+      "finance": {
+        "limit": 5,
+        "categories": ["finance", "business", "equities"]
+      }
+    },
+    "default_group": "other",
+    "default_group_limit": 3
+  }
+}
+```
+
+Group limits are applied after AI score filtering and before enrichment. If
+`category_groups` and `max_items` are omitted, filtering behaves as before.
+
 `api_key_env` must be the name of an environment variable, not the API key
 itself. Put the real secret in `.env`:
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -262,6 +262,35 @@ cp data/config.example.json data/config.json  # 自定义信息源
 }
 ```
 
+**均衡日报（可选）**
+
+可以限制日报总条数，并避免单一类别占据过多内容。类别来自
+`sources.rss[].category` 等信息源配置。
+
+```jsonc
+{
+  "filtering": {
+    "ai_score_threshold": 6.0,
+    "max_items": 20,
+    "category_groups": {
+      "ai": {
+        "limit": 5,
+        "categories": ["ai-news", "ai-tools", "machine-learning"]
+      },
+      "finance": {
+        "limit": 5,
+        "categories": ["finance", "business", "equities"]
+      }
+    },
+    "default_group": "other",
+    "default_group_limit": 3
+  }
+}
+```
+
+分组限额在 AI 分数过滤之后、内容补充之前执行。未配置
+`category_groups` 和 `max_items` 时，筛选行为保持不变。
+
 `data/config.json` 里的任意字符串值都可以通过 `${VAR_NAME}` 引用环境变量。这适合用于 `ai.base_url`、私有 RSS 链接、Webhook 地址或自定义请求头模板等字段。
 
 完整配置参考请查看[配置指南](docs/configuration.md)。

--- a/data/config.example.json
+++ b/data/config.example.json
@@ -111,7 +111,11 @@
   },
   "filtering": {
     "ai_score_threshold": 6.0,
-    "time_window_hours": 24
+    "time_window_hours": 24,
+    "max_items": null,
+    "category_groups": {},
+    "default_group": "other",
+    "default_group_limit": null
   },
   "webhook": {
     "enabled": false,

--- a/data/config.github.json
+++ b/data/config.github.json
@@ -111,7 +111,11 @@
   },
   "filtering": {
     "ai_score_threshold": 6.0,
-    "time_window_hours": 24
+    "time_window_hours": 24,
+    "max_items": null,
+    "category_groups": {},
+    "default_group": "other",
+    "default_group_limit": null
   },
   "webhook": {
     "enabled": false,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -400,13 +400,50 @@ Content is scored 0-10:
 {
   "filtering": {
     "ai_score_threshold": 7.0,
-    "time_window_hours": 24
+    "time_window_hours": 24,
+    "max_items": 20,
+    "category_groups": {
+      "ai": {
+        "name": "AI / Machine Learning",
+        "limit": 5,
+        "categories": ["ai-news", "ai-tools", "machine-learning", "llm"]
+      },
+      "finance": {
+        "name": "Finance",
+        "limit": 5,
+        "categories": ["finance", "equities", "crypto"]
+      }
+    },
+    "default_group": "other",
+    "default_group_limit": 3
   }
 }
 ```
 
 - `ai_score_threshold`: Only include content scoring >= this value
 - `time_window_hours`: Fetch content from last N hours
+- `max_items`: Optional final cap after all group limits are applied
+- `category_groups`: Optional map of quota groups. Each group requires a positive
+  `limit` and a non-empty `categories` list. Items within each group are kept by
+  AI score, highest first.
+- `category_groups.*.name`: Optional display name used in run logs
+- `default_group`: Group key for items whose category does not match any
+  configured group. Default is `other`.
+- `default_group_limit`: Optional positive limit for unmatched items. If omitted,
+  unmatched items are unlimited except for `max_items`.
+
+Balanced digest filtering runs after AI score threshold filtering and topic
+deduplication, but before enrichment. This reduces enrichment calls to only the
+items that can appear in the final digest.
+
+Group matching uses the source category stored in `ContentItem.metadata.category`.
+RSS sources expose this through `sources.rss[].category`, and OpenBB watchlists
+through `sources.openbb.watchlists[].category`. Sources without a category enter
+the default group.
+
+If the same category appears in multiple groups, Horizon logs a warning and uses
+the first group in configuration order. Omitting both `category_groups` and
+`max_items` preserves the previous filtering behavior.
 
 ## Environment Variable Substitution
 

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -39,22 +39,33 @@ Engagement metadata is source-specific: HN provides score and comment count, Red
 
 ## Filtering
 
-After scoring, items are filtered by `filtering.ai_score_threshold` (default: `7.0`) and sorted by score descending. Only items meeting the threshold appear in the daily summary.
+After scoring, items are filtered by `filtering.ai_score_threshold` (default: `7.0`) and sorted by score descending. Optional balanced digest quotas are then applied before enrichment.
 
 ```json
 {
   "filtering": {
     "ai_score_threshold": 7.0,
-    "time_window_hours": 24
+    "time_window_hours": 24,
+    "max_items": 20,
+    "category_groups": {
+      "ai": {
+        "limit": 5,
+        "categories": ["ai-news", "ai-tools", "machine-learning"]
+      }
+    }
   }
 }
 ```
+
+`category_groups` limits each configured category group independently.
+`max_items` caps the merged result. Both fields are optional; without them,
+scoring and filtering behave as before.
 
 Items scoring 9.0 or above are featured in the "Today's Highlights" section of the summary.
 
 ## Enrichment
 
-Items that pass the score threshold go through a second AI pass for enrichment (`src/ai/enricher.py`):
+Items that pass the score threshold and any balanced digest limits go through a second AI pass for enrichment (`src/ai/enricher.py`):
 
 1. **Concept extraction** — AI identifies 1-3 technical concepts in the item that may need explanation.
 2. **Web search** — Each concept is searched via DuckDuckGo to gather grounding context.

--- a/src/main.py
+++ b/src/main.py
@@ -122,7 +122,11 @@ def print_config_template():
   },
   "filtering": {
     "ai_score_threshold": 7.0,
-    "time_window_hours": 24
+    "time_window_hours": 24,
+    "max_items": null,
+    "category_groups": {},
+    "default_group": "other",
+    "default_group_limit": null
   }
 }
 

--- a/src/mcp/service.py
+++ b/src/mcp/service.py
@@ -204,6 +204,13 @@ class HorizonPipelineService:
             "filtering": {
                 "ai_score_threshold": ctx.config.filtering.ai_score_threshold,
                 "time_window_hours": ctx.config.filtering.time_window_hours,
+                "max_items": ctx.config.filtering.max_items,
+                "category_groups": {
+                    key: group.model_dump(mode="json")
+                    for key, group in ctx.config.filtering.category_groups.items()
+                },
+                "default_group": ctx.config.filtering.default_group,
+                "default_group_limit": ctx.config.filtering.default_group_limit,
             },
             "enabled_sources": get_enabled_sources(ctx.config),
             "selected_sources": selected_sources,
@@ -327,10 +334,29 @@ class HorizonPipelineService:
         important_items.sort(key=lambda x: x.ai_score or 0, reverse=True)
 
         before_dedup = len(important_items)
+        orchestrator = None
         if topic_dedup and important_items:
             storage = make_storage(ctx.runtime, ctx.config_path)
             orchestrator = make_orchestrator(ctx.runtime, ctx.config, storage)
             important_items = await orchestrator.merge_topic_duplicates(important_items)
+        after_dedup = len(important_items)
+
+        filtering = ctx.config.filtering
+        balanced_enabled = bool(
+            getattr(filtering, "category_groups", {})
+            or getattr(filtering, "max_items", None) is not None
+        )
+        balanced_group_counts: dict[str, int] = {}
+        if balanced_enabled:
+            if orchestrator is None:
+                storage = make_storage(ctx.runtime, ctx.config_path)
+                orchestrator = make_orchestrator(ctx.runtime, ctx.config, storage)
+            balanced_result = orchestrator.apply_balanced_digest(
+                important_items,
+                log=False,
+            )
+            important_items = balanced_result.items
+            balanced_group_counts = balanced_result.group_counts
 
         self.run_store.save_items(run_id, "filtered", items_to_dicts(important_items))
         meta = self.run_store.update_meta(
@@ -339,7 +365,10 @@ class HorizonPipelineService:
                 "filtered_count": len(important_items),
                 "filter_threshold": effective_threshold,
                 "topic_dedup_enabled": topic_dedup,
-                "topic_dedup_removed": before_dedup - len(important_items),
+                "topic_dedup_removed": before_dedup - after_dedup,
+                "balanced_digest_enabled": balanced_enabled,
+                "balanced_digest_group_counts": balanced_group_counts,
+                "balanced_digest_removed": after_dedup - len(important_items),
             },
         )
 
@@ -347,7 +376,10 @@ class HorizonPipelineService:
             "run_id": run_id,
             "kept": len(important_items),
             "threshold": effective_threshold,
-            "removed_by_topic_dedup": before_dedup - len(important_items),
+            "removed_by_topic_dedup": before_dedup - after_dedup,
+            "removed_by_balanced_digest": after_dedup - len(important_items),
+            "balanced_digest_enabled": balanced_enabled,
+            "group_counts": balanced_group_counts,
             "source_counts": get_source_counts(important_items),
             "artifact": str((self.run_store.run_dir(run_id) / "filtered_items.json").resolve()),
             "meta": meta,

--- a/src/models.py
+++ b/src/models.py
@@ -309,11 +309,23 @@ class EmailConfig(BaseModel):
     enabled: bool = False
 
 
+class CategoryGroupConfig(BaseModel):
+    """A quota group containing one or more source categories."""
+
+    name: Optional[str] = None
+    limit: int = Field(gt=0)
+    categories: List[str] = Field(min_length=1)
+
+
 class FilteringConfig(BaseModel):
     """Content filtering configuration."""
 
     ai_score_threshold: float = 7.0
     time_window_hours: int = 24
+    max_items: Optional[int] = Field(default=None, gt=0)
+    category_groups: Dict[str, CategoryGroupConfig] = Field(default_factory=dict)
+    default_group: str = "other"
+    default_group_limit: Optional[int] = Field(default=None, gt=0)
 
 
 class Config(BaseModel):

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -2,8 +2,9 @@
 
 import asyncio
 from collections import defaultdict
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from typing import List, Dict
+from typing import List, Dict, Optional
 from urllib.parse import urlparse
 import httpx
 from rich.console import Console
@@ -25,6 +26,17 @@ from .ai.analyzer import ContentAnalyzer
 from .ai.summarizer import DailySummarizer
 from .ai.enricher import ContentEnricher
 from .ai.tokens import get_usage_snapshot
+
+
+@dataclass
+class BalancedDigestResult:
+    """Items and selection statistics from balanced digest filtering."""
+
+    items: List[ContentItem]
+    enabled: bool = False
+    group_counts: Dict[str, int] = field(default_factory=dict)
+    group_limits: Dict[str, Optional[int]] = field(default_factory=dict)
+    duplicate_categories: List[str] = field(default_factory=list)
 
 
 class HorizonOrchestrator:
@@ -113,6 +125,10 @@ class HorizonOrchestrator:
 
             # 5.6 Optional second-stage Twitter reply expansion + targeted re-analysis
             await self._expand_twitter_discussion(important_items)
+
+            # 5.7 Apply per-category and global digest limits before enrichment
+            balanced_result = self.apply_balanced_digest(important_items)
+            important_items = balanced_result.items
 
             # Show per-sub-source selection breakdown
             selected_counts: Dict[str, int] = defaultdict(int)
@@ -463,6 +479,116 @@ class HorizonOrchestrator:
                 drop_indices.add(dup_idx)
 
         return [item for i, item in enumerate(items) if i not in drop_indices]
+
+    def apply_balanced_digest(
+        self,
+        items: List[ContentItem],
+        *,
+        log: bool = True,
+    ) -> BalancedDigestResult:
+        """Apply configured category quotas and the final item cap.
+
+        Categories are read from ``item.metadata["category"]``. If a category
+        appears in more than one configured group, the first group in config
+        order wins.
+        """
+        filtering = self.config.filtering
+        groups = filtering.category_groups
+        max_items = filtering.max_items
+
+        if not groups and max_items is None:
+            return BalancedDigestResult(items=items)
+
+        sorted_items = sorted(
+            items,
+            key=lambda item: item.ai_score or 0,
+            reverse=True,
+        )
+
+        category_to_group: Dict[str, str] = {}
+        duplicate_categories: List[str] = []
+        for group_key, group in groups.items():
+            for category in group.categories:
+                if category in category_to_group:
+                    if category_to_group[category] != group_key:
+                        duplicate_categories.append(category)
+                    continue
+                category_to_group[category] = group_key
+
+        if log:
+            for category in sorted(set(duplicate_categories)):
+                first_group = category_to_group[category]
+                self.console.print(
+                    f"[yellow]Warning: category '{category}' is configured in multiple "
+                    f"groups; using '{first_group}'.[/yellow]"
+                )
+
+        selected: List[tuple[ContentItem, str]] = []
+        group_counts: Dict[str, int] = defaultdict(int)
+        default_group = filtering.default_group
+
+        for item in sorted_items:
+            category = item.metadata.get("category")
+            group_key = (
+                category_to_group.get(category, default_group)
+                if isinstance(category, str)
+                else default_group
+            )
+
+            if group_key in groups:
+                limit = groups[group_key].limit
+            else:
+                limit = filtering.default_group_limit
+
+            if limit is not None and group_counts[group_key] >= limit:
+                continue
+
+            selected.append((item, group_key))
+            group_counts[group_key] += 1
+
+        if max_items is not None:
+            selected = selected[:max_items]
+
+        final_counts: Dict[str, int] = defaultdict(int)
+        for _, group_key in selected:
+            final_counts[group_key] += 1
+
+        group_limits: Dict[str, Optional[int]] = {
+            group_key: group.limit for group_key, group in groups.items()
+        }
+        group_limits.setdefault(default_group, filtering.default_group_limit)
+
+        if log:
+            self.console.print(
+                f"⚖️ Balanced digest selected {len(selected)}/{len(items)} items"
+            )
+            for group_key, group in groups.items():
+                label = group.name or group_key
+                self.console.print(
+                    f"      • {label}: {final_counts.get(group_key, 0)}/{group.limit}"
+                )
+            if (
+                final_counts.get(default_group, 0)
+                or filtering.default_group_limit is not None
+            ):
+                limit_label = (
+                    str(filtering.default_group_limit)
+                    if filtering.default_group_limit is not None
+                    else "unlimited"
+                )
+                self.console.print(
+                    f"      • {default_group}: "
+                    f"{final_counts.get(default_group, 0)}/{limit_label}"
+                )
+            self.console.print("")
+
+        return BalancedDigestResult(
+            items=[item for item, _ in selected],
+            enabled=True,
+            group_counts=dict(final_counts),
+            group_limits=group_limits,
+            duplicate_categories=sorted(set(duplicate_categories)),
+        )
 
     async def _expand_twitter_discussion(self, items: List[ContentItem]) -> None:
         """Second-stage: fetch reply text for important Twitter items and re-analyze.

--- a/tests/test_balanced_digest.py
+++ b/tests/test_balanced_digest.py
@@ -1,0 +1,190 @@
+import asyncio
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+from rich.console import Console
+
+from src.models import (
+    AIConfig,
+    CategoryGroupConfig,
+    Config,
+    ContentItem,
+    FilteringConfig,
+    SourceType,
+    SourcesConfig,
+)
+from src.orchestrator import HorizonOrchestrator
+
+
+def make_item(item_id: str, score: float, category: str | None) -> ContentItem:
+    metadata = {"category": category} if category is not None else {}
+    return ContentItem(
+        id=item_id,
+        source_type=SourceType.RSS,
+        title=item_id,
+        url=f"https://example.com/{item_id}",
+        published_at=datetime.now(timezone.utc),
+        ai_score=score,
+        metadata=metadata,
+    )
+
+
+def make_orchestrator(filtering: FilteringConfig) -> HorizonOrchestrator:
+    orchestrator = HorizonOrchestrator.__new__(HorizonOrchestrator)
+    orchestrator.config = SimpleNamespace(filtering=filtering)
+    orchestrator.console = Console(record=True)
+    return orchestrator
+
+
+def test_unconfigured_balanced_digest_preserves_old_behavior() -> None:
+    items = [make_item("lower", 7.0, "ai"), make_item("higher", 9.0, "finance")]
+    result = make_orchestrator(FilteringConfig()).apply_balanced_digest(items)
+
+    assert result.enabled is False
+    assert result.items is items
+
+
+def test_category_groups_apply_limits_and_default_group_limit() -> None:
+    filtering = FilteringConfig(
+        category_groups={
+            "ai": CategoryGroupConfig(limit=2, categories=["ai", "ml"]),
+            "finance": CategoryGroupConfig(limit=1, categories=["finance"]),
+        },
+        default_group_limit=1,
+    )
+    items = [
+        make_item("ai-low", 7.0, "ai"),
+        make_item("finance-low", 6.0, "finance"),
+        make_item("other-high", 9.5, "world"),
+        make_item("ai-high", 9.0, "ml"),
+        make_item("finance-high", 8.5, "finance"),
+        make_item("ai-mid", 8.0, "ai"),
+        make_item("other-low", 5.0, None),
+    ]
+
+    result = make_orchestrator(filtering).apply_balanced_digest(items)
+
+    assert [item.id for item in result.items] == [
+        "other-high",
+        "ai-high",
+        "finance-high",
+        "ai-mid",
+    ]
+    assert result.group_counts == {"other": 1, "ai": 2, "finance": 1}
+
+
+def test_max_items_applies_after_group_limits() -> None:
+    filtering = FilteringConfig(
+        max_items=2,
+        category_groups={
+            "ai": CategoryGroupConfig(limit=2, categories=["ai"]),
+            "finance": CategoryGroupConfig(limit=2, categories=["finance"]),
+        },
+    )
+    items = [
+        make_item("finance", 8.0, "finance"),
+        make_item("ai-top", 10.0, "ai"),
+        make_item("ai-second", 9.0, "ai"),
+    ]
+
+    result = make_orchestrator(filtering).apply_balanced_digest(items)
+
+    assert [item.id for item in result.items] == ["ai-top", "ai-second"]
+    assert result.group_counts == {"ai": 2}
+
+
+def test_max_items_works_without_category_groups() -> None:
+    filtering = FilteringConfig(max_items=1)
+    items = [make_item("lower", 7.0, None), make_item("higher", 9.0, None)]
+
+    result = make_orchestrator(filtering).apply_balanced_digest(items)
+
+    assert [item.id for item in result.items] == ["higher"]
+
+
+def test_duplicate_category_warns_and_first_group_wins() -> None:
+    filtering = FilteringConfig(
+        category_groups={
+            "first": CategoryGroupConfig(limit=1, categories=["shared"]),
+            "second": CategoryGroupConfig(limit=2, categories=["shared"]),
+        }
+    )
+    orchestrator = make_orchestrator(filtering)
+
+    result = orchestrator.apply_balanced_digest(
+        [make_item("top", 9.0, "shared"), make_item("second", 8.0, "shared")]
+    )
+
+    assert [item.id for item in result.items] == ["top"]
+    assert result.duplicate_categories == ["shared"]
+    assert "using 'first'" in orchestrator.console.export_text()
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"max_items": 0},
+        {"default_group_limit": 0},
+        {"category_groups": {"ai": {"limit": 0, "categories": ["ai"]}}},
+        {"category_groups": {"ai": {"limit": 1, "categories": []}}},
+    ],
+)
+def test_balanced_digest_config_rejects_non_positive_or_empty_limits(kwargs) -> None:
+    with pytest.raises(ValidationError):
+        FilteringConfig(**kwargs)
+
+
+def test_run_applies_balanced_digest_before_enrichment(tmp_path, monkeypatch) -> None:
+    config = Config(
+        ai=AIConfig(
+            provider="openai",
+            model="test",
+            api_key_env="TEST_API_KEY",
+            languages=[],
+        ),
+        sources=SourcesConfig(),
+        filtering=FilteringConfig(
+            ai_score_threshold=7.0,
+            max_items=1,
+            category_groups={
+                "ai": CategoryGroupConfig(limit=1, categories=["ai"]),
+                "finance": CategoryGroupConfig(limit=1, categories=["finance"]),
+            },
+        ),
+    )
+    storage = SimpleNamespace()
+    orchestrator = HorizonOrchestrator(config, storage)
+    items = [
+        make_item("ai", 9.0, "ai"),
+        make_item("finance", 8.0, "finance"),
+        make_item("below-threshold", 6.0, "ai"),
+    ]
+    enriched_ids: list[str] = []
+
+    async def fetch_all_sources(since):  # type: ignore[no-untyped-def]
+        return items
+
+    async def analyze_content(input_items):  # type: ignore[no-untyped-def]
+        return input_items
+
+    async def merge_topic_duplicates(input_items):  # type: ignore[no-untyped-def]
+        return input_items
+
+    async def expand_twitter_discussion(input_items):  # type: ignore[no-untyped-def]
+        return None
+
+    async def enrich_important_items(input_items):  # type: ignore[no-untyped-def]
+        enriched_ids.extend(item.id for item in input_items)
+
+    monkeypatch.setattr(orchestrator, "fetch_all_sources", fetch_all_sources)
+    monkeypatch.setattr(orchestrator, "_analyze_content", analyze_content)
+    monkeypatch.setattr(orchestrator, "merge_topic_duplicates", merge_topic_duplicates)
+    monkeypatch.setattr(orchestrator, "_expand_twitter_discussion", expand_twitter_discussion)
+    monkeypatch.setattr(orchestrator, "_enrich_important_items", enrich_important_items)
+    monkeypatch.chdir(tmp_path)
+
+    asyncio.run(orchestrator.run())
+
+    assert enriched_ids == ["ai"]

--- a/tests/test_mcp_service_smoke.py
+++ b/tests/test_mcp_service_smoke.py
@@ -142,3 +142,46 @@ def test_filter_items_uses_public_topic_dedup_api(tmp_path: Path, monkeypatch) -
     assert result["kept"] == 1
     assert result["removed_by_topic_dedup"] == 1
     assert service.run_store.load_items("run-topic-dedup", "filtered")[0]["id"] == "item-1"
+
+
+def test_filter_items_applies_balanced_digest(tmp_path: Path, monkeypatch) -> None:
+    service = HorizonPipelineService(runs_root=tmp_path / "mcp-runs")
+    service.run_store.create_run("run-balanced")
+    filtering = SimpleNamespace(
+        ai_score_threshold=7.0,
+        max_items=1,
+        category_groups={},
+    )
+
+    monkeypatch.setattr(
+        service,
+        "_load_stage_items",
+        lambda **kwargs: (
+            [make_item("item-1", score=9.0), make_item("item-2", score=8.0)],
+            SimpleNamespace(
+                runtime=SimpleNamespace(),
+                config_path=tmp_path / "config.json",
+                config=SimpleNamespace(filtering=filtering),
+            ),
+        ),
+    )
+    monkeypatch.setattr("src.mcp.service.make_storage", lambda runtime, config_path: object())
+
+    class FakeOrchestrator:
+        def apply_balanced_digest(self, items, log=True):  # type: ignore[no-untyped-def]
+            assert log is False
+            return SimpleNamespace(items=items[:1], group_counts={"other": 1})
+
+    monkeypatch.setattr(
+        "src.mcp.service.make_orchestrator",
+        lambda runtime, config, storage: FakeOrchestrator(),
+    )
+
+    result = asyncio.run(
+        service.filter_items(run_id="run-balanced", topic_dedup=False)
+    )
+
+    assert result["kept"] == 1
+    assert result["removed_by_balanced_digest"] == 1
+    assert result["balanced_digest_enabled"] is True
+    assert result["group_counts"] == {"other": 1}


### PR DESCRIPTION
## Summary

Add balanced digest filtering to keep daily summaries category-balanced and
limit their total size.

## Scope

- [x] This PR contains one focused feature
- [x] This PR does not combine unrelated changes

## Changes

- Add `filtering.max_items` and `filtering.category_groups`
- Support grouping multiple source categories with per-group limits
- Apply quotas after AI score filtering and before enrichment
- Support default-group limits and duplicate-category warnings
- Reuse balanced filtering in the MCP pipeline
- Add configuration examples and documentation
- Add unit and pipeline-order tests

## Notes for Reviewers

When `category_groups` and `max_items` are omitted, existing filtering behavior
is unchanged.

Categories are read from `ContentItem.metadata.category`, currently populated
by categorized sources such as RSS and OpenBB.

## Checklist

- [x] I explained the change clearly
- [x] I kept the PR focused and easy to review
- [x] I tested the change locally

## Testing

```text
uv run --extra dev pytest -q
All tests passed.
```
---

## 中文说明

### 概述

新增均衡日报筛选功能，用于控制日报总条数，并避免单一类别占据过多内容。

### 主要改动

- 新增 `filtering.max_items` 和 `filtering.category_groups`
- 支持将多个 source category 聚合为一组，并设置每组条数上限
- 在 AI 分数阈值过滤之后、Enrichment 之前执行分组限额
- 支持未匹配内容的默认分组及条数限制
- 同一 category 配置到多个组时输出 warning
- MCP filtering pipeline 复用相同筛选逻辑
- 补充中英文 README、配置指南、示例配置和测试

### 向后兼容

未配置 `category_groups` 和 `max_items` 时，保持原有筛选行为不变。

类别读取自 `ContentItem.metadata.category`。目前 RSS 和 OpenBB 等支持 category 的信息源可以参与分组；没有 category 的内容会进入默认组。

### 测试

```text
uv run --extra dev pytest -q
全部测试通过。
```