### PR TITLE
fix(webhook): skip platform-specific error code check for generic webhook

### DIFF
--- a/src/services/webhook.py
+++ b/src/services/webhook.py
@@ -628,22 +628,24 @@ class WebhookNotifier:
         except (json.JSONDecodeError, ValueError):
             return None
 
-        # Feishu/Lark: "code" or "StatusCode" field
-        feishu_code = data.get("code") or data.get("StatusCode")
-        if feishu_code is not None and feishu_code != 0:
-            msg = data.get("msg") or data.get("StatusMessage") or ""
-            return f"Feishu/Lark error (code={feishu_code}): {msg}"
+        platform = self.config.platform
 
-        # DingTalk: "errcode" field
-        dingtalk_code = data.get("errcode")
-        if dingtalk_code is not None and dingtalk_code != 0:
-            msg = data.get("errmsg") or ""
-            return f"DingTalk error (errcode={dingtalk_code}): {msg}"
+        if platform in ("feishu", "lark"):
+            code = data.get("code") or data.get("StatusCode")
+            if code is not None and code != 0:
+                msg = data.get("msg") or data.get("StatusMessage") or ""
+                return f"Feishu/Lark error (code={code}): {msg}"
 
-        # Slack/Discord: "ok" field
-        if data.get("ok") is False:
-            error = data.get("error") or ""
-            return f"Slack/Discord error: {error}"
+        elif platform == "dingtalk":
+            errcode = data.get("errcode")
+            if errcode is not None and errcode != 0:
+                msg = data.get("errmsg") or ""
+                return f"DingTalk error (errcode={errcode}): {msg}"
+
+        elif platform in ("slack", "discord"):
+            if data.get("ok") is False:
+                error = data.get("error") or ""
+                return f"Slack/Discord error: {error}"
 
         return None
 


### PR DESCRIPTION
Summary

  Fix false-positive error detection in _check_body_error_code for webhook responses. Previously, all platforms were checked against all error patterns (Feishu, DingTalk, Slack/Discord), which meant:

  1. generic platforms could have arbitrary JSON fields like code or ok misidentified as platform errors, causing successful notifications to display as warnings.
  2. Even known platforms could be cross-contaminated — e.g. a Slack response containing a code field would trigger the Feishu error pattern.

  The fix scopes each platform to only check its own error pattern, and skips the check entirely for generic.

  Scope

  - [x] This PR contains one feature / one fix / one focused change
  - [x] This PR does not combine multiple unrelated features

  Changes

  - Refactored _check_body_error_code to use platform-specific branching instead of checking all patterns unconditionally
  - generic platform now skips error code detection entirely

  Checklist

  - [x] I explained the change clearly
  - [x] I kept the PR focused and easy to review
  - [x] I tested the change locally when applicable