### PR TITLE
docs(configuration): document OPENAI_BASE_URL env var for custom endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@
 # AI API Keys (configure at least one)
 ANTHROPIC_API_KEY=sk-ant-xxx
 OPENAI_API_KEY=sk-xxx
+# OPENAI_BASE_URL=https://your-proxy.com/v1  # Custom open-ai compatible provider
 AZURE_OPENAI_API_KEY=xxx
 AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
 GOOGLE_API_KEY=xxx

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -193,6 +193,15 @@ By default, AI scoring and enrichment run one item at a time. If your API endpoi
 
 For OpenAI-compatible gateways, Horizon sends `temperature` by default. If a newer reasoning-style model rejects that parameter with an error such as `temperature is deprecated for this model`, Horizon retries once without it and remembers that capability for later requests.
 
+You can also set the base URL via environment variable:
+
+| Provider | Environment Variable |
+| --- | --- |
+| OpenAI / OpenAI-compatible | `OPENAI_BASE_URL` |
+| Ollama | `HORIZON_OLLAMA_BASE_URL`, `OLLAMA_BASE_URL`, `OLLAMA_HOST` |
+
+The `base_url` in `config.json` takes precedence over environment variables if both are set.
+
 ## Information Sources
 
 All sources are configured under the top-level `sources` key in `config.json`.


### PR DESCRIPTION
Add Openai base url env var and documentation for it

## Summary

OPENAI_BASE_URL is already supported by the underlying OpenAI SDK, no code changes needed.

## Scope

- [x] This PR contains **one feature / one fix / one focused change**
- [x] This PR does **not** combine multiple unrelated features

## Changes

- .env.example: Added OPENAI_BASE_URL as a commented optional environment variable
- docs/configuration.md: Added OPENAI_BASE_URL and Ollama env vars table under the "Custom Base URL" section, with a note on precedence

## Notes for Reviewers

Im not sure about the section **custom base url**. If you would like any changes let me know

## Checklist

- [x] I explained the change clearly
- [x] I kept the PR focused and easy to review
- [x] I tested the change locally when applicable
