### PR TITLE
feat(scrapers): add GDELT and Google News RSS sources for a larger pool of news

### DIFF
--- a/data/config.example.json
+++ b/data/config.example.json
@@ -107,6 +107,25 @@
       "keywords": [],
       "min_stars": 10,
       "max_items": 30
+    },
+    "gdelt": {
+      "enabled": false,
+      "query": "artificial intelligence",
+      "mode": "ArtList",
+      "max_records": 75,
+      "timespan": null,
+      "language": null,
+      "country": null,
+      "category": "news"
+    },
+    "google_news": {
+      "enabled": false,
+      "query": "artificial intelligence",
+      "language": "en",
+      "country": "US",
+      "ceid": null,
+      "max_results": 100,
+      "category": "news"
     }
   },
   "filtering": {

--- a/src/models.py
+++ b/src/models.py
@@ -17,6 +17,8 @@ class SourceType(str, Enum):
     TWITTER = "twitter"
     OPENBB = "openbb"
     OSSINSIGHT = "ossinsight"
+    GDELT = "gdelt"
+    GOOGLE_NEWS = "google_news"
 
 
 class ContentItem(BaseModel):
@@ -264,6 +266,43 @@ class OSSInsightConfig(BaseModel):
     max_items: int = 30
 
 
+class GDELTConfig(BaseModel):
+    """GDELT 2.0 DOC API source configuration.
+
+    Queries the key-less GDELT DOC API
+    (https://api.gdeltproject.org/api/v2/doc/doc) for recent news articles
+    matching a search query and emits them as ContentItems. No API key is
+    required. The DOC API caps results at 250 records per request, so keep
+    `max_records` modest.
+    """
+
+    enabled: bool = False
+    query: str = "artificial intelligence"
+    mode: str = "ArtList"
+    max_records: int = 75  # GDELT DOC API caps at 250; keep modest
+    timespan: Optional[str] = None  # e.g. "24h"; overrides since-derived window
+    language: Optional[str] = None  # sourcelang filter, e.g. "english"; None = no filter
+    country: Optional[str] = None  # sourcecountry filter; None = no filter
+    category: Optional[str] = None  # Horizon category label for downstream grouping
+
+
+class GoogleNewsConfig(BaseModel):
+    """Google News RSS search source configuration.
+
+    Builds Google News RSS search URLs
+    (https://news.google.com/rss/search) for a query and parses the
+    resulting feed via feedparser. No API key is required.
+    """
+
+    enabled: bool = False
+    query: str = "artificial intelligence"
+    language: str = "en"  # hl
+    country: str = "US"  # gl
+    ceid: Optional[str] = None  # when None scraper derives it as "{country}:{language}"
+    max_results: int = 100  # cap ~100
+    category: Optional[str] = None
+
+
 class SourcesConfig(BaseModel):
     """All sources configuration."""
 
@@ -275,6 +314,8 @@ class SourcesConfig(BaseModel):
     twitter: Optional[TwitterConfig] = None
     openbb: Optional[OpenBBConfig] = None
     ossinsight: OSSInsightConfig = Field(default_factory=OSSInsightConfig)
+    gdelt: Optional[GDELTConfig] = None
+    google_news: Optional[GoogleNewsConfig] = None
 
 
 class WebhookConfig(BaseModel):

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -22,6 +22,8 @@ from .scrapers.twitter import TwitterScraper
 from .scrapers.twitter_playwright import TwitterPlaywrightScraper
 from .scrapers.openbb import OpenBBScraper
 from .scrapers.ossinsight import OSSInsightScraper
+from .scrapers.gdelt import GDELTScraper
+from .scrapers.google_news import GoogleNewsScraper
 from .ai.client import create_ai_client
 from .ai.analyzer import ContentAnalyzer
 from .ai.summarizer import DailySummarizer
@@ -300,6 +302,16 @@ class HorizonOrchestrator:
                 oss_scraper = OSSInsightScraper(self.config.sources.ossinsight, client)
                 tasks.append(self._fetch_with_progress("OSS Insight", oss_scraper, since))
 
+            # GDELT 2.0 DOC API (key-less global news)
+            if self.config.sources.gdelt and self.config.sources.gdelt.enabled:
+                gdelt_scraper = GDELTScraper(self.config.sources.gdelt, client)
+                tasks.append(self._fetch_with_progress("GDELT", gdelt_scraper, since))
+
+            # Google News RSS (key-less news search)
+            if self.config.sources.google_news and self.config.sources.google_news.enabled:
+                gn_scraper = GoogleNewsScraper(self.config.sources.google_news, client)
+                tasks.append(self._fetch_with_progress("Google News", gn_scraper, since))
+
             # Fetch all concurrently
             results = await asyncio.gather(*tasks, return_exceptions=True)
 
@@ -354,6 +366,12 @@ class HorizonOrchestrator:
             return meta["repo"]
         if meta.get("watchlist"):
             return meta["watchlist"]
+        if meta.get("source_name"):
+            return meta["source_name"]
+        if meta.get("gn_query"):
+            return f"google_news:{meta['gn_query']}"
+        if meta.get("domain"):
+            return meta["domain"]
         return item.author or "unknown"
 
     def merge_cross_source_duplicates(self, items: List[ContentItem]) -> List[ContentItem]:

--- a/src/scrapers/gdelt.py
+++ b/src/scrapers/gdelt.py
@@ -1,0 +1,184 @@
+"""GDELT 2.0 DOC API scraper.
+
+Pulls recent global news articles from the key-less GDELT 2.0 DOC API
+(https://api.gdeltproject.org/api/v2/doc/doc) and maps them into
+ContentItem instances so the rest of the Horizon pipeline (deduplication,
+AI scoring, enrichment, summarization) treats them the same way as RSS or
+Hacker News items.
+
+Design notes:
+
+* No API key is required; GDELT is fully open. The DOC API caps results at
+  250 records per request, so `max_records` is kept modest by default.
+* GDELT expresses source-language and source-country filters as query
+  operators (``sourcelang:`` / ``sourcecountry:``) rather than separate
+  parameters, so they are appended to the query string.
+* GDELT can return non-JSON or empty bodies on transient errors, so the
+  ``.json()`` call is guarded and an empty/missing ``articles`` key yields
+  an empty list rather than raising.
+* A single malformed article is skipped, not allowed to abort the batch.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, List, Optional
+
+import httpx
+
+from .base import BaseScraper
+from ..models import ContentItem, GDELTConfig, SourceType
+
+logger = logging.getLogger(__name__)
+
+
+class GDELTScraper(BaseScraper):
+    """Scraper backed by the GDELT 2.0 DOC API."""
+
+    SOURCE_TYPE = SourceType.GDELT
+    BASE_URL = "https://api.gdeltproject.org/api/v2/doc/doc"
+
+    def __init__(self, config: GDELTConfig, http_client: httpx.AsyncClient):
+        """Initialize the scraper.
+
+        Args:
+            config: GDELT source configuration.
+            http_client: Shared async HTTP client.
+        """
+        super().__init__({"gdelt": config}, http_client)
+        self.gdelt_config = config
+
+    async def fetch(self, since: datetime) -> List[ContentItem]:
+        """Fetch articles from the GDELT DOC API.
+
+        Args:
+            since: Only fetch items published after this time (used to derive
+                the GDELT ``startdatetime`` unless ``timespan`` is set).
+
+        Returns:
+            List[ContentItem]: Fetched content items.
+        """
+        if not self.gdelt_config.enabled:
+            return []
+
+        query = (self.gdelt_config.query or "").strip()
+        if not query:
+            return []
+
+        # GDELT expresses language/country as query operators.
+        if self.gdelt_config.language:
+            query = f"{query} sourcelang:{self.gdelt_config.language}"
+        if self.gdelt_config.country:
+            query = f"{query} sourcecountry:{self.gdelt_config.country}"
+
+        params: dict[str, Any] = {
+            "query": query,
+            "mode": self.gdelt_config.mode,
+            "format": "json",
+            "maxrecords": self.gdelt_config.max_records,
+            "sort": "datedesc",
+        }
+
+        # timespan takes precedence over an explicit start/end window.
+        if self.gdelt_config.timespan:
+            params["timespan"] = self.gdelt_config.timespan
+        else:
+            since_utc = self._ensure_utc(since)
+            now_utc = datetime.now(timezone.utc)
+            params["startdatetime"] = since_utc.strftime("%Y%m%d%H%M%S")
+            params["enddatetime"] = now_utc.strftime("%Y%m%d%H%M%S")
+
+        try:
+            response = await self.client.get(
+                self.BASE_URL, params=params, follow_redirects=True
+            )
+            response.raise_for_status()
+
+            try:
+                payload = response.json()
+            except Exception as exc:
+                logger.warning("GDELT returned a non-JSON body: %s", exc)
+                return []
+
+            if not isinstance(payload, dict):
+                return []
+
+            articles = payload.get("articles")
+            if not articles:
+                return []
+
+            items: List[ContentItem] = []
+            for raw in articles:
+                item = self._raw_to_item(raw)
+                if item is not None:
+                    items.append(item)
+            return items
+
+        except httpx.HTTPError as exc:
+            logger.warning("Error fetching GDELT articles: %s", exc)
+            return []
+        except Exception as exc:
+            logger.warning("Error parsing GDELT response: %s", exc)
+            return []
+
+    def _raw_to_item(self, raw: Any) -> Optional[ContentItem]:
+        """Map one GDELT article record into a ContentItem.
+
+        Returns None when the record has no URL/title or an unparseable
+        ``seendate`` (published_at is required), so a single bad article is
+        skipped rather than aborting the batch.
+        """
+        if not isinstance(raw, dict):
+            return None
+
+        url = (raw.get("url") or "").strip()
+        title = (raw.get("title") or "").strip()
+        if not url or not title:
+            return None
+
+        seendate = (raw.get("seendate") or "").strip()
+        published = self._parse_seendate(seendate)
+        if published is None:
+            return None
+
+        native_id = f"{seendate}::{url}"
+        meta = {
+            "domain": raw.get("domain"),
+            "sourcecountry": raw.get("sourcecountry"),
+            "language": raw.get("language"),
+            "query": self.gdelt_config.query,
+            "category": self.gdelt_config.category,
+        }
+
+        try:
+            return ContentItem(
+                id=self._generate_id("gdelt", "article", native_id),
+                source_type=self.SOURCE_TYPE,
+                title=title,
+                url=url,
+                content=None,
+                author=raw.get("domain"),
+                published_at=published,
+                metadata={k: v for k, v in meta.items() if v is not None},
+            )
+        except Exception as exc:
+            logger.warning("Skipping invalid GDELT article %s: %s", url, exc)
+            return None
+
+    @staticmethod
+    def _parse_seendate(value: str) -> Optional[datetime]:
+        """Parse a GDELT ``seendate`` ("YYYYMMDDTHHMMSSZ") into aware UTC."""
+        if not value:
+            return None
+        try:
+            dt = datetime.strptime(value, "%Y%m%dT%H%M%SZ")
+        except (ValueError, TypeError):
+            return None
+        return dt.replace(tzinfo=timezone.utc)
+
+    @staticmethod
+    def _ensure_utc(moment: datetime) -> datetime:
+        if moment.tzinfo is None:
+            return moment.replace(tzinfo=timezone.utc)
+        return moment.astimezone(timezone.utc)

--- a/src/scrapers/google_news.py
+++ b/src/scrapers/google_news.py
@@ -1,0 +1,223 @@
+"""Google News RSS search scraper.
+
+Pulls recent news articles from Google News' key-less RSS search endpoint
+(https://news.google.com/rss/search) for a configured query and maps each
+feed entry into a ContentItem so the rest of the Horizon pipeline
+(deduplication, AI scoring, enrichment, summarization) treats them the same
+way as RSS, Hacker News, or GDELT items.
+
+Design notes:
+
+* No API key is required; Google News exposes an open RSS search endpoint.
+* The desired time window is expressed as a Google News query *operator*
+  rather than a request parameter. ``since`` is converted to an integer
+  number of hours; for windows up to 100 hours we use ``when:<hours>h``
+  (Google News supports ``when:Nh`` / ``when:Nd``), and for longer windows
+  we fall back to ``after:YYYY-MM-DD`` using the ``since`` date. This keeps
+  the mapping deterministic and lets Google bound the result set.
+* Localization is expressed through the ``hl`` (language), ``gl`` (country)
+  and ``ceid`` params; ``ceid`` defaults to ``"{country}:{language}"`` when
+  not configured.
+* Google News headlines are usually formatted "Headline - Publisher" and the
+  publisher is also exposed via ``entry.source.title``; it is captured into
+  the ``source_name`` metadata key defensively.
+* A single malformed entry is skipped, not allowed to abort the batch.
+"""
+
+from __future__ import annotations
+
+import calendar
+import hashlib
+import logging
+import math
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Any, List, Optional
+
+import feedparser
+import httpx
+
+from .base import BaseScraper
+from ..models import ContentItem, GoogleNewsConfig, SourceType
+
+logger = logging.getLogger(__name__)
+
+
+class GoogleNewsScraper(BaseScraper):
+    """Scraper backed by the Google News RSS search endpoint."""
+
+    SOURCE_TYPE = SourceType.GOOGLE_NEWS
+    BASE_URL = "https://news.google.com/rss/search"
+
+    def __init__(self, config: GoogleNewsConfig, http_client: httpx.AsyncClient):
+        """Initialize the scraper.
+
+        Args:
+            config: Google News source configuration.
+            http_client: Shared async HTTP client.
+        """
+        super().__init__({"google_news": config}, http_client)
+        self.gn_config = config
+
+    async def fetch(self, since: datetime) -> List[ContentItem]:
+        """Fetch articles from the Google News RSS search endpoint.
+
+        Args:
+            since: Only fetch items published after this time (used to derive
+                the Google News ``when:``/``after:`` query operator).
+
+        Returns:
+            List[ContentItem]: Fetched content items.
+        """
+        if not self.gn_config.enabled:
+            return []
+
+        base_query = (self.gn_config.query or "").strip()
+        if not base_query:
+            return []
+
+        query = f"{base_query} {self._time_operator(since)}"
+
+        ceid = self.gn_config.ceid or f"{self.gn_config.country}:{self.gn_config.language}"
+        params: dict[str, Any] = {
+            "q": query,
+            "hl": self.gn_config.language,
+            "gl": self.gn_config.country,
+            "ceid": ceid,
+        }
+
+        try:
+            response = await self.client.get(
+                self.BASE_URL, params=params, follow_redirects=True
+            )
+            response.raise_for_status()
+
+            feed = feedparser.parse(response.text)
+
+            items: List[ContentItem] = []
+            for entry in feed.entries:
+                if len(items) >= self.gn_config.max_results:
+                    break
+                item = self._entry_to_item(entry)
+                if item is not None:
+                    items.append(item)
+            return items
+
+        except httpx.HTTPError as exc:
+            logger.warning("Error fetching Google News feed: %s", exc)
+            return []
+        except Exception as exc:
+            logger.warning("Error parsing Google News feed: %s", exc)
+            return []
+
+    def _time_operator(self, since: datetime) -> str:
+        """Build the Google News time operator from ``since``.
+
+        Computes the number of whole hours between ``since`` and now (min 1).
+        For windows up to 100 hours we use ``when:<hours>h``; for longer
+        windows Google News' relative operator is unreliable, so we fall back
+        to ``after:YYYY-MM-DD`` using the ``since`` date.
+        """
+        since_utc = self._ensure_utc(since)
+        now_utc = datetime.now(timezone.utc)
+        seconds = (now_utc - since_utc).total_seconds()
+        hours = max(1, math.ceil(seconds / 3600))
+        if hours <= 100:
+            return f"when:{hours}h"
+        return f"after:{since_utc.strftime('%Y-%m-%d')}"
+
+    def _entry_to_item(self, entry: Any) -> Optional[ContentItem]:
+        """Map one Google News RSS entry into a ContentItem.
+
+        Returns None when the entry has no title/link or an unparseable
+        published date (published_at is required), so a single bad entry is
+        skipped rather than aborting the batch.
+        """
+        try:
+            title = (entry.get("title") or "").strip()
+            if not title:
+                return None
+
+            link = (entry.get("link") or "").strip()
+            if not link:
+                return None
+
+            published = self._parse_date(entry)
+            if published is None:
+                return None
+
+            source_name = self._extract_source_name(entry)
+
+            entry_id = entry.get("id") or link
+            entry_hash = hashlib.sha256(str(entry_id).encode("utf-8")).hexdigest()[:16]
+
+            meta = {
+                "gn_query": self.gn_config.query,
+                "source_name": source_name,
+                "category": self.gn_config.category,
+            }
+
+            return ContentItem(
+                id=self._generate_id("google_news", "article", entry_hash),
+                source_type=self.SOURCE_TYPE,
+                title=title,
+                url=link,
+                content=self._extract_content(entry),
+                author=source_name,
+                published_at=published,
+                metadata={k: v for k, v in meta.items() if v is not None},
+            )
+        except Exception as exc:
+            logger.warning("Skipping invalid Google News entry: %s", exc)
+            return None
+
+    @staticmethod
+    def _extract_source_name(entry: Any) -> Optional[str]:
+        """Extract the publisher name from a Google News entry, guarding misses."""
+        source = entry.get("source")
+        if isinstance(source, dict):
+            name = source.get("title")
+            if name:
+                return str(name).strip()
+        # feedparser may expose source as an attribute-bearing object.
+        title = getattr(source, "title", None)
+        if title:
+            return str(title).strip()
+        return None
+
+    @staticmethod
+    def _parse_date(entry: Any) -> Optional[datetime]:
+        """Parse the publication date of an entry into aware UTC."""
+        for field in ["published", "updated", "created"]:
+            if field in entry:
+                try:
+                    parsed = entry.get(f"{field}_parsed")
+                    if parsed:
+                        return datetime.fromtimestamp(
+                            calendar.timegm(parsed), tz=timezone.utc
+                        )
+                    return parsedate_to_datetime(entry[field])
+                except Exception:
+                    continue
+        return None
+
+    @staticmethod
+    def _extract_content(entry: Any) -> Optional[str]:
+        """Extract text content from a Google News entry, if any."""
+        if "summary" in entry:
+            return entry.summary
+        if "description" in entry:
+            return entry.description
+        content = entry.get("content")
+        if content:
+            try:
+                return content[0].get("value", "")
+            except Exception:
+                return None
+        return None
+
+    @staticmethod
+    def _ensure_utc(moment: datetime) -> datetime:
+        if moment.tzinfo is None:
+            return moment.replace(tzinfo=timezone.utc)
+        return moment.astimezone(timezone.utc)

--- a/tests/test_gdelt.py
+++ b/tests/test_gdelt.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+
+from src.models import GDELTConfig
+from src.scrapers.gdelt import GDELTScraper
+
+
+SINCE = datetime(2026, 6, 27, 8, 30, 0, tzinfo=timezone.utc)
+
+
+def _mock_client(payload: dict | None = None) -> AsyncMock:
+    response = MagicMock()
+    response.json.return_value = payload if payload is not None else {}
+    response.raise_for_status.return_value = None
+    client = AsyncMock()
+    client.get.return_value = response
+    return client
+
+
+def _articles_payload() -> dict:
+    return {
+        "articles": [
+            {
+                "url": "https://example.com/ai-1",
+                "title": "AI breakthrough one",
+                "seendate": "20260628T120000Z",
+                "domain": "example.com",
+                "sourcecountry": "United States",
+                "language": "English",
+                "socialimage": "https://example.com/img1.jpg",
+            },
+            {
+                "url": "https://news.test/ai-2",
+                "title": "AI breakthrough two",
+                "seendate": "20260628T130000Z",
+                "domain": "news.test",
+                "sourcecountry": "United Kingdom",
+                "language": "English",
+            },
+        ]
+    }
+
+
+def test_time_window_uses_startdatetime_when_no_timespan() -> None:
+    client = _mock_client(_articles_payload())
+    config = GDELTConfig(enabled=True, query="ai")
+    scraper = GDELTScraper(config, client)
+
+    asyncio.run(scraper.fetch(SINCE))
+
+    params = client.get.call_args.kwargs["params"]
+    assert params["startdatetime"] == SINCE.strftime("%Y%m%d%H%M%S")
+    assert "enddatetime" in params
+    assert "timespan" not in params
+
+
+def test_time_window_uses_timespan_when_set() -> None:
+    client = _mock_client(_articles_payload())
+    config = GDELTConfig(enabled=True, query="ai", timespan="24h")
+    scraper = GDELTScraper(config, client)
+
+    asyncio.run(scraper.fetch(SINCE))
+
+    params = client.get.call_args.kwargs["params"]
+    assert params["timespan"] == "24h"
+    assert "startdatetime" not in params
+    assert "enddatetime" not in params
+
+
+def test_language_and_country_appended_to_query() -> None:
+    client = _mock_client(_articles_payload())
+    config = GDELTConfig(
+        enabled=True, query="ai", language="english", country="US"
+    )
+    scraper = GDELTScraper(config, client)
+
+    asyncio.run(scraper.fetch(SINCE))
+
+    params = client.get.call_args.kwargs["params"]
+    assert params["query"] == "ai sourcelang:english sourcecountry:US"
+
+
+def test_parses_articles_into_content_items() -> None:
+    client = _mock_client(_articles_payload())
+    config = GDELTConfig(enabled=True, query="ai")
+    scraper = GDELTScraper(config, client)
+
+    items = asyncio.run(scraper.fetch(SINCE))
+
+    assert len(items) == 2
+    first = items[0]
+    assert str(first.url) == "https://example.com/ai-1"
+    assert first.title == "AI breakthrough one"
+    assert first.published_at == datetime(2026, 6, 28, 12, 0, 0, tzinfo=timezone.utc)
+    assert first.metadata["domain"] == "example.com"
+    assert first.metadata["sourcecountry"] == "United States"
+    assert first.id.startswith("gdelt:article:")
+
+
+def test_disabled_config_returns_empty() -> None:
+    client = _mock_client(_articles_payload())
+    config = GDELTConfig(enabled=False, query="ai")
+    scraper = GDELTScraper(config, client)
+
+    assert asyncio.run(scraper.fetch(SINCE)) == []
+
+
+def test_http_error_returns_empty() -> None:
+    client = AsyncMock()
+    client.get.side_effect = httpx.HTTPError("boom")
+    config = GDELTConfig(enabled=True, query="ai")
+    scraper = GDELTScraper(config, client)
+
+    assert asyncio.run(scraper.fetch(SINCE)) == []
+
+
+def test_missing_articles_key_returns_empty() -> None:
+    client = _mock_client({"foo": "bar"})
+    config = GDELTConfig(enabled=True, query="ai")
+    scraper = GDELTScraper(config, client)
+
+    assert asyncio.run(scraper.fetch(SINCE)) == []
+
+
+def test_empty_query_returns_empty() -> None:
+    client = _mock_client(_articles_payload())
+    config = GDELTConfig(enabled=True, query="   ")
+    scraper = GDELTScraper(config, client)
+
+    assert asyncio.run(scraper.fetch(SINCE)) == []
+
+
+def test_bad_article_is_skipped_not_crashing() -> None:
+    payload = {
+        "articles": [
+            {  # missing url -> skipped
+                "title": "No URL",
+                "seendate": "20260628T120000Z",
+                "domain": "example.com",
+            },
+            {  # unparseable seendate -> skipped
+                "url": "https://example.com/bad-date",
+                "title": "Bad date",
+                "seendate": "not-a-date",
+                "domain": "example.com",
+            },
+            {  # valid -> kept
+                "url": "https://example.com/good",
+                "title": "Good one",
+                "seendate": "20260628T140000Z",
+                "domain": "example.com",
+            },
+        ]
+    }
+    client = _mock_client(payload)
+    config = GDELTConfig(enabled=True, query="ai")
+    scraper = GDELTScraper(config, client)
+
+    items = asyncio.run(scraper.fetch(SINCE))
+
+    assert len(items) == 1
+    assert str(items[0].url) == "https://example.com/good"
+
+
+def test_non_json_body_returns_empty() -> None:
+    response = MagicMock()
+    response.json.side_effect = ValueError("no json")
+    response.raise_for_status.return_value = None
+    client = AsyncMock()
+    client.get.return_value = response
+    config = GDELTConfig(enabled=True, query="ai")
+    scraper = GDELTScraper(config, client)
+
+    assert asyncio.run(scraper.fetch(SINCE)) == []

--- a/tests/test_google_news.py
+++ b/tests/test_google_news.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+
+from src.models import GoogleNewsConfig
+from src.scrapers.google_news import GoogleNewsScraper
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _feed(items_xml: str) -> str:
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+    <rss version="2.0"><channel>
+      <title>Google News</title>
+      {items_xml}
+    </channel></rss>
+    """
+
+
+def _item(
+    title: str,
+    link: str,
+    pub: str = "Sat, 27 Jun 2026 12:00:00 GMT",
+    source: str | None = "Publisher",
+) -> str:
+    source_tag = f"<source>{source}</source>" if source is not None else ""
+    return f"""
+      <item>
+        <title>{title}</title>
+        <link>{link}</link>
+        <guid>{link}</guid>
+        <pubDate>{pub}</pubDate>
+        <description>Summary text</description>
+        {source_tag}
+      </item>
+    """
+
+
+def _mock_client(text: str) -> AsyncMock:
+    response = MagicMock()
+    response.text = text
+    response.raise_for_status.return_value = None
+    client = AsyncMock()
+    client.get.return_value = response
+    return client
+
+
+def test_short_window_uses_when_operator() -> None:
+    client = _mock_client(_feed(_item("Foo - Publisher", "https://example.com/a")))
+    config = GoogleNewsConfig(enabled=True, query="ai")
+    scraper = GoogleNewsScraper(config, client)
+
+    since = _now() - timedelta(hours=24)
+    asyncio.run(scraper.fetch(since))
+
+    q = client.get.call_args.kwargs["params"]["q"]
+    assert "when:" in q
+    assert q.endswith("h")
+    assert q.startswith("ai ")
+
+
+def test_long_window_uses_after_operator() -> None:
+    client = _mock_client(_feed(_item("Foo - Publisher", "https://example.com/a")))
+    config = GoogleNewsConfig(enabled=True, query="ai")
+    scraper = GoogleNewsScraper(config, client)
+
+    since = _now() - timedelta(days=30)
+    asyncio.run(scraper.fetch(since))
+
+    q = client.get.call_args.kwargs["params"]["q"]
+    assert "after:" in q
+    assert "when:" not in q
+
+
+def test_ceid_defaults_when_unset() -> None:
+    client = _mock_client(_feed(_item("Foo - Publisher", "https://example.com/a")))
+    config = GoogleNewsConfig(enabled=True, query="ai", language="en", country="US")
+    scraper = GoogleNewsScraper(config, client)
+
+    asyncio.run(scraper.fetch(_now() - timedelta(hours=6)))
+
+    params = client.get.call_args.kwargs["params"]
+    assert params["ceid"] == "US:en"
+    assert params["hl"] == "en"
+    assert params["gl"] == "US"
+
+
+def test_parses_feed_into_content_items() -> None:
+    items_xml = _item(
+        "Headline One - Publisher",
+        "https://example.com/a",
+        pub="Sat, 27 Jun 2026 12:00:00 GMT",
+    ) + _item(
+        "Headline Two - Other",
+        "https://example.com/b",
+        pub="Sat, 27 Jun 2026 13:00:00 GMT",
+        source="Other",
+    )
+    client = _mock_client(_feed(items_xml))
+    config = GoogleNewsConfig(enabled=True, query="ai")
+    scraper = GoogleNewsScraper(config, client)
+
+    items = asyncio.run(scraper.fetch(_now() - timedelta(days=365)))
+
+    assert len(items) == 2
+    first = items[0]
+    assert first.title == "Headline One - Publisher"
+    assert str(first.url) == "https://example.com/a"
+    assert first.published_at == datetime(2026, 6, 27, 12, 0, 0, tzinfo=timezone.utc)
+    assert first.id.startswith("google_news:article:")
+    assert first.metadata["gn_query"] == "ai"
+    assert first.metadata["source_name"] == "Publisher"
+
+
+def test_disabled_config_returns_empty() -> None:
+    client = _mock_client(_feed(_item("Foo", "https://example.com/a")))
+    config = GoogleNewsConfig(enabled=False, query="ai")
+    scraper = GoogleNewsScraper(config, client)
+
+    assert asyncio.run(scraper.fetch(_now())) == []
+
+
+def test_empty_query_returns_empty() -> None:
+    client = _mock_client(_feed(_item("Foo", "https://example.com/a")))
+    config = GoogleNewsConfig(enabled=True, query="   ")
+    scraper = GoogleNewsScraper(config, client)
+
+    assert asyncio.run(scraper.fetch(_now())) == []
+
+
+def test_http_error_returns_empty() -> None:
+    client = AsyncMock()
+    client.get.side_effect = httpx.HTTPError("boom")
+    config = GoogleNewsConfig(enabled=True, query="ai")
+    scraper = GoogleNewsScraper(config, client)
+
+    assert asyncio.run(scraper.fetch(_now())) == []
+
+
+def test_empty_feed_returns_empty() -> None:
+    client = _mock_client(_feed(""))
+    config = GoogleNewsConfig(enabled=True, query="ai")
+    scraper = GoogleNewsScraper(config, client)
+
+    assert asyncio.run(scraper.fetch(_now())) == []
+
+
+def test_entry_missing_link_or_title_is_skipped() -> None:
+    items_xml = (
+        _item("", "https://example.com/no-title")  # missing title
+        + "<item><title>No link</title><pubDate>Sat, 27 Jun 2026 12:00:00 GMT</pubDate></item>"
+        + _item("Good - Publisher", "https://example.com/good")
+    )
+    client = _mock_client(_feed(items_xml))
+    config = GoogleNewsConfig(enabled=True, query="ai")
+    scraper = GoogleNewsScraper(config, client)
+
+    items = asyncio.run(scraper.fetch(_now() - timedelta(days=365)))
+
+    assert len(items) == 1
+    assert str(items[0].url) == "https://example.com/good"
+
+
+def test_max_results_cap() -> None:
+    items_xml = "".join(
+        _item(f"Item {i} - Pub", f"https://example.com/{i}") for i in range(5)
+    )
+    client = _mock_client(_feed(items_xml))
+    config = GoogleNewsConfig(enabled=True, query="ai", max_results=2)
+    scraper = GoogleNewsScraper(config, client)
+
+    items = asyncio.run(scraper.fetch(_now() - timedelta(days=365)))
+
+    assert len(items) == 2


### PR DESCRIPTION

## Summary

Add two **key-less** news scrapers wired into the Horizon pipeline so global and
publisher news flow through the existing dedup → scoring → enrichment stages like
any other source — no API keys, no quota, no new dependencies.

- **GDELTScraper** — pulls recent global news from the key-less GDELT 2.0 DOC API,
  mapping articles to `ContentItem`s.
- **GoogleNewsScraper** — pulls articles from the key-less Google News RSS search
  endpoint, deriving the time window via `when:Nh` (≤100h) or `after:YYYY-MM-DD`
  operators and extracting the publisher name.

Both sources are **opt-in** (`enabled=False` by default), so existing runs are
unaffected.

## Scope

- [x] This PR contains **one feature / one fix / one focused change**
- [x] This PR does **not** combine multiple unrelated features

## Changes

- **`src/scrapers/gdelt.py`** (new) — `GDELTScraper(BaseScraper)`. Hits the GDELT 2.0
  DOC API (`mode=ArtList`, `format=json`) using the injected `httpx` client; maps the
  `since` window to `startdatetime`/`enddatetime` (`YYYYMMDDHHMMSS` UTC), with optional
  `timespan` taking precedence; maps articles → `ContentItem` (url, title,
  `seendate`→`published_at`, domain/sourcecountry/language metadata).
- **`src/scrapers/google_news.py`** (new) — `GoogleNewsScraper(BaseScraper)`. Builds
  Google News RSS search URLs (`hl`/`gl`/`ceid`) with a `when:Nh` / `after:` time
  operator derived from `since`; parses with `feedparser` (existing dep); extracts the
  publisher name; capped ~100 results.
- **`src/models.py`** — new `SourceType.GDELT` / `SourceType.GOOGLE_NEWS`; new
  `GDELTConfig` / `GoogleNewsConfig` models registered as `Optional[...] = None` on
  `SourcesConfig` (mirrors `openbb`/`twitter`).
- **`src/orchestrator.py`** — imports, `enabled`-gated registration in
  `fetch_all_sources`, and `_sub_source_label` branches (GDELT domain / Google News
  publisher).
- **`data/config.example.json`** — disabled-by-default `gdelt` and `google_news`
  stanzas.
- **`tests/test_gdelt.py` / `tests/test_google_news.py`** — 20 new tests (10 each,
  fully mocked; no live network).

## Notes for Reviewers

- **No scraper-local dedup** — relies on the orchestrator's existing URL normalization
  + AI topic dedup.
- **Failure isolation** — both `fetch()` methods wrap network/parse errors and return
  `[]`, and guard per-record parsing, consistent with the orchestrator's
  `asyncio.gather(return_exceptions=True)` contract.
- **Dependency injection honored** — neither scraper constructs its own `httpx` client;
  both use the injected `self.client`.
- Validate against live responses if possible: GDELT field names
  (`url`/`title`/`seendate`/`domain`/`sourcecountry`) and Google News publisher
  extraction (`entry.source.title`) are covered by **mocked** tests only.
- The Google News time-operator cutover (`when:Nh` for ≤100h, else `after:YYYY-MM-DD`)
  is a deterministic heuristic — confirm it matches desired windowing.
- Out of scope (deferred): the 5 keyed services (NewsAPI, Exa, APITube, Mediastack,
  NewsData); no docs or scripts changes.

## Checklist

- [x] I explained the change clearly
- [x] I kept the PR focused and easy to review
- [x] I tested the change locally when applicable — `uv run --extra dev pytest` → **281 passed** (+20 new)
