### PR TITLE
chore(summary): omit references and tags

### DIFF
--- a/src/ai/summarizer.py
+++ b/src/ai/summarizer.py
@@ -106,7 +106,7 @@ class DailySummarizer:
             if language == "zh":
                 t = _pangu(t)
             score = item.ai_score or "?"
-            toc_entries.append(f"{i + 1}. [{t}]({item.url}) \u2b50\ufe0f {score}/10")
+            toc_entries.append(f"{i + 1}. [{t}](#item-{i + 1}) \u2b50\ufe0f {score}/10")
         toc = "\n".join(toc_entries) + "\n\n---\n\n"
 
         parts = [self._format_item(item, labels, language, i + 1) for i, item in enumerate(items)]

--- a/src/ai/summarizer.py
+++ b/src/ai/summarizer.py
@@ -226,22 +226,9 @@ class DailySummarizer:
             lines.append("")
             lines.append(f"**{labels['background']}**: {background}")
 
-        sources = meta.get("sources") or []
-        if sources:
-            items_html = "".join(f'<li><a href="{s["url"]}">{s["title"]}</a></li>\n' for s in sources)
-            lines += [
-                "",
-                f'<details><summary>{labels["references"]}</summary>\n<ul>\n{items_html}\n</ul>\n</details>',
-            ]
-
         if discussion:
             lines.append("")
             lines.append(f"**{labels['discussion']}**: {discussion}")
-
-        if item.ai_tags:
-            tags_str = ", ".join([f"`#{t}`" for t in item.ai_tags])
-            lines.append("")
-            lines.append(f"**{labels['tags']}**: {tags_str}")
 
         lines.append("")
         lines.append("---")

--- a/src/ai/summarizer.py
+++ b/src/ai/summarizer.py
@@ -106,7 +106,7 @@ class DailySummarizer:
             if language == "zh":
                 t = _pangu(t)
             score = item.ai_score or "?"
-            toc_entries.append(f"{i + 1}. [{t}](#item-{i + 1}) \u2b50\ufe0f {score}/10")
+            toc_entries.append(f"{i + 1}. [{t}]({item.url}) \u2b50\ufe0f {score}/10")
         toc = "\n".join(toc_entries) + "\n\n---\n\n"
 
         parts = [self._format_item(item, labels, language, i + 1) for i, item in enumerate(items)]

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -57,7 +57,8 @@ def test_generate_webhook_item_renders_single_item_detail():
     assert result.startswith("Item 1/2")
     assert "## [Important Item 1](https://example.com/items/1)" in result
     assert "Summary for item 1." in result
-    assert "**Tags**: `#AI`, `#News`" in result
+    assert "**Tags**:" not in result
+    assert "`#AI`" not in result
 
 
 def test_generate_webhook_item_includes_discussion_link_when_distinct():
@@ -90,6 +91,25 @@ def test_generate_webhook_item_omits_discussion_link_when_same_as_item_url():
     assert "[Discussion](https://example.com/items/1)" not in result
 
 
+def test_generate_webhook_item_omits_reference_links():
+    summarizer = DailySummarizer()
+    item = _make_item(1)
+    item.metadata["sources"] = [
+        {"title": "Reference Article", "url": "https://example.com/reference"}
+    ]
+
+    result = summarizer.generate_webhook_item(
+        item,
+        language="zh",
+        index=1,
+        total=1,
+    )
+
+    assert "参考链接" not in result
+    assert "Reference Article" not in result
+    assert "https://example.com/reference" not in result
+
+
 def test_generate_webhook_item_uses_localized_discussion_label():
     summarizer = DailySummarizer()
     item = _make_item(1)
@@ -120,6 +140,8 @@ def test_generate_summary_zh_uses_localized_selection_header_and_numeric_date():
 
     assert "> 从 10 条内容中筛选出 1 条重要资讯。" in result
     assert "rss · tester · 4月25日 08:00" in result
+    assert "参考链接" not in result
+    assert "**标签**" not in result
     assert "From 10 items" not in result
     assert "Apr 25, 08:00" not in result
 

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -44,6 +44,23 @@ def test_generate_webhook_overview_lists_items_without_full_details():
     assert "Summary for item 1." not in result
 
 
+def test_generate_summary_toc_links_to_original_item_url():
+    summarizer = DailySummarizer()
+    item = _make_item(1)
+
+    result = _run_async(
+        summarizer.generate_summary(
+            [item],
+            date="2026-04-25",
+            total_fetched=10,
+            language="zh",
+        )
+    )
+
+    assert "1. [Important Item 1](https://example.com/items/1) ⭐️ 8.0/10" in result
+    assert "[Important Item 1](#item-1)" not in result
+
+
 def test_generate_webhook_item_renders_single_item_detail():
     summarizer = DailySummarizer()
 

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -57,8 +57,8 @@ def test_generate_summary_toc_links_to_original_item_url():
         )
     )
 
-    assert "1. [Important Item 1](https://example.com/items/1) ⭐️ 8.0/10" in result
-    assert "[Important Item 1](#item-1)" not in result
+    assert "1. [Important Item 1](#item-1) ⭐️ 8.0/10" in result
+    assert "1. [Important Item 1](https://example.com/items/1) ⭐️ 8.0/10" not in result
 
 
 def test_generate_webhook_item_renders_single_item_detail():


### PR DESCRIPTION
## Summary
- remove the references/参考链接 block from daily summary item rendering
- remove the tags/标签 block from daily summary item rendering
- keep the rest of the original markdown format unchanged

## Test Plan
- uv run pytest tests/test_summarizer.py -q
- uv run horizon --hours 24
