### PR TITLE
Add auditable run artifacts and Twitter List support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# Horizon
+
+## What this is
+Horizon is a configurable content aggregation and summarization pipeline that fetches source items, analyzes them with an AI model, filters by importance/category, and emits daily summaries.
+
+## Setup
+Use `uv sync` to install the project environment, provide runtime credentials through environment variables rather than config secrets, then run tests with `uv run pytest` before changing behavior.
+
+## How it works
+Scrapers emit `ContentItem` records, the orchestrator merges and analyzes them, `StorageManager` persists summaries and auditable run artifacts, and optional delivery integrations send the resulting digest.
+
+## Lessons / gotchas
+Keep user-specific source choices, private list IDs, cookies, and curation preferences in local config; keep upstreamable code changes generic, small, isolated, and covered by tests to reduce rebase conflicts.

--- a/src/ai/analyzer.py
+++ b/src/ai/analyzer.py
@@ -41,6 +41,14 @@ class ContentAnalyzer:
         concurrency = getattr(config, "analysis_concurrency", 1)
         return max(concurrency, 1)
 
+    def _get_system_prompt(self) -> str:
+        """Return the base analysis prompt plus optional config-provided focus."""
+        config = getattr(self.client, "config", None)
+        focus = getattr(config, "curation_focus", None)
+        if not focus:
+            return CONTENT_ANALYSIS_SYSTEM
+        return f"{CONTENT_ANALYSIS_SYSTEM}\n\nAdditional curation focus:\n{focus.strip()}"
+
     async def analyze_batch(self, items: List[ContentItem]) -> List[ContentItem]:
         throttle_sec = self._get_throttle_sec()
         concurrency = self._get_concurrency()
@@ -141,7 +149,7 @@ class ContentAnalyzer:
 
         # Get AI completion
         response = await self.client.complete(
-            system=CONTENT_ANALYSIS_SYSTEM,
+            system=self._get_system_prompt(),
             user=user_prompt,
         )
 

--- a/src/ai/summarizer.py
+++ b/src/ai/summarizer.py
@@ -21,6 +21,7 @@ LABELS = {
     "en": {
         "header": "Horizon Daily",
         "source": "Source",
+        "source_short": "source",
         "original": "Original",
         "background": "Background",
         "discussion": "Discussion",
@@ -42,6 +43,7 @@ LABELS = {
     "zh": {
         "header": "Horizon 每日速递",
         "source": "来源",
+        "source_short": "来源",
         "original": "原文",
         "background": "背景",
         "discussion": "社区讨论",
@@ -108,7 +110,10 @@ class DailySummarizer:
             if language == "zh":
                 t = _pangu(t)
             score = item.ai_score or "?"
-            toc_entries.append(f"{i + 1}. [{t}](#item-{i + 1}) \u2b50\ufe0f {score}/10")
+            toc_entries.append(
+                f"{i + 1}. [{t}](#item-{i + 1}) · "
+                f"{labels['source_short']}: {self._source_label(item)} ⭐️ {score}/10"
+            )
         toc = "\n".join(toc_entries) + "\n\n---\n\n"
 
         parts = [self._format_item(item, labels, language, i + 1) for i, item in enumerate(items)]
@@ -220,7 +225,7 @@ class DailySummarizer:
 
         lines = [
             f'<a id="item-{index}"></a>',
-            f"## [{title}]({url}) \u2b50\ufe0f {score}/10",  # ⭐️
+            f"## [{title}]({url}) · {labels['source_short']}: {self._source_label(item)} ⭐️ {score}/10",  # ⭐️
             "",
             summary,
             "",
@@ -252,6 +257,16 @@ class DailySummarizer:
         lines.append("---")
 
         return "\n".join(lines) + "\n\n"
+
+    def _source_label(self, item: ContentItem) -> str:
+        """Compact source label shown next to item titles."""
+        meta = item.metadata
+        parts = [item.source_type.value]
+        if meta.get("subreddit"):
+            parts.append(f"r/{meta['subreddit']}")
+        elif meta.get("feed_name"):
+            parts.append(str(meta["feed_name"]))
+        return " / ".join(parts)
 
     def _generate_empty_summary(self, date: str, total_fetched: int, labels: dict) -> str:
         """Generate summary when no high-scoring items were found."""

--- a/src/ai/summarizer.py
+++ b/src/ai/summarizer.py
@@ -21,6 +21,7 @@ LABELS = {
     "en": {
         "header": "Horizon Daily",
         "source": "Source",
+        "original": "Original",
         "background": "Background",
         "discussion": "Discussion",
         "references": "References",
@@ -41,6 +42,7 @@ LABELS = {
     "zh": {
         "header": "Horizon 每日速递",
         "source": "来源",
+        "original": "原文",
         "background": "背景",
         "discussion": "社区讨论",
         "references": "参考链接",
@@ -205,7 +207,10 @@ class DailySummarizer:
             else:
                 day = item.published_at.strftime("%d").lstrip("0")
                 source_parts.append(item.published_at.strftime(f"%b {day}, %H:%M"))
-        source_line = " \u00b7 ".join(source_parts)  # ·
+        source_line = (
+            f"**{labels['source']}**: [{labels['original']}]({url})"
+            f" · {' · '.join(source_parts)}"
+        )
 
         discussion_url = meta.get("discussion_url")
         if discussion_url:

--- a/src/models.py
+++ b/src/models.py
@@ -421,7 +421,7 @@ class FilteringConfig(BaseModel):
     max_items: Optional[int] = Field(default=None, gt=0)
     category_groups: Dict[str, CategoryGroupConfig] = Field(default_factory=dict)
     default_group: str = "other"
-    default_group_limit: Optional[int] = Field(default=None, gt=0)
+    default_group_limit: Optional[int] = Field(default=None, ge=0)
 
 
 class Config(BaseModel):

--- a/src/models.py
+++ b/src/models.py
@@ -132,6 +132,9 @@ class HackerNewsConfig(BaseModel):
     enabled: bool = True
     fetch_top_stories: int = 30
     min_score: int = 100
+    include_keywords: List[str] = Field(default_factory=list)
+    exclude_keywords: List[str] = Field(default_factory=list)
+    category: Optional[str] = None
 
 
 class RSSSourceConfig(BaseModel):
@@ -154,6 +157,7 @@ class RedditSubredditConfig(BaseModel):
     )
     fetch_limit: int = 25
     min_score: int = 10
+    category: Optional[str] = None
 
 
 class RedditUserConfig(BaseModel):
@@ -163,6 +167,7 @@ class RedditUserConfig(BaseModel):
     enabled: bool = True
     sort: str = "new"
     fetch_limit: int = 10
+    category: Optional[str] = None
 
 
 class RedditConfig(BaseModel):
@@ -267,6 +272,7 @@ class OSSInsightConfig(BaseModel):
     keywords: List[str] = Field(default_factory=list)
     min_stars: int = 5
     max_items: int = 30
+    category: Optional[str] = None
 
 
 class GDELTConfig(BaseModel):

--- a/src/models.py
+++ b/src/models.py
@@ -110,6 +110,7 @@ class AIConfig(BaseModel):
     analysis_concurrency: int = 1
     enrichment_concurrency: int = 1
     languages: List[str] = Field(default_factory=lambda: ["en"])
+    curation_focus: Optional[str] = None
     # Azure OpenAI specific; required when provider == AZURE
     azure_endpoint_env: Optional[str] = None
     api_version: Optional[str] = None
@@ -210,6 +211,8 @@ class TwitterConfig(BaseModel):
     # Playwright settings (used when mode == "playwright")
     cookie_dir: str = "data"
     cookie_file_pattern: str = "x_cookies_*.json"
+    list_id: Optional[str] = None  # X/Twitter List ID; when set, scrape this list timeline only
+    category: Optional[str] = None  # Category assigned to emitted Twitter items for digest grouping
 
 
 class OpenBBWatchlist(BaseModel):

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -62,6 +62,21 @@ class HorizonOrchestrator:
             else None
         )
 
+    def _run_id(self) -> str:
+        """Return a stable filesystem-safe UTC run identifier."""
+        return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
+
+    def _save_run_artifact(self, run_id: str, stage: str, items: List[ContentItem]) -> None:
+        """Best-effort persistence of intermediate run stages."""
+        saver = getattr(self.storage, "save_run_artifact", None)
+        if not saver:
+            return
+        try:
+            path = saver(run_id, stage, items)
+            self.console.print(f"   [dim]Saved {stage} artifact: {path}[/dim]")
+        except Exception as exc:
+            self.console.print(f"[yellow]Warning: could not save {stage} artifact: {exc}[/yellow]")
+
     async def run(self, force_hours: int = None) -> None:
         """Execute the complete workflow.
 
@@ -83,10 +98,12 @@ class HorizonOrchestrator:
         try:
             # 1. Determine time window
             since = self._determine_time_window(force_hours)
+            run_id = self._run_id()
             self.console.print(f"📅 Fetching content since: {since.strftime('%Y-%m-%d %H:%M:%S')}\n")
 
             # 2. Fetch content from all sources
             all_items = await self.fetch_all_sources(since)
+            self._save_run_artifact(run_id, "raw", all_items)
             self.console.print(f"📥 Fetched {len(all_items)} items from all sources\n")
 
             if not all_items:
@@ -95,6 +112,7 @@ class HorizonOrchestrator:
 
             # 3. Merge cross-source duplicates (same URL from different sources)
             merged_items = self.merge_cross_source_duplicates(all_items)
+            self._save_run_artifact(run_id, "merged", merged_items)
             if len(merged_items) < len(all_items):
                 self.console.print(
                     f"🔗 Merged {len(all_items) - len(merged_items)} cross-source duplicates "
@@ -103,6 +121,7 @@ class HorizonOrchestrator:
 
             # 4. Analyze with AI
             analyzed_items = await self._analyze_content(merged_items)
+            self._save_run_artifact(run_id, "analyzed", analyzed_items)
             self.console.print(f"🤖 Analyzed {len(analyzed_items)} items with AI\n")
 
             # 5. Filter by score threshold
@@ -111,6 +130,12 @@ class HorizonOrchestrator:
                 item for item in analyzed_items
                 if item.ai_score and item.ai_score >= threshold
             ]
+            rejected_items = [
+                item for item in analyzed_items
+                if not item.ai_score or item.ai_score < threshold
+            ]
+            self._save_run_artifact(run_id, "important", important_items)
+            self._save_run_artifact(run_id, "rejected", rejected_items)
             important_items.sort(key=lambda x: x.ai_score or 0, reverse=True)
 
             self.console.print(
@@ -132,6 +157,7 @@ class HorizonOrchestrator:
             # 5.7 Apply per-category and global digest limits before enrichment
             balanced_result = self.apply_balanced_digest(important_items)
             important_items = balanced_result.items
+            self._save_run_artifact(run_id, "selected", important_items)
 
             # Show per-sub-source selection breakdown
             selected_counts: Dict[str, int] = defaultdict(int)

--- a/src/scrapers/hackernews.py
+++ b/src/scrapers/hackernews.py
@@ -21,7 +21,10 @@ class HackerNewsScraper(BaseScraper):
 
     def __init__(self, config: HackerNewsConfig, http_client: httpx.AsyncClient):
         super().__init__(config.model_dump(), http_client)
+        self.hn_config = config
         self.base_url = "https://hacker-news.firebaseio.com/v0"
+        self._include_keywords = [kw.lower() for kw in config.include_keywords if kw]
+        self._exclude_keywords = [kw.lower() for kw in config.exclude_keywords if kw]
 
     async def fetch(self, since: datetime) -> List[ContentItem]:
         if not self.config.get("enabled", True):
@@ -53,6 +56,8 @@ class HackerNewsScraper(BaseScraper):
                     continue
                 published_at = datetime.fromtimestamp(story["time"], tz=timezone.utc)
                 if published_at < since:
+                    continue
+                if not self._matches_filters(story):
                     continue
                 valid_stories.append(story)
                 # Queue comment fetching
@@ -124,6 +129,19 @@ class HackerNewsScraper(BaseScraper):
         content = "\n\n".join(parts)
         hn_discussion_url = f"https://news.ycombinator.com/item?id={story_id}"
 
+        metadata = {
+            "score": story.get("score", 0),
+            "descendants": story.get("descendants", 0),
+            "type": story.get("type", "story"),
+            "discussion_url": hn_discussion_url,
+            "comment_count": len(comments),
+        }
+        if self.hn_config.category:
+            metadata["category"] = self.hn_config.category
+        matched_keywords = self._matched_keywords(story)
+        if matched_keywords:
+            metadata["matched_keywords"] = matched_keywords
+
         return ContentItem(
             id=self._generate_id("hackernews", "story", str(story_id)),
             source_type=SourceType.HACKERNEWS,
@@ -132,11 +150,26 @@ class HackerNewsScraper(BaseScraper):
             content=content,
             author=author,
             published_at=published_at,
-            metadata={
-                "score": story.get("score", 0),
-                "descendants": story.get("descendants", 0),
-                "type": story.get("type", "story"),
-                "discussion_url": hn_discussion_url,
-                "comment_count": len(comments),
-            }
+            metadata=metadata,
         )
+
+    def _story_haystack(self, story: dict) -> str:
+        """Return lower-cased story fields used for configured keyword filters."""
+        return " ".join(
+            str(story.get(key) or "").lower()
+            for key in ("title", "url", "text")
+        )
+
+    def _matched_keywords(self, story: dict) -> list[str]:
+        """Configured include keywords that matched this story."""
+        haystack = self._story_haystack(story)
+        return sorted({kw for kw in self._include_keywords if kw in haystack})
+
+    def _matches_filters(self, story: dict) -> bool:
+        """Apply optional include/exclude keyword filters before comment fetching."""
+        haystack = self._story_haystack(story)
+        if self._exclude_keywords and any(kw in haystack for kw in self._exclude_keywords):
+            return False
+        if self._include_keywords and not any(kw in haystack for kw in self._include_keywords):
+            return False
+        return True

--- a/src/scrapers/ossinsight.py
+++ b/src/scrapers/ossinsight.py
@@ -4,11 +4,12 @@ Fetches star-gain rankings from api.ossinsight.io and emits them as
 ContentItems. An optional keyword filter narrows results to repos whose
 description, repo name, or collection names match at least one configured
 substring (case-insensitive). Without keywords, all trending repos in the
-configured languages flow through.
+configured languages flow through. If OSS Insight is unavailable, falls back
+to GitHub repository search so the OSS bucket can still receive candidates.
 """
 
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import Any, List, Optional, cast
 
 import httpx
 
@@ -20,6 +21,7 @@ class OSSInsightScraper(BaseScraper):
     """Scraper for OSS Insight trending repositories endpoint."""
 
     BASE_URL = "https://api.ossinsight.io/v1/trends/repos"
+    GITHUB_SEARCH_URL = "https://api.github.com/search/repositories"
 
     def __init__(self, config: OSSInsightConfig, http_client: httpx.AsyncClient):
         """Initialize scraper.
@@ -42,6 +44,8 @@ class OSSInsightScraper(BaseScraper):
 
         for lang in self.cfg.languages:
             rows = await self._fetch_period(self.cfg.period, lang)
+            if not rows:
+                rows = await self._fetch_github_search(lang, since)
             for row in rows:
                 item = self._row_to_item(row, lang)
                 if item is None:
@@ -77,8 +81,66 @@ class OSSInsightScraper(BaseScraper):
         rows = data.get("rows") or []
         return rows
 
+    async def _fetch_github_search(self, language: str, since: datetime) -> List[dict]:
+        """Fallback to GitHub repository search when OSS Insight is unavailable."""
+        # GitHub Search rejects queries with more than five boolean operators.
+        # Query a few compact keyword chunks instead of one huge OR clause.
+        keywords = [kw for kw in (self.cfg.keywords or ["AI", "LLM", "agent"]) if kw]
+        keyword_chunks = [keywords[i : i + 5] for i in range(0, min(len(keywords), 10), 5)]
+        created_since = since.date().isoformat()
+        rows = []
+        seen: set[int] = set()
+        for chunk in keyword_chunks:
+            query_parts = [
+                " OR ".join(chunk),
+                "in:name,description",
+                f"stars:>={max(self.cfg.min_stars, 1)}",
+                f"created:>={created_since}",
+            ]
+            if language and language.lower() != "all":
+                query_parts.append(f"language:{language}")
+
+            try:
+                response = await self.client.get(
+                    self.GITHUB_SEARCH_URL,
+                    params={
+                        "q": " ".join(query_parts),
+                        "sort": "stars",
+                        "order": "desc",
+                        "per_page": min(max(self.cfg.max_items, 1), 30),
+                    },
+                    headers={"Accept": "application/vnd.github+json", "User-Agent": "Horizon/1.0"},
+                    timeout=20.0,
+                )
+                response.raise_for_status()
+            except httpx.HTTPError:
+                continue
+
+            payload = response.json()
+            for repo in payload.get("items") or []:
+                repo_id = repo.get("id")
+                if not repo_id or repo_id in seen:
+                    continue
+                seen.add(repo_id)
+                rows.append({
+                    "repo_id": repo_id,
+                    "repo_name": repo.get("full_name"),
+                    "html_url": repo.get("html_url"),
+                    "description": repo.get("description") or "",
+                    "stars": repo.get("stargazers_count", 0),
+                    "forks": repo.get("forks_count", 0),
+                    "pushes": 0,
+                    "pull_requests": 0,
+                    "primary_language": repo.get("language") or language,
+                    "collection_names": "GitHub search fallback",
+                    "fallback": "github_search",
+                    "pushed_at": repo.get("pushed_at"),
+                    "owner": (repo.get("owner") or {}).get("login"),
+                })
+        return rows
+
     def _row_to_item(self, row: dict, language: str) -> Optional[ContentItem]:
-        """Convert a raw OSS Insight row into a ContentItem."""
+        """Convert a raw OSS Insight/GitHub row into a ContentItem."""
         repo_name = row.get("repo_name")
         repo_id = row.get("repo_id")
         if not repo_name or not repo_id:
@@ -87,18 +149,22 @@ class OSSInsightScraper(BaseScraper):
         stars_gained = self._stars_int(row)
         description = (row.get("description") or "").strip()
         primary_language = row.get("primary_language") or language
+        is_fallback = row.get("fallback") == "github_search"
 
-        title = f"{repo_name} (+{stars_gained}⭐ {self.cfg.period})"
-        url = f"https://github.com/{repo_name}"
+        suffix = "GitHub search fallback" if is_fallback else self.cfg.period
+        title = f"{repo_name} ({stars_gained}⭐ {suffix})"
+        url = row.get("html_url") or f"https://github.com/{repo_name}"
 
         content_lines = [
             f"Trending GitHub repo: {repo_name}",
-            f"Stars gained ({self.cfg.period}): {stars_gained}",
-            f"Forks gained: {row.get('forks', 0)}",
+            f"Stars ({suffix}): {stars_gained}",
+            f"Forks: {row.get('forks', 0)}",
             f"Pushes: {row.get('pushes', 0)}",
             f"Pull requests: {row.get('pull_requests', 0)}",
             f"Language: {primary_language}",
         ]
+        if row.get("pushed_at"):
+            content_lines.append(f"Last pushed: {row['pushed_at']}")
         if description:
             content_lines.append("")
             content_lines.append(description)
@@ -107,26 +173,32 @@ class OSSInsightScraper(BaseScraper):
             content_lines.append("")
             content_lines.append(f"OSS Insight collections: {collections}")
 
+        metadata: dict[str, Any] = {
+            "repo": repo_name,
+            "stars_gained": stars_gained,
+            "forks_gained": self._int(row.get("forks")),
+            "pushes": self._int(row.get("pushes")),
+            "pull_requests": self._int(row.get("pull_requests")),
+            "primary_language": primary_language,
+            "period": self.cfg.period,
+            "collection_names": collections,
+            "description": description,
+        }
+        if self.cfg.category:
+            metadata["category"] = self.cfg.category
+        if is_fallback:
+            metadata["fallback"] = "github_search"
+            metadata["pushed_at"] = row.get("pushed_at")
+
         return ContentItem(
             id=self._generate_id(SourceType.OSSINSIGHT.value, "trending", str(repo_id)),
             source_type=SourceType.OSSINSIGHT,
             title=title,
-            url=url,
+            url=cast(Any, url),
             content="\n".join(content_lines),
-            author=repo_name.split("/")[0] if "/" in repo_name else None,
+            author=row.get("owner") or (repo_name.split("/")[0] if "/" in repo_name else None),
             published_at=datetime.now(timezone.utc),
-            metadata={
-                "repo": repo_name,
-                "stars_gained": stars_gained,
-                "forks_gained": self._int(row.get("forks")),
-                "pushes": self._int(row.get("pushes")),
-                "pull_requests": self._int(row.get("pull_requests")),
-                "primary_language": primary_language,
-                "period": self.cfg.period,
-                "collection_names": collections,
-                "description": description,
-                **({"category": self.cfg.category} if self.cfg.category else {}),
-            },
+            metadata=metadata,
         )
 
     @staticmethod

--- a/src/scrapers/ossinsight.py
+++ b/src/scrapers/ossinsight.py
@@ -125,6 +125,7 @@ class OSSInsightScraper(BaseScraper):
                 "period": self.cfg.period,
                 "collection_names": collections,
                 "description": description,
+                **({"category": self.cfg.category} if self.cfg.category else {}),
             },
         )
 

--- a/src/scrapers/reddit.py
+++ b/src/scrapers/reddit.py
@@ -105,7 +105,7 @@ class RedditScraper(BaseScraper):
             if child.get("kind") == "t3"
         ]
         return await self._process_posts(
-            posts, since, "subreddit", cfg.subreddit, cfg.min_score
+            posts, since, "subreddit", cfg.subreddit, cfg.min_score, cfg.category
         )
 
     async def _fetch_subreddit_rss(
@@ -159,6 +159,7 @@ class RedditScraper(BaseScraper):
                         "flair": None,
                         "discussion_url": link,
                         "fallback": "rss",
+                        **({"category": cfg.category} if cfg.category else {}),
                     },
                 )
             )
@@ -191,7 +192,7 @@ class RedditScraper(BaseScraper):
 
         posts = self._parse_old_reddit_posts(response.text, cfg)
         return await self._process_posts(
-            posts, since, "subreddit-html", cfg.subreddit, cfg.min_score
+            posts, since, "subreddit-html", cfg.subreddit, cfg.min_score, cfg.category
         )
 
     def _parse_old_reddit_posts(
@@ -300,7 +301,7 @@ class RedditScraper(BaseScraper):
             if child.get("kind") == "t3"
         ]
         return await self._process_posts(
-            posts, since, "user", cfg.username, min_score=0
+            posts, since, "user", cfg.username, min_score=0, category=cfg.category
         )
 
     async def _process_posts(
@@ -310,6 +311,7 @@ class RedditScraper(BaseScraper):
         subtype: str,
         source_name: str,
         min_score: int,
+        category: Optional[str] = None,
     ) -> List[ContentItem]:
         valid_posts = []
         comment_tasks = []
@@ -340,7 +342,7 @@ class RedditScraper(BaseScraper):
         for post, comments in zip(valid_posts, all_comments):
             if isinstance(comments, Exception):
                 comments = []
-            item = self._parse_post(post, cast(List[dict], comments), subtype)
+            item = self._parse_post(post, cast(List[dict], comments), subtype, category)
             if item:
                 items.append(item)
         return items
@@ -442,7 +444,7 @@ class RedditScraper(BaseScraper):
         return comments[:fetch_limit]
 
     def _parse_post(
-        self, post: dict, comments: List[dict], subtype: str
+        self, post: dict, comments: List[dict], subtype: str, category: Optional[str] = None
     ) -> Optional[ContentItem]:
         post_id = post["id"]
         title = post.get("title", "")
@@ -493,6 +495,7 @@ class RedditScraper(BaseScraper):
                 "is_self": is_self,
                 "flair": post.get("link_flair_text"),
                 "discussion_url": discussion_url,
+                **({"category": category} if category else {}),
             },
         )
 

--- a/src/scrapers/twitter_list_playwright.py
+++ b/src/scrapers/twitter_list_playwright.py
@@ -1,0 +1,91 @@
+"""X/Twitter List scraping helpers for the Playwright scraper."""
+
+import asyncio
+import logging
+import random
+from datetime import datetime
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+async def scrape_list_timeline(ctx, list_id: str, since: datetime, fetch_limit: int) -> Optional[list[dict]]:
+    """Scrape an X/Twitter List timeline via DOM extraction.
+
+    Returns raw tweet dictionaries compatible with ``TwitterPlaywrightScraper._parse_tweet``.
+    This module is intentionally isolated from the profile scraper so List support can be
+    maintained or upstreamed with a minimal integration hook.
+    """
+    page = await ctx.new_page()
+    all_tweets: list[dict] = []
+    seen_ids: set[str] = set()
+
+    async def route_handler(route):
+        if route.request.resource_type in ("media", "image", "video", "font"):
+            await route.abort()
+        else:
+            await route.continue_()
+
+    await page.route("**/*", route_handler)
+
+    try:
+        await page.goto(f"https://x.com/i/lists/{list_id}", wait_until="domcontentloaded", timeout=30000)
+        await asyncio.sleep(6)
+
+        for scroll_index in range(20):
+            tweets = await page.evaluate(r"""
+                () => {
+                    const results = [];
+                    const articles = document.querySelectorAll('article[data-testid="tweet"]');
+                    articles.forEach(article => {
+                        const link = article.querySelector('a[href*="/status/"]');
+                        const textEl = article.querySelector('[data-testid="tweetText"]');
+                        const timeEl = article.querySelector('time');
+                        const href = link ? link.getAttribute('href') : '';
+                        const match = href.match(/\/(\w+)\/status\/(\d+)/);
+                        const username = match ? match[1] : '';
+                        const tweetId = match ? match[2] : '';
+                        const text = textEl ? textEl.innerText : '';
+                        const timestamp = timeEl ? timeEl.getAttribute('datetime') : '';
+                        if (tweetId && text) results.push({ username, tweetId, text, timestamp });
+                    });
+                    return results;
+                }
+            """)
+
+            for tweet in tweets:
+                tweet_id = tweet["tweetId"]
+                if not tweet_id or tweet_id in seen_ids:
+                    continue
+                seen_ids.add(tweet_id)
+                try:
+                    published_at = datetime.fromisoformat(tweet["timestamp"].replace("Z", "+00:00"))
+                except Exception:
+                    continue
+                if published_at < since:
+                    continue
+                all_tweets.append({
+                    "tweet_id": tweet_id,
+                    "text": tweet["text"],
+                    "datetime": published_at.isoformat(),
+                    "username": tweet.get("username", ""),
+                })
+
+            if len(all_tweets) >= fetch_limit * 10:
+                break
+            await page.evaluate("window.scrollBy(0, 1200)")
+            await asyncio.sleep(random.uniform(2, 4))
+            at_bottom = await page.evaluate(
+                "window.innerHeight + window.scrollY >= document.body.scrollHeight - 500"
+            )
+            if at_bottom and scroll_index > 3:
+                break
+
+        logger.info("  -> List %s: %d tweets within window", list_id, len(all_tweets))
+        return all_tweets[: fetch_limit * 10]
+
+    except Exception as exc:
+        logger.warning("Failed to scrape X/Twitter list %s: %s", list_id, exc)
+        return None
+    finally:
+        await page.close()

--- a/src/scrapers/twitter_playwright.py
+++ b/src/scrapers/twitter_playwright.py
@@ -13,6 +13,7 @@ from typing import List, Optional
 
 from ..models import ContentItem, SourceType, TwitterConfig
 from .base import BaseScraper
+from .twitter_list_playwright import scrape_list_timeline
 
 logger = logging.getLogger(__name__)
 
@@ -73,8 +74,12 @@ class TwitterPlaywrightScraper(BaseScraper):
             return []
 
         users = [u.strip().lstrip("@") for u in self.twitter_config.users if u.strip()]
-        if not users:
-            logger.debug("No Twitter users configured, skipping.")
+        list_id = (self.twitter_config.list_id or "").strip()
+        scrape_list = bool(list_id)
+        if scrape_list:
+            logger.info("Scraping X/Twitter list %s", list_id)
+        elif not users:
+            logger.debug("No Twitter users or list configured, skipping.")
             return []
 
         if not PLAYWRIGHT_AVAILABLE:
@@ -141,6 +146,18 @@ class TwitterPlaywrightScraper(BaseScraper):
                 ctx = contexts[context_idx]
                 consecutive_failures = 0
 
+                if scrape_list:
+                    logger.info("Scraping X/Twitter list %s with cookie #%d...", list_id, context_idx + 1)
+                    username = "list"
+                    await asyncio.sleep(random.uniform(3, 6))
+                    tweets = await scrape_list_timeline(ctx, list_id, since, self.twitter_config.fetch_limit)
+                    if tweets is not None:
+                        parsed = [item for item in (self._parse_tweet(t, username) for t in tweets) if item]
+                        async with lock:
+                            all_items.extend(parsed)
+                    return
+
+
                 for username in queue:
                     wait_time = (
                         random.uniform(5.0, 10.0) if not is_retry else random.uniform(10.0, 20.0)
@@ -172,8 +189,11 @@ class TwitterPlaywrightScraper(BaseScraper):
             for i, username in enumerate(users):
                 queues[i % num_contexts].append(username)
 
-            # First pass — all queues in parallel
-            await asyncio.gather(*[process_queue(i, q) for i, q in enumerate(queues)])
+            # First pass — one list scrape, or all configured user queues in parallel.
+            if scrape_list:
+                await process_queue(0, [])
+            else:
+                await asyncio.gather(*[process_queue(i, q) for i, q in enumerate(queues)])
 
             # Retry failed users with a different context
             if failed_users:
@@ -358,6 +378,10 @@ class TwitterPlaywrightScraper(BaseScraper):
             if not text:
                 return None
 
+            # List timelines contain posts from many authors; use the post's real author.
+            if username == "list" and tweet.get("username"):
+                username = tweet["username"]
+
             created_at_raw = tweet.get("datetime", "")
             try:
                 published_at = datetime.fromisoformat(created_at_raw)
@@ -370,6 +394,16 @@ class TwitterPlaywrightScraper(BaseScraper):
             if len(text) > 50:
                 title_body += "..."
 
+            metadata = {
+                "tweet_id": tweet_id,
+                "is_retweet": tweet.get("is_retweet", False),
+                "images": tweet.get("images", []),
+            }
+            if self.twitter_config.category:
+                metadata["category"] = self.twitter_config.category
+            if self.twitter_config.list_id:
+                metadata["list_id"] = self.twitter_config.list_id
+
             return ContentItem(
                 id=self._generate_id(SourceType.TWITTER.value, "tweet", tweet_id),
                 source_type=SourceType.TWITTER,
@@ -378,11 +412,7 @@ class TwitterPlaywrightScraper(BaseScraper):
                 content=text,
                 author=username,
                 published_at=published_at,
-                metadata={
-                    "tweet_id": tweet_id,
-                    "is_retweet": tweet.get("is_retweet", False),
-                    "images": tweet.get("images", []),
-                },
+                metadata=metadata,
             )
         except Exception as exc:
             logger.debug("Failed to parse tweet: %s", exc)

--- a/src/storage/manager.py
+++ b/src/storage/manager.py
@@ -117,6 +117,29 @@ class StorageManager:
 
         return filepath
 
+    def save_run_artifact(self, run_id: str, stage: str, items: list) -> Path:
+        """Persist a run stage as JSONL for auditability.
+
+        Each line is one ContentItem serialized with Pydantic's JSON mode.
+        Re-running the same stage overwrites the file so the artifact reflects
+        the latest state of that stage.
+        """
+        safe_stage = re.sub(r"[^A-Za-z0-9_.-]", "_", stage)
+        run_dir = self.data_dir / "runs" / run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+        filepath = run_dir / f"{safe_stage}.jsonl"
+
+        with open(filepath, "w", encoding="utf-8") as f:
+            for item in items:
+                if hasattr(item, "model_dump"):
+                    row = item.model_dump(mode="json")
+                else:
+                    row = item
+                f.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")))
+                f.write("\n")
+
+        return filepath
+
     def load_subscribers(self) -> list:
         """Loads the list of email subscribers."""
         subscribers_path = self.data_dir / "subscribers.json"

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -94,3 +94,13 @@ def test_analyze_batch_concurrent_preserves_order(monkeypatch):
     result = asyncio.run(analyzer.analyze_batch(items))
 
     assert [item.id for item in result] == [item.id for item in items]
+
+
+def test_system_prompt_appends_optional_curation_focus():
+    client = SimpleNamespace(config=SimpleNamespace(curation_focus="Prioritize AI and quant."))
+    analyzer = ContentAnalyzer(client)
+
+    prompt = analyzer._get_system_prompt()
+
+    assert "Additional curation focus:" in prompt
+    assert "Prioritize AI and quant." in prompt

--- a/tests/test_balanced_digest.py
+++ b/tests/test_balanced_digest.py
@@ -75,6 +75,24 @@ def test_category_groups_apply_limits_and_default_group_limit() -> None:
     assert result.group_counts == {"other": 1, "ai": 2, "finance": 1}
 
 
+def test_default_group_limit_zero_excludes_uncategorized_items() -> None:
+    filtering = FilteringConfig(
+        category_groups={
+            "ai": CategoryGroupConfig(limit=2, categories=["ai"]),
+        },
+        default_group_limit=0,
+    )
+    items = [
+        make_item("hn-off-topic", 9.5, None),
+        make_item("ai-topic", 7.0, "ai"),
+    ]
+
+    result = make_orchestrator(filtering).apply_balanced_digest(items)
+
+    assert [item.id for item in result.items] == ["ai-topic"]
+    assert result.group_counts == {"ai": 1}
+
+
 def test_max_items_applies_after_group_limits() -> None:
     filtering = FilteringConfig(
         max_items=2,
@@ -126,7 +144,6 @@ def test_duplicate_category_warns_and_first_group_wins() -> None:
     "kwargs",
     [
         {"max_items": 0},
-        {"default_group_limit": 0},
         {"category_groups": {"ai": {"limit": 0, "categories": ["ai"]}}},
         {"category_groups": {"ai": {"limit": 1, "categories": []}}},
     ],

--- a/tests/test_hackernews.py
+++ b/tests/test_hackernews.py
@@ -1,0 +1,86 @@
+import asyncio
+from datetime import datetime, timezone
+
+import httpx
+
+from src.models import HackerNewsConfig
+from src.scrapers.hackernews import HackerNewsScraper
+
+
+def _story(story_id: int, title: str, score: int = 100, url: str = "https://example.com") -> dict:
+    return {
+        "id": story_id,
+        "type": "story",
+        "title": title,
+        "url": url,
+        "by": "tester",
+        "time": int(datetime.now(timezone.utc).timestamp()),
+        "score": score,
+        "descendants": 0,
+        "kids": [],
+    }
+
+
+def test_hackernews_include_exclude_filters_and_category() -> None:
+    stories = {
+        1: _story(1, "New LLM inference engine", url="https://example.com/llm"),
+        2: _story(2, "European digital identity policy", url="https://example.com/policy"),
+        3: _story(3, "Generic TypeScript validation pattern", url="https://example.com/ts"),
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/topstories.json"):
+            return httpx.Response(200, json=[1, 2, 3])
+        story_id = int(request.url.path.rsplit("/", 1)[-1].removesuffix(".json"))
+        return httpx.Response(200, json=stories[story_id])
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    scraper = HackerNewsScraper(
+        HackerNewsConfig(
+            enabled=True,
+            fetch_top_stories=3,
+            min_score=1,
+            include_keywords=["LLM", "agent", "inference"],
+            exclude_keywords=["digital identity", "TypeScript validation"],
+            category="ai-news",
+        ),
+        client,
+    )
+
+    items = asyncio.run(scraper.fetch(datetime.now(timezone.utc).replace(year=2020)))
+    asyncio.run(client.aclose())
+
+    assert [item.title for item in items] == ["New LLM inference engine"]
+    assert items[0].metadata["category"] == "ai-news"
+    assert items[0].metadata["matched_keywords"] == ["inference", "llm"]
+
+
+def test_hackernews_without_include_keywords_only_applies_excludes() -> None:
+    stories = {
+        1: _story(1, "Useful AI agents project"),
+        2: _story(2, "Digital identity policy debate"),
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/topstories.json"):
+            return httpx.Response(200, json=[1, 2])
+        story_id = int(request.url.path.rsplit("/", 1)[-1].removesuffix(".json"))
+        return httpx.Response(200, json=stories[story_id])
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    scraper = HackerNewsScraper(
+        HackerNewsConfig(
+            enabled=True,
+            fetch_top_stories=2,
+            min_score=1,
+            exclude_keywords=["digital identity"],
+            category="ai-news",
+        ),
+        client,
+    )
+
+    items = asyncio.run(scraper.fetch(datetime.now(timezone.utc).replace(year=2020)))
+    asyncio.run(client.aclose())
+
+    assert [item.title for item in items] == ["Useful AI agents project"]
+    assert items[0].metadata["category"] == "ai-news"

--- a/tests/test_ossinsight.py
+++ b/tests/test_ossinsight.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 
-import httpx
 import asyncio
+import httpx
 
 from src.models import OSSInsightConfig
 from src.scrapers.ossinsight import OSSInsightScraper
@@ -47,3 +47,55 @@ def test_ossinsight_items_carry_configured_category() -> None:
 
     assert len(items) == 1
     assert items[0].metadata["category"] == "oss"
+
+
+def test_ossinsight_falls_back_to_github_search_when_api_fails() -> None:
+    requests: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(str(request.url))
+        if request.url.host == "api.ossinsight.io":
+            return httpx.Response(500, text="upstream broken")
+        if request.url.host == "api.github.com":
+            return httpx.Response(
+                200,
+                json={
+                    "items": [
+                        {
+                            "id": 456,
+                            "full_name": "example/llm-runner",
+                            "html_url": "https://github.com/example/llm-runner",
+                            "description": "LLM inference runner",
+                            "stargazers_count": 42,
+                            "forks_count": 4,
+                            "pushed_at": "2026-06-30T00:00:00Z",
+                            "language": "Python",
+                            "owner": {"login": "example"},
+                        }
+                    ]
+                },
+            )
+        raise AssertionError(f"unexpected url: {request.url}")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    scraper = OSSInsightScraper(
+        OSSInsightConfig(
+            enabled=True,
+            languages=["Python"],
+            keywords=["llm"],
+            min_stars=1,
+            max_items=5,
+            category="oss",
+        ),
+        client,
+    )
+
+    items = asyncio.run(scraper.fetch(datetime(2026, 6, 30, tzinfo=timezone.utc)))
+    asyncio.run(client.aclose())
+
+    assert any("api.ossinsight.io" in url for url in requests)
+    assert any("api.github.com/search/repositories" in url for url in requests)
+    assert len(items) == 1
+    assert items[0].title == "example/llm-runner (42⭐ GitHub search fallback)"
+    assert items[0].metadata["category"] == "oss"
+    assert items[0].metadata["fallback"] == "github_search"

--- a/tests/test_ossinsight.py
+++ b/tests/test_ossinsight.py
@@ -1,0 +1,49 @@
+from datetime import datetime, timezone
+
+import httpx
+import asyncio
+
+from src.models import OSSInsightConfig
+from src.scrapers.ossinsight import OSSInsightScraper
+
+
+def test_ossinsight_items_carry_configured_category() -> None:
+    payload = {
+        "data": {
+            "rows": [
+                {
+                    "repo_id": 123,
+                    "repo_name": "example/agent-tool",
+                    "description": "LLM agent workflow tool",
+                    "stars": 12,
+                    "forks": 1,
+                    "pushes": 2,
+                    "pull_requests": 3,
+                    "primary_language": "Python",
+                    "collection_names": "AI",
+                }
+            ]
+        }
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=payload)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    scraper = OSSInsightScraper(
+        OSSInsightConfig(
+            enabled=True,
+            languages=["Python"],
+            keywords=["agent"],
+            min_stars=1,
+            max_items=5,
+            category="oss",
+        ),
+        client,
+    )
+
+    items = asyncio.run(scraper.fetch(datetime.now(timezone.utc)))
+    asyncio.run(client.aclose())
+
+    assert len(items) == 1
+    assert items[0].metadata["category"] == "oss"

--- a/tests/test_reddit.py
+++ b/tests/test_reddit.py
@@ -17,6 +17,7 @@ def _make_config(fetch_comments: int = 1) -> RedditConfig:
                 sort="hot",
                 fetch_limit=1,
                 min_score=1,
+                category="ai-tools",
             )
         ],
         users=[],
@@ -182,6 +183,7 @@ def test_reddit_listing_uses_old_reddit_first():
     assert items[0].author == "old_author"
     assert items[0].metadata["score"] == 42
     assert items[0].metadata["num_comments"] == 7
+    assert items[0].metadata["category"] == "ai-tools"
 
 
 def test_reddit_listing_old_failure_falls_back_to_json_then_rss():
@@ -230,6 +232,7 @@ def test_reddit_listing_old_failure_falls_back_to_json_then_rss():
     assert items[0].author == "rss_author"
     assert items[0].metadata["subreddit"] == "LocalLLaMA"
     assert items[0].metadata["fallback"] == "rss"
+    assert items[0].metadata["category"] == "ai-tools"
 
 
 def test_reddit_comments_use_old_reddit_first():

--- a/tests/test_run_artifacts.py
+++ b/tests/test_run_artifacts.py
@@ -1,0 +1,112 @@
+from datetime import datetime, timezone
+import json
+
+from src.models import ContentItem, SourceType
+from types import SimpleNamespace
+
+import pytest
+from rich.console import Console
+
+from src.models import AIConfig, CategoryGroupConfig, Config, FilteringConfig, SourcesConfig
+from src.orchestrator import HorizonOrchestrator
+from src.storage.manager import StorageManager
+
+
+def make_item(item_id: str, score: float | None = None) -> ContentItem:
+    return ContentItem(
+        id=item_id,
+        source_type=SourceType.TWITTER,
+        title=f"title {item_id}",
+        url=f"https://x.com/user/status/{item_id}",
+        content="body",
+        author="user",
+        published_at=datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc),
+        ai_score=score,
+        ai_reason="reason" if score is not None else None,
+        metadata={"category": "ai-tools"},
+    )
+
+
+def test_save_run_artifact_writes_jsonl_with_scores(tmp_path):
+    storage = StorageManager(data_dir=str(tmp_path))
+
+    path = storage.save_run_artifact("2026-06-30T120000Z", "analyzed", [make_item("1", 7.5)])
+
+    assert path == tmp_path / "runs" / "2026-06-30T120000Z" / "analyzed.jsonl"
+    rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["id"] == "1"
+    assert row["source_type"] == "twitter"
+    assert row["url"] == "https://x.com/user/status/1"
+    assert row["published_at"] == "2026-06-30T12:00:00Z"
+    assert row["fetched_at"].endswith("Z")
+    assert row["ai_score"] == 7.5
+    assert row["ai_reason"] == "reason"
+    assert row["metadata"] == {"category": "ai-tools"}
+
+
+def test_orchestrator_persists_auditable_run_stages(monkeypatch, tmp_path):
+    config = Config(
+        ai=AIConfig(
+            provider="openai",
+            model="test",
+            api_key_env="TEST_API_KEY",
+            languages=[],
+        ),
+        sources=SourcesConfig(),
+        filtering=FilteringConfig(
+            ai_score_threshold=6.0,
+            max_items=1,
+            category_groups={"ai": CategoryGroupConfig(limit=1, categories=["ai-tools"])},
+            default_group_limit=1,
+        ),
+    )
+    storage = StorageManager(data_dir=str(tmp_path))
+    orchestrator = HorizonOrchestrator(config, storage)
+    orchestrator.console = Console(record=True)
+
+    raw_items = [make_item("selected", 9.0), make_item("rejected", 4.0)]
+    raw_items[0].metadata["category"] = "ai-tools"
+    raw_items[1].metadata["category"] = "ai-tools"
+
+    async def fetch_all_sources(since):
+        return raw_items
+
+    async def analyze_content(input_items):
+        return input_items
+
+    async def merge_topic_duplicates(input_items):
+        return input_items
+
+    async def expand_twitter_discussion(input_items):
+        return None
+
+    async def enrich_important_items(input_items):
+        return None
+
+    monkeypatch.setattr(orchestrator, "fetch_all_sources", fetch_all_sources)
+    monkeypatch.setattr(orchestrator, "_analyze_content", analyze_content)
+    monkeypatch.setattr(orchestrator, "merge_topic_duplicates", merge_topic_duplicates)
+    monkeypatch.setattr(orchestrator, "_expand_twitter_discussion", expand_twitter_discussion)
+    monkeypatch.setattr(orchestrator, "_enrich_important_items", enrich_important_items)
+    monkeypatch.setattr(orchestrator, "_run_id", lambda: "run-1")
+    monkeypatch.chdir(tmp_path)
+
+    import asyncio
+
+    asyncio.run(orchestrator.run())
+
+    run_dir = tmp_path / "runs" / "run-1"
+    assert sorted(p.name for p in run_dir.glob("*.jsonl")) == [
+        "analyzed.jsonl",
+        "important.jsonl",
+        "merged.jsonl",
+        "raw.jsonl",
+        "rejected.jsonl",
+        "selected.jsonl",
+    ]
+    selected_rows = [json.loads(line) for line in (run_dir / "selected.jsonl").read_text().splitlines()]
+    rejected_rows = [json.loads(line) for line in (run_dir / "rejected.jsonl").read_text().splitlines()]
+    assert [row["id"] for row in selected_rows] == ["selected"]
+    assert [row["id"] for row in rejected_rows] == ["rejected"]

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -72,7 +72,23 @@ def test_generate_webhook_item_includes_discussion_link_when_distinct():
         total=1,
     )
 
-    assert "tester · Apr 25, 08:00 · [Discussion](https://news.ycombinator.com/item?id=1)" in result
+    assert (
+        "**Source**: [Original](https://example.com/items/1) · rss · tester · Apr 25, 08:00"
+        " · [Discussion](https://news.ycombinator.com/item?id=1)"
+    ) in result
+
+
+def test_generate_webhook_item_labels_original_source_link():
+    summarizer = DailySummarizer()
+
+    result = summarizer.generate_webhook_item(
+        _make_item(1),
+        language="en",
+        index=1,
+        total=1,
+    )
+
+    assert "**Source**: [Original](https://example.com/items/1)" in result
 
 
 def test_generate_webhook_item_omits_discussion_link_when_same_as_item_url():
@@ -105,6 +121,19 @@ def test_generate_webhook_item_uses_localized_discussion_label():
     assert "[社区讨论](https://www.reddit.com/r/python/comments/abc123/test/)" in result
 
 
+def test_generate_webhook_item_labels_original_source_link_in_zh():
+    summarizer = DailySummarizer()
+
+    result = summarizer.generate_webhook_item(
+        _make_item(1),
+        language="zh",
+        index=1,
+        total=1,
+    )
+
+    assert "**来源**: [原文](https://example.com/items/1)" in result
+
+
 def test_generate_summary_zh_uses_localized_selection_header_and_numeric_date():
     summarizer = DailySummarizer()
     item = _make_item(1)
@@ -119,7 +148,7 @@ def test_generate_summary_zh_uses_localized_selection_header_and_numeric_date():
     )
 
     assert "> 从 10 条内容中筛选出 1 条重要资讯。" in result
-    assert "rss · tester · 4月25日 08:00" in result
+    assert "**来源**: [原文](https://example.com/items/1) · rss · tester · 4月25日 08:00" in result
     assert "From 10 items" not in result
     assert "Apr 25, 08:00" not in result
 

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -55,7 +55,7 @@ def test_generate_webhook_item_renders_single_item_detail():
     )
 
     assert result.startswith("Item 1/2")
-    assert "## [Important Item 1](https://example.com/items/1)" in result
+    assert "## [Important Item 1](https://example.com/items/1) · source: rss ⭐️ 8.0/10" in result
     assert "Summary for item 1." in result
     assert "**Tags**: `#AI`, `#News`" in result
 
@@ -148,6 +148,8 @@ def test_generate_summary_zh_uses_localized_selection_header_and_numeric_date():
     )
 
     assert "> 从 10 条内容中筛选出 1 条重要资讯。" in result
+    assert "1. [Important Item 1](#item-1) · 来源: rss ⭐️ 8.0/10" in result
+    assert "## [Important Item 1](https://example.com/items/1) · 来源: rss ⭐️ 8.0/10" in result
     assert "**来源**: [原文](https://example.com/items/1) · rss · tester · 4月25日 08:00" in result
     assert "From 10 items" not in result
     assert "Apr 25, 08:00" not in result

--- a/tests/test_twitter_playwright_list.py
+++ b/tests/test_twitter_playwright_list.py
@@ -1,0 +1,32 @@
+from datetime import datetime, timezone
+
+from src.models import TwitterConfig
+from src.scrapers.twitter_playwright import TwitterPlaywrightScraper
+
+
+def test_twitter_config_accepts_list_id_and_default_category():
+    cfg = TwitterConfig(mode="playwright", list_id="123", category="ai-tools")
+
+    assert cfg.list_id == "123"
+    assert cfg.category == "ai-tools"
+
+
+def test_playwright_list_tweets_use_real_author_and_configured_category():
+    cfg = TwitterConfig(mode="playwright", list_id="123", category="ai-tools")
+    scraper = TwitterPlaywrightScraper(cfg)
+
+    item = scraper._parse_tweet(
+        {
+            "tweet_id": "42",
+            "text": "AI agent tool release",
+            "datetime": datetime(2026, 6, 30, 12, 0, tzinfo=timezone.utc).isoformat(),
+            "username": "real_author",
+        },
+        "list",
+    )
+
+    assert item is not None
+    assert item.author == "real_author"
+    assert str(item.url) == "https://x.com/real_author/status/42"
+    assert item.metadata["category"] == "ai-tools"
+    assert item.metadata["list_id"] == "123"


### PR DESCRIPTION
## Summary
- add X/Twitter List scraping support for Playwright mode via a small isolated helper module
- persist auditable JSONL run artifacts for raw, merged, analyzed, important, rejected, and selected stages
- add config-driven curation focus without changing the base analysis prompt
- add tests for Twitter List metadata, run artifacts, and optional curation focus

## Tests
- uv run pytest

Result: 286 passed, 8 warnings