### PR TITLE
feat(cli): add staged checkpointing and resume support

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,33 @@ For Gemini, use `GOOGLE_API_KEY`:
 
 Any string value in `data/config.json` can reference environment variables with `${VAR_NAME}`. This is useful for values such as `ai.base_url`, private RSS feed URLs, webhook endpoints, or custom header templates.
 
+#### OpenAI-compatible Gateways
+
+Horizon works with any OpenAI-compatible API through `base_url`. For example, OpenCode Go:
+
+```jsonc
+{
+  "ai": {
+    "provider": "openai",
+    "model": "glm-5.1",
+    "base_url": "https://opencode.ai/zen/go/v1",
+    "api_key_env": "OPENCODE_API_KEY"
+  }
+}
+```
+
+Set your API key in `.env`:
+
+```bash
+OPENCODE_API_KEY=<your-opencode-go-key>
+```
+
+Compatibility depends on whether the gateway accepts Horizon's parameters (`temperature`, `response_format`, `max_tokens`). Most models work out of the box; a few may fail with server-side errors or reject specific parameter values. Test models with:
+
+```bash
+uv run python scripts/probe_opencode_go.py
+```
+
 For the full reference, see the [Configuration Guide](docs/configuration.md).
 
 ### 3. Run
@@ -282,15 +309,32 @@ For the full reference, see the [Configuration Guide](docs/configuration.md).
 #### Local Installation
 
 ```bash
-uv run horizon           # Run with default 24h window
-uv run horizon --hours 48  # Fetch from last 48 hours
+uv run horizon              # Run with default 24h window
+uv run horizon --hours 48   # Fetch from last 48 hours
 ```
+
+**Inspect previous runs:**
+
+```bash
+uv run horizon --list-runs  # Show recent runs and their completed stages
+```
+
+**Resume from an interrupted run:**
+
+If a run fails partway through (e.g. network error during enrichment), you can resume with `--resume`:
+
+```bash
+uv run horizon --resume <run_id>              # Auto-detect last completed stage
+uv run horizon --resume <run_id> --resume-from filtered  # Resume from a specific stage
+```
+
+Stages are saved progressively under `data/mcp-runs/<run_id>/` as `raw`, `scored`, `filtered`, and `enriched`. If `--resume-from` is omitted, Horizon automatically picks the latest available stage (enriched → filtered → scored → raw).
 
 #### With Docker
 
 ```bash
-docker compose run --rm horizon           # Run with default 24h window
-docker compose run --rm horizon --hours 48  # Fetch from last 48 hours
+docker compose run --rm horizon              # Run with default 24h window
+docker compose run --rm horizon --hours 48   # Fetch from last 48 hours
 ```
 
 The generated report will be saved to `data/summaries/`.

--- a/scripts/probe_opencode_go.py
+++ b/scripts/probe_opencode_go.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Probe OpenCode Go model compatibility for Horizon-style requests.
+
+This script helps answer practical questions like:
+- Which OpenCode Go models work on the OpenAI-compatible endpoint?
+- Does a model accept `response_format={"type": "json_object"}`?
+- Does it accept `temperature`?
+- Does it require `max_tokens` or `max_completion_tokens`?
+
+Usage examples:
+
+  uv run python scripts/probe_opencode_go.py
+  uv run python scripts/probe_opencode_go.py --models kimi-k2.6 glm-5.2
+  uv run python scripts/probe_opencode_go.py --timeout 90 --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+from dotenv import load_dotenv
+
+
+DEFAULT_BASE_URL = "https://opencode.ai/zen/go/v1"
+DEFAULT_MODELS = [
+    "kimi-k2.7-code",
+    "kimi-k2.6",
+    "glm-5.2",
+    "glm-5.1",
+    "deepseek-v4-pro",
+    "deepseek-v4-flash",
+    "mimo-v2.5",
+    "mimo-v2.5-pro",
+]
+
+
+@dataclass
+class ProbeCase:
+    name: str
+    use_temperature: bool
+    use_response_format: bool
+    token_param: str
+
+
+CASES = [
+    ProbeCase(
+        name="horizon_default",
+        use_temperature=True,
+        use_response_format=True,
+        token_param="max_tokens",
+    ),
+    ProbeCase(
+        name="no_response_format",
+        use_temperature=True,
+        use_response_format=False,
+        token_param="max_tokens",
+    ),
+    ProbeCase(
+        name="no_temperature",
+        use_temperature=False,
+        use_response_format=True,
+        token_param="max_tokens",
+    ),
+    ProbeCase(
+        name="max_completion_tokens",
+        use_temperature=True,
+        use_response_format=True,
+        token_param="max_completion_tokens",
+    ),
+    ProbeCase(
+        name="minimal",
+        use_temperature=False,
+        use_response_format=False,
+        token_param="max_tokens",
+    ),
+]
+
+
+def build_payload(model: str, case: ProbeCase) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": "Return only valid JSON."},
+            {
+                "role": "user",
+                "content": (
+                    'Return exactly this JSON object: '
+                    '{"ok": true, "model": "' + model + '"}'
+                ),
+            },
+        ],
+        case.token_param: 80,
+    }
+    if case.use_temperature:
+        payload["temperature"] = 0.3
+    if case.use_response_format:
+        payload["response_format"] = {"type": "json_object"}
+    return payload
+
+
+async def probe_case(
+    client: httpx.AsyncClient,
+    *,
+    model: str,
+    case: ProbeCase,
+) -> dict[str, Any]:
+    try:
+        response = await client.post(
+            "/chat/completions",
+            json=build_payload(model, case),
+        )
+    except Exception as exc:  # network / timeout / transport
+        return {
+            "ok": False,
+            "status": None,
+            "case": case.name,
+            "error": f"transport_error: {exc}",
+        }
+
+    try:
+        body = response.json()
+    except Exception:
+        body = {"raw": response.text[:500]}
+
+    if response.is_success:
+        choice = None
+        if isinstance(body, dict):
+            choices = body.get("choices")
+            if isinstance(choices, list) and choices:
+                choice = choices[0]
+        message = (choice or {}).get("message", {}) if isinstance(choice, dict) else {}
+        return {
+            "ok": True,
+            "status": response.status_code,
+            "case": case.name,
+            "content": message.get("content"),
+            "reasoning": message.get("reasoning"),
+            "finish_reason": (choice or {}).get("finish_reason") if isinstance(choice, dict) else None,
+        }
+
+    error = body.get("error") if isinstance(body, dict) else None
+    return {
+        "ok": False,
+        "status": response.status_code,
+        "case": case.name,
+        "error": error if error is not None else body,
+    }
+
+
+async def probe_model(
+    client: httpx.AsyncClient,
+    model: str,
+) -> dict[str, Any]:
+    results = []
+    for case in CASES:
+        results.append(await probe_case(client, model=model, case=case))
+    return {"model": model, "results": results}
+
+
+def summarize(model_result: dict[str, Any]) -> str:
+    parts = [model_result["model"]]
+    for result in model_result["results"]:
+        status = "OK" if result["ok"] else "FAIL"
+        detail = result.get("finish_reason") or result.get("error")
+        if isinstance(detail, dict):
+            detail = detail.get("message") or json.dumps(detail, ensure_ascii=False)
+        parts.append(f"  - {result['case']}: {status} ({detail})")
+    return "\n".join(parts)
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--models", nargs="*", default=DEFAULT_MODELS)
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    parser.add_argument("--api-key-env", default="OPENCODE_API_KEY")
+    parser.add_argument("--timeout", type=float, default=45.0)
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+
+    load_dotenv()
+    api_key = os.getenv(args.api_key_env)
+    if not api_key:
+        raise SystemExit(
+            f"Missing API key. Set {args.api_key_env} in .env or your shell first."
+        )
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    async with httpx.AsyncClient(
+        base_url=args.base_url,
+        headers=headers,
+        timeout=httpx.Timeout(args.timeout),
+    ) as client:
+        results = []
+        for model in args.models:
+            results.append(await probe_model(client, model))
+
+    if args.as_json:
+        print(json.dumps(results, ensure_ascii=False, indent=2))
+    else:
+        for result in results:
+            print(summarize(result))
+            print("")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/ai/client.py
+++ b/src/ai/client.py
@@ -179,6 +179,10 @@ class OpenAIClient(AIClient):
     # Providers that need temperature clamped to (0, 1]
     _TEMP_CLAMP = {"minimax"}
 
+    # Newer reasoning-series / GPT-5 family models reject legacy `max_tokens`
+    # and require `max_completion_tokens` instead.
+    _MODELS_REQUIRING_MAX_COMPLETION_TOKENS = ("o1", "o3", "o4", "gpt-5")
+
     def __init__(self, config: AIConfig):
         """Initialize OpenAI-compatible client.
 
@@ -203,6 +207,10 @@ class OpenAIClient(AIClient):
         # Some newer models (e.g. Claude Opus 4.7 on Bedrock Converse) reject
         # `temperature`. We learn this on first 400 and stop sending it.
         self._supports_temperature = True
+        self._use_max_completion_tokens = any(
+            config.model.startswith(prefix)
+            for prefix in self._MODELS_REQUIRING_MAX_COMPLETION_TOKENS
+        )
 
     async def complete(
         self,
@@ -236,11 +244,10 @@ class OpenAIClient(AIClient):
                 temperature=temperature,
                 max_tokens=max_tokens,
                 include_temperature=self._supports_temperature,
+                use_max_completion_tokens=self._use_max_completion_tokens,
             )
         except Exception as exc:
-            if self._supports_temperature and self._is_temperature_unsupported(
-                str(exc)
-            ):
+            if self._supports_temperature and self._is_temperature_unsupported(str(exc)):
                 self._supports_temperature = False
                 response = await self._do_request(
                     system=system,
@@ -248,6 +255,17 @@ class OpenAIClient(AIClient):
                     temperature=temperature,
                     max_tokens=max_tokens,
                     include_temperature=False,
+                    use_max_completion_tokens=self._use_max_completion_tokens,
+                )
+            elif not self._use_max_completion_tokens and self._is_max_tokens_unsupported(str(exc)):
+                self._use_max_completion_tokens = True
+                response = await self._do_request(
+                    system=system,
+                    user=user,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    include_temperature=self._supports_temperature,
+                    use_max_completion_tokens=True,
                 )
             else:
                 raise
@@ -268,6 +286,7 @@ class OpenAIClient(AIClient):
         temperature: float,
         max_tokens: int,
         include_temperature: bool,
+        use_max_completion_tokens: bool,
     ):
         request_kwargs = {
             "model": self.model,
@@ -275,8 +294,9 @@ class OpenAIClient(AIClient):
                 {"role": "system", "content": system},
                 {"role": "user", "content": user},
             ],
-            "max_tokens": max_tokens,
         }
+        token_param = "max_completion_tokens" if use_max_completion_tokens else "max_tokens"
+        request_kwargs[token_param] = max_tokens
         if include_temperature:
             request_kwargs["temperature"] = temperature
         if self.provider not in self._NO_RESPONSE_FORMAT:
@@ -291,6 +311,11 @@ class OpenAIClient(AIClient):
             or "not support" in lowered
             or "unsupported" in lowered
         )
+
+    @staticmethod
+    def _is_max_tokens_unsupported(message: str) -> bool:
+        lowered = message.lower()
+        return "max_tokens" in lowered and "max_completion_tokens" in lowered
 
 
 class AzureOpenAIClient(AIClient):

--- a/src/main.py
+++ b/src/main.py
@@ -10,6 +10,8 @@ from rich.console import Console
 
 from .storage.manager import ConfigError, StorageManager
 from .orchestrator import HorizonOrchestrator
+from .mcp.run_store import RunStore
+from .models import ContentItem
 
 
 console = Console()
@@ -37,6 +39,24 @@ def main():
 
     parser = argparse.ArgumentParser(description="Horizon - AI-Driven Information Aggregation System")
     parser.add_argument("--hours", type=int, help="Force fetch from last N hours")
+    parser.add_argument(
+        "--resume",
+        type=str,
+        metavar="RUN_ID",
+        help="Resume a previous run from a saved stage",
+    )
+    parser.add_argument(
+        "--resume-from",
+        type=str,
+        choices=["raw", "scored", "filtered", "enriched"],
+        default="enriched",
+        help="Stage to resume from (default: enriched — auto-detect latest)",
+    )
+    parser.add_argument(
+        "--list-runs",
+        action="store_true",
+        help="List recent checkpointed runs and exit",
+    )
     args = parser.parse_args()
 
     try:
@@ -72,9 +92,99 @@ def main():
             console.print(f"[bold red]❌ Error loading configuration: {e}[/bold red]")
             sys.exit(1)
 
-        # Create and run orchestrator
+        # Initialize run store for checkpoints
+        runs_root = data_dir if isinstance(data_dir, Path) else Path(data_dir)
+        runs_root = runs_root / "mcp-runs"
+        run_store = RunStore(runs_root)
+
+        # Handle --list-runs
+        if args.list_runs:
+            runs = run_store.list_runs(limit=20)
+            if not runs:
+                console.print("[yellow]No checkpointed runs found.[/yellow]")
+            else:
+                console.print("[bold]Recent checkpointed runs:[/bold]\n")
+                for r in runs:
+                    stages = []
+                    for s in ("raw", "scored", "filtered", "enriched"):
+                        if run_store.has_stage(r["run_id"], s):
+                            stages.append(s)
+                    console.print(
+                        f"  [cyan]{r['run_id']}[/cyan] — {r.get('created_at', '?')[:19]}\n"
+                        f"    stages: {', '.join(stages) if stages else 'none'}"
+                    )
+            sys.exit(0)
+
+        # --resume: load from saved stage and continue
+        if args.resume:
+            resume_run_id = args.resume
+            resume_stage = args.resume_from
+
+            # Auto-detect latest available stage if not specified or enriched not found
+            if resume_stage == "enriched" and not run_store.has_stage(resume_run_id, "enriched"):
+                for auto_stage in ("filtered", "scored", "raw"):
+                    if run_store.has_stage(resume_run_id, auto_stage):
+                        resume_stage = auto_stage
+                        console.print(
+                            f"[yellow]⚠️  Stage 'enriched' not found, auto-detected: {auto_stage}[/yellow]"
+                        )
+                        break
+
+            if not run_store.has_stage(resume_run_id, resume_stage):
+                available = []
+                for s in ("raw", "scored", "filtered", "enriched"):
+                    if run_store.has_stage(resume_run_id, s):
+                        available.append(s)
+                console.print(
+                    f"[bold red]❌ Stage '{resume_stage}' not found in run {resume_run_id}[/bold red]"
+                )
+                if available:
+                    console.print(f"   Available stages: {', '.join(available)}")
+                sys.exit(1)
+
+            console.print(
+                f"📂 Loading {resume_stage} items from run {resume_run_id}..."
+            )
+            payload = run_store.load_items(resume_run_id, resume_stage)
+            items = [ContentItem.model_validate(d) for d in payload]
+
+            # Get total fetched from raw stage for summary context
+            total_fetched = len(items)
+            if run_store.has_stage(resume_run_id, "raw"):
+                try:
+                    total_fetched = len(run_store.load_items(resume_run_id, "raw"))
+                except Exception:
+                    pass
+            elif run_store.has_stage(resume_run_id, "scored"):
+                try:
+                    total_fetched = len(run_store.load_items(resume_run_id, "scored"))
+                except Exception:
+                    pass
+
+            console.print(f"   Loaded {len(items)} items\n")
+
+            orchestrator = HorizonOrchestrator(config, storage)
+            asyncio.run(
+                orchestrator.resume_from(
+                    items=items,
+                    stage=resume_stage,
+                    all_fetched=total_fetched,
+                    run_store=run_store,
+                    run_id=resume_run_id,
+                )
+            )
+            return
+
+        # Create and run orchestrator with checkpointing
+        run_id = run_store.create_run()
+        console.print(f"[dim]Checkpoint run: {run_id}[/dim]\n")
+
         orchestrator = HorizonOrchestrator(config, storage)
-        asyncio.run(orchestrator.run(force_hours=args.hours))
+        asyncio.run(orchestrator.run(
+            force_hours=args.hours,
+            run_store=run_store,
+            run_id=run_id,
+        ))
 
     except KeyboardInterrupt:
         console.print("\n[yellow]⚠️  Interrupted by user[/yellow]")

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -47,11 +47,18 @@ class HorizonOrchestrator:
             else None
         )
 
-    async def run(self, force_hours: int = None) -> None:
+    async def run(
+        self,
+        force_hours: int = None,
+        run_store=None,
+        run_id: str = None,
+    ) -> None:
         """Execute the complete workflow.
 
         Args:
             force_hours: Optional override for time window in hours
+            run_store: Optional RunStore for checkpoint persistence
+            run_id: Run identifier (required when run_store is provided)
         """
         self.console.print("[bold cyan]🌅 Horizon - Starting aggregation...[/bold cyan]\n")
 
@@ -86,9 +93,15 @@ class HorizonOrchestrator:
                     f"→ {len(merged_items)} unique items\n"
                 )
 
+            if run_store and run_id:
+                run_store.save_items(run_id, "raw", [i.model_dump(mode="json") for i in merged_items])
+
             # 4. Analyze with AI
             analyzed_items = await self._analyze_content(merged_items)
             self.console.print(f"🤖 Analyzed {len(analyzed_items)} items with AI\n")
+
+            if run_store and run_id:
+                run_store.save_items(run_id, "scored", [i.model_dump(mode="json") for i in analyzed_items])
 
             # 5. Filter by score threshold
             threshold = self.config.filtering.ai_score_threshold
@@ -114,6 +127,9 @@ class HorizonOrchestrator:
             # 5.6 Optional second-stage Twitter reply expansion + targeted re-analysis
             await self._expand_twitter_discussion(important_items)
 
+            if run_store and run_id:
+                run_store.save_items(run_id, "filtered", [i.model_dump(mode="json") for i in important_items])
+
             # Show per-sub-source selection breakdown
             selected_counts: Dict[str, int] = defaultdict(int)
             for item in important_items:
@@ -125,6 +141,9 @@ class HorizonOrchestrator:
 
             # 6. Search related stories + enrich with background knowledge (2nd AI pass)
             await self._enrich_important_items(important_items)
+
+            if run_store and run_id:
+                run_store.save_items(run_id, "enriched", [i.model_dump(mode="json") for i in important_items])
 
             # 7. Generate and save daily summaries for each configured language
             today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
@@ -216,6 +235,157 @@ class HorizonOrchestrator:
                 )
 
             raise
+
+    async def resume_from(
+        self,
+        items: List[ContentItem],
+        stage: str,
+        all_fetched: int = 0,
+        run_store=None,
+        run_id: str = None,
+    ) -> None:
+        """Resume pipeline from a saved stage.
+
+        Args:
+            items: Deserialized ContentItem list from saved stage
+            stage: Source stage (raw, scored, filtered, enriched)
+            all_fetched: Original total fetched count (for summary context)
+            run_store: Optional RunStore for saving subsequent stages
+            run_id: Run identifier
+        """
+        valid = {"raw", "scored", "filtered", "enriched"}
+        if stage not in valid:
+            raise ValueError(f"Invalid resume stage '{stage}'. Must be one of: {', '.join(sorted(valid))}")
+
+        self.console.print(f"[bold cyan]🔄 Resuming from stage: {stage}[/bold cyan]\n")
+
+        if stage == "raw":
+            analyzed_items = await self._analyze_content(items)
+            self.console.print(f"🤖 Re-analyzed {len(analyzed_items)} items with AI\n")
+            if run_store and run_id:
+                run_store.save_items(run_id, "scored", [i.model_dump(mode="json") for i in analyzed_items])
+
+            threshold = self.config.filtering.ai_score_threshold
+            important_items = [i for i in analyzed_items if i.ai_score and i.ai_score >= threshold]
+            important_items.sort(key=lambda x: x.ai_score or 0, reverse=True)
+
+            deduped = await self.merge_topic_duplicates(important_items)
+            if len(deduped) < len(important_items):
+                self.console.print(
+                    f"🧹 Removed {len(important_items) - len(deduped)} topic duplicates "
+                    f"→ {len(deduped)} unique items\n"
+                )
+            important_items = deduped
+
+            await self._expand_twitter_discussion(important_items)
+            if run_store and run_id:
+                run_store.save_items(run_id, "filtered", [i.model_dump(mode="json") for i in important_items])
+
+            items = important_items
+
+        elif stage == "scored":
+            threshold = self.config.filtering.ai_score_threshold
+            important_items = [i for i in items if i.ai_score and i.ai_score >= threshold]
+            important_items.sort(key=lambda x: x.ai_score or 0, reverse=True)
+            self.console.print(f"⭐️ {len(important_items)} items scored ≥ {threshold}\n")
+
+            deduped = await self.merge_topic_duplicates(important_items)
+            if len(deduped) < len(important_items):
+                self.console.print(
+                    f"🧹 Removed {len(important_items) - len(deduped)} topic duplicates "
+                    f"→ {len(deduped)} unique items\n"
+                )
+            important_items = deduped
+
+            await self._expand_twitter_discussion(important_items)
+            if run_store and run_id:
+                run_store.save_items(run_id, "filtered", [i.model_dump(mode="json") for i in important_items])
+
+            items = important_items
+
+        elif stage == "filtered":
+            self.console.print(f"⭐️ {len(items)} items from filtered stage\n")
+            items = items
+
+        elif stage == "enriched":
+            self.console.print(f"📚 {len(items)} already-enriched items\n")
+            items = items
+
+        if stage in ("filtered", "scored", "raw"):
+            await self._enrich_important_items(items)
+            if run_store and run_id:
+                run_store.save_items(run_id, "enriched", [i.model_dump(mode="json") for i in items])
+
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        for lang in self.config.ai.languages:
+            summarizer = DailySummarizer()
+            summary = await summarizer.generate_summary(items, today, all_fetched or len(items), language=lang)
+
+            summary_path = self.storage.save_daily_summary(today, summary, language=lang)
+            self.console.print(f"💾 Saved {lang.upper()} summary to: {summary_path}\n")
+
+            try:
+                from pathlib import Path
+
+                post_filename = f"{today}-summary-{lang}.md"
+                posts_dir = Path("docs/_posts")
+                posts_dir.mkdir(parents=True, exist_ok=True)
+                dest_path = posts_dir / post_filename
+
+                front_matter = (
+                    "---\n"
+                    "layout: default\n"
+                    f"title: \"Horizon Summary: {today} ({lang.upper()})\"\n"
+                    f"date: {today}\n"
+                    f"lang: {lang}\n"
+                    "---\n\n"
+                )
+
+                summary_content = summary
+                first_line = summary_content.strip().split("\n")[0]
+                if first_line.startswith("# "):
+                    parts = summary_content.split("\n", 1)
+                    if len(parts) > 1:
+                        summary_content = parts[1].strip()
+
+                with open(dest_path, "w", encoding="utf-8") as f:
+                    f.write(front_matter + summary_content)
+
+                self.console.print(f"📄 Copied {lang.upper()} summary to GitHub Pages: {dest_path}\n")
+            except Exception as e:
+                self.console.print(f"[yellow]⚠️  Failed to copy {lang.upper()} summary to docs/: {e}[/yellow]\n")
+
+            if self.email_manager and self.config.email and self.config.email.enabled:
+                self.console.print(f"📧 Sending {lang.upper()} email summary...")
+                subscribers = self.storage.load_subscribers()
+                subject = f"Horizon Summary ({lang.upper()}) - {today}"
+                self.email_manager.send_daily_summary(summary, subject, subscribers)
+
+            if self.webhook_notifier:
+                await self.webhook_notifier.send_daily_summary(
+                    summary=summary,
+                    important_items=items,
+                    all_items_count=all_fetched or len(items),
+                    date=today,
+                    lang=lang,
+                    summarizer=summarizer,
+                )
+
+        self.console.print("[bold green]✅ Horizon resume completed successfully![/bold green]")
+        usage = get_usage_snapshot()
+        if usage.total_tokens > 0:
+            self.console.print(
+                f"\n🧮 Token usage this run: "
+                f"{usage.total_tokens} tokens "
+                f"(input: {usage.total_input_tokens}, output: {usage.total_output_tokens})"
+            )
+            for provider, u in sorted(usage.per_provider.items()):
+                if u.total <= 0:
+                    continue
+                self.console.print(
+                    f"   • {provider}: {u.total} tokens "
+                    f"(in: {u.input_tokens}, out: {u.output_tokens})"
+                )
 
     def _determine_time_window(self, force_hours: int = None) -> datetime:
         if force_hours:


### PR DESCRIPTION
Closes #124

## What

Saves intermediate artifacts (raw, scored, filtered, enriched) during normal CLI runs and adds resume flags to continue from any completed stage after a failure. Also documents OpenCode Go gateway compatibility in README.

## Changes

- **src/orchestrator.py**: `run()` saves checkpoints after each stage via RunStore. New `resume_from()` method handles all resume paths.
- **src/main.py**: new flags `--resume <run_id>`, `--resume-from <stage>`, `--list-runs`. Auto-detects last available stage when `--resume-from` is omitted.
- **README.md**: documented CLI staging/resume + OpenAI-compatible gateway config (OpenCode Go).
- **scripts/probe_opencode_go.py**: utility to test gateway model parameter compatibility.

## Usage

```bash
uv run horizon --hours 24
uv run horizon --resume <run_id>
uv run horizon --resume <run_id> --resume-from filtered
uv run horizon --list-runs

# Test gateway compatibility
uv run python scripts/probe_opencode_go.py
```