### PR TITLE
fix(scrapers): add missing category field to all source configs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -206,13 +206,15 @@ All sources are configured under the top-level `sources` key in `config.json`.
       {
         "type": "user_events",
         "username": "gvanrossum",
-        "enabled": true
+        "enabled": true,
+        "category": "oss"
       },
       {
         "type": "repo_releases",
         "owner": "python",
         "repo": "cpython",
-        "enabled": true
+        "enabled": true,
+        "category": "oss"
       }
     ]
   }
@@ -227,7 +229,8 @@ All sources are configured under the top-level `sources` key in `config.json`.
     "hackernews": {
       "enabled": true,
       "fetch_top_stories": 30,
-      "min_score": 100
+      "min_score": 100,
+      "category": "tech"
     }
   }
 }
@@ -265,14 +268,16 @@ Reddit scraping is free and does not require API keys. Subreddit posts and comme
           "subreddit": "MachineLearning",
           "sort": "hot",
           "fetch_limit": 25,
-          "min_score": 10
+          "min_score": 10,
+          "category": "ai-ml"
         }
       ],
       "users": [
         {
           "username": "spez",
           "sort": "new",
-          "fetch_limit": 10
+          "fetch_limit": 10,
+          "category": "social"
         }
       ]
     }
@@ -293,7 +298,8 @@ Telegram scraping uses the public web preview at `https://t.me/s/<channel>`, so 
         {
           "channel": "zaihuapd",
           "enabled": true,
-          "fetch_limit": 20
+          "fetch_limit": 20,
+          "category": "ai-news"
         }
       ]
     }
@@ -305,6 +311,7 @@ Telegram scraping uses the public web preview at `https://t.me/s/<channel>`, so 
 - `channels` — list of public Telegram channels to monitor
 - `channel` — Telegram channel username only, without `@` or the full `https://t.me/` URL
 - `fetch_limit` — maximum number of recent messages to inspect per channel per run (default: `20`)
+- `category` — optional tag for balanced digest grouping (e.g., `"ai-news"`, `"finance"`)
 
 ### Twitter
 
@@ -317,6 +324,7 @@ Requires an [Apify](https://apify.com) account. Set `APIFY_TOKEN` in your `.env`
       "enabled": true,
       "users": ["karpathy", "ylecun"],
       "fetch_limit": 10,
+      "category": "social",
       "fetch_reply_text": false,
       "max_replies_per_tweet": 3,
       "max_tweets_to_expand": 10,
@@ -328,6 +336,7 @@ Requires an [Apify](https://apify.com) account. Set `APIFY_TOKEN` in your `.env`
 
 - `users` — Twitter screen names to monitor, without the `@` prefix
 - `fetch_limit` — maximum tweets to fetch per run (across all users combined; minimum 100 due to actor constraint)
+- `category` — optional tag for balanced digest grouping (applies to all tweets from this source)
 - `fetch_reply_text` — when `true`, fetch actual reply bodies for important tweets and append them under `--- Top Comments ---` so the AI can factor in community discussion. Disabled by default.
 - `max_replies_per_tweet` — maximum reply lines to append per tweet (default: 3)
 - `max_tweets_to_expand` — cap on how many tweets get reply expansion per run, to control Apify credit usage (default: 10)
@@ -394,7 +403,8 @@ Pulls top star-gain repositories from the [OSS Insight](https://ossinsight.io) p
       "languages": ["All", "Python", "TypeScript"],
       "keywords": [],
       "min_stars": 10,
-      "max_items": 30
+      "max_items": 30,
+      "category": "oss-trending"
     }
   }
 }
@@ -405,6 +415,7 @@ Pulls top star-gain repositories from the [OSS Insight](https://ossinsight.io) p
 - `keywords` — optional case-insensitive substrings matched against `description`, `collection_names`, and `repo_name`. Only repos containing at least one keyword pass through. Leave empty to ingest everything trending.
 - `min_stars` — drop repos with fewer than this many stars gained in the period.
 - `max_items` — final cap after merging and sorting by `stars_gained` descending.
+- `category` — optional tag for balanced digest grouping (e.g., `"oss-trending"`)
 
 No API key is required.
 
@@ -459,9 +470,13 @@ deduplication, but before enrichment. This reduces enrichment calls to only the
 items that can appear in the final digest.
 
 Group matching uses the source category stored in `ContentItem.metadata.category`.
-RSS sources expose this through `sources.rss[].category`, and OpenBB watchlists
-through `sources.openbb.watchlists[].category`. Sources without a category enter
-the default group.
+All source types support a `category` field: `sources.rss[].category`,
+`sources.github[].category`, `sources.hackernews.category`,
+`sources.reddit.subreddits[].category`, `sources.reddit.users[].category`,
+`sources.telegram.channels[].category`, `sources.twitter.category`,
+`sources.openbb.watchlists[].category`, `sources.ossinsight.category`,
+`sources.gdelt.category`, and `sources.google_news.category`.
+Sources without a category set enter the default group.
 
 If the same category appears in multiple groups, Horizon logs a warning and uses
 the first group in configuration order. Omitting both `category_groups` and

--- a/docs/scrapers.md
+++ b/docs/scrapers.md
@@ -24,14 +24,16 @@ Stories and their comments are fetched concurrently. For each story, the top 5 c
 {
   "enabled": true,
   "fetch_top_stories": 30,
-  "min_score": 100
+  "min_score": 100,
+  "category": "tech"
 }
 ```
 
 - `fetch_top_stories` — number of top story IDs to fetch
 - `min_score` — minimum HN points to include a story
+- `category` — optional tag for balanced digest grouping
 
-**Extracted data**: title, URL (falls back to HN discussion URL), author, score, comment count, and top comment text.
+**Extracted data**: title, URL (falls back to HN discussion URL), author, score, comment count, top comment text, and category.
 
 ## GitHub
 
@@ -53,7 +55,8 @@ Two source types are supported:
 {
   "type": "user_events",
   "username": "torvalds",
-  "enabled": true
+  "enabled": true,
+  "category": "oss"
 }
 ```
 
@@ -62,9 +65,12 @@ Two source types are supported:
   "type": "repo_releases",
   "owner": "golang",
   "repo": "go",
-  "enabled": true
+  "enabled": true,
+  "category": "oss"
 }
 ```
+
+- `category` — optional tag for balanced digest grouping; set per source entry
 
 **Authentication**: Set `GITHUB_TOKEN` in your environment for higher rate limits (5000 req/hr vs 60 without).
 
@@ -115,14 +121,16 @@ Subreddits and users are fetched concurrently. Comments are sorted by score, lim
       "subreddit": "MachineLearning",
       "sort": "hot",
       "fetch_limit": 25,
-      "min_score": 10
+      "min_score": 10,
+      "category": "ai-ml"
     }
   ],
   "users": [
     {
       "username": "spez",
       "sort": "new",
-      "fetch_limit": 10
+      "fetch_limit": 10,
+      "category": "social"
     }
   ]
 }
@@ -131,10 +139,11 @@ Subreddits and users are fetched concurrently. Comments are sorted by score, lim
 - `sort` — `hot`, `new`, `top`, or `rising` (subreddits); `hot` or `new` (users)
 - `time_filter` — for `top`/`rising` sorts: `hour`, `day`, `week`, `month`, `year`, `all`
 - `min_score` — minimum post score (subreddits only)
+- `category` — optional tag for balanced digest grouping; set per subreddit or per user entry
 
 **Rate limiting**: Detects HTTP 429 responses on JSON requests, reads the `Retry-After` header, waits, and retries once. Uses browser-like request headers for no-key public access.
 
-**Extracted data**: title, URL, author, score, upvote ratio, comment count, subreddit, flair, self-text, and top comments.
+**Extracted data**: title, URL, author, score, upvote ratio, comment count, subreddit, flair, self-text, top comments, and category.
 
 ## OpenBB
 
@@ -208,6 +217,7 @@ Flow:
 
 - `users` — Twitter screen names to monitor, without the `@` prefix
 - `fetch_limit` — maximum tweets to fetch per run
+- `category` — optional tag for balanced digest grouping (applies to all tweets from this source)
 - `fetch_reply_text` — when `true`, a second Apify run fetches reply bodies for each important tweet and appends them under `--- Top Comments ---` for AI analysis
 - `max_replies_per_tweet` — maximum reply lines per tweet (sorted by engagement score)
 - `max_tweets_to_expand` — cap on reply expansion runs per pipeline cycle, to control Apify credit usage
@@ -217,4 +227,4 @@ Flow:
 
 **Authentication**: Set `APIFY_TOKEN` in your `.env`. Get a token at [console.apify.com](https://console.apify.com/account/integrations).
 
-**Extracted data**: tweet text, URL, author, publish time, likes, retweets, replies, views, and (optionally) reply-thread text appended under `--- Top Comments ---`.
+**Extracted data**: tweet text, URL, author, publish time, likes, retweets, replies, views, category, and (optionally) reply-thread text appended under `--- Top Comments ---`.

--- a/src/models.py
+++ b/src/models.py
@@ -123,6 +123,7 @@ class GitHubSourceConfig(BaseModel):
     owner: Optional[str] = None
     repo: Optional[str] = None
     enabled: bool = True
+    category: Optional[str] = None
 
 
 class HackerNewsConfig(BaseModel):
@@ -131,6 +132,7 @@ class HackerNewsConfig(BaseModel):
     enabled: bool = True
     fetch_top_stories: int = 30
     min_score: int = 100
+    category: Optional[str] = None
 
 
 class RSSSourceConfig(BaseModel):
@@ -153,6 +155,7 @@ class RedditSubredditConfig(BaseModel):
     )
     fetch_limit: int = 25
     min_score: int = 10
+    category: Optional[str] = None
 
 
 class RedditUserConfig(BaseModel):
@@ -162,6 +165,7 @@ class RedditUserConfig(BaseModel):
     enabled: bool = True
     sort: str = "new"
     fetch_limit: int = 10
+    category: Optional[str] = None
 
 
 class RedditConfig(BaseModel):
@@ -179,6 +183,7 @@ class TelegramChannelConfig(BaseModel):
     channel: str  # channel username, e.g. "zaihuapd"
     enabled: bool = True
     fetch_limit: int = 20
+    category: Optional[str] = None
 
 
 class TelegramConfig(BaseModel):
@@ -200,6 +205,7 @@ class TwitterConfig(BaseModel):
     mode: str = "apify"  # "apify" or "playwright"
     users: List[str] = Field(default_factory=list)
     fetch_limit: int = 10
+    category: Optional[str] = None
     fetch_reply_text: bool = False
     max_replies_per_tweet: int = 3
     max_tweets_to_expand: int = 10
@@ -264,6 +270,7 @@ class OSSInsightConfig(BaseModel):
     keywords: List[str] = Field(default_factory=list)
     min_stars: int = 5
     max_items: int = 30
+    category: Optional[str] = None
 
 
 class GDELTConfig(BaseModel):

--- a/src/scrapers/github.py
+++ b/src/scrapers/github.py
@@ -57,31 +57,29 @@ class GitHubScraper(BaseScraper):
                 continue
 
             if source.type == "user_events" and source.username:
-                user_items = await self._fetch_user_events(source.username, since)
+                user_items = await self._fetch_user_events(source, since)
                 items.extend(user_items)
             elif source.type == "repo_releases" and source.owner and source.repo:
-                release_items = await self._fetch_repo_releases(
-                    source.owner, source.repo, since
-                )
+                release_items = await self._fetch_repo_releases(source, since)
                 items.extend(release_items)
 
         return items
 
     async def _fetch_user_events(
         self,
-        username: str,
-        since: datetime
+        source: GitHubSourceConfig,
+        since: datetime,
     ) -> List[ContentItem]:
         """Fetch public events for a user.
 
         Args:
-            username: GitHub username
+            source: GitHub source configuration
             since: Only fetch events after this time
 
         Returns:
             List[ContentItem]: Event content items
         """
-        url = f"{self.base_url}/users/{username}/events/public"
+        url = f"{self.base_url}/users/{source.username}/events/public"
         items = []
 
         try:
@@ -105,16 +103,16 @@ class GitHubScraper(BaseScraper):
                 ]:
                     continue
 
-                item = self._parse_event(event, username)
+                item = self._parse_event(event, source)
                 if item:
                     items.append(item)
 
         except httpx.HTTPError as e:
-            logger.warning("Error fetching GitHub events for %s: %s", username, e)
+            logger.warning("Error fetching GitHub events for %s: %s", source.username, e)
 
         return items
 
-    def _parse_event(self, event: dict, username: str) -> Optional[ContentItem]:
+    def _parse_event(self, event: dict, source: GitHubSourceConfig) -> Optional[ContentItem]:
         """Parse GitHub event into ContentItem.
 
         Args:
@@ -127,6 +125,7 @@ class GitHubScraper(BaseScraper):
         event_type = event["type"]
         event_id = event["id"]
         created_at = datetime.fromisoformat(event["created_at"].replace("Z", "+00:00"))
+        username = source.username
 
         repo_name = event["repo"]["name"]
         repo_url = f"https://github.com/{repo_name}"
@@ -165,25 +164,25 @@ class GitHubScraper(BaseScraper):
             metadata={
                 "event_type": event_type,
                 "repo": repo_name,
+                "category": source.category,
             }
         )
 
     async def _fetch_repo_releases(
         self,
-        owner: str,
-        repo: str,
-        since: datetime
+        source: GitHubSourceConfig,
+        since: datetime,
     ) -> List[ContentItem]:
         """Fetch releases for a repository.
 
         Args:
-            owner: Repository owner
-            repo: Repository name
+            source: GitHub source configuration
             since: Only fetch releases after this time
 
         Returns:
             List[ContentItem]: Release content items
         """
+        owner, repo = source.owner, source.repo
         url = f"{self.base_url}/repos/{owner}/{repo}/releases"
         items = []
 
@@ -212,6 +211,7 @@ class GitHubScraper(BaseScraper):
                         "repo": f"{owner}/{repo}",
                         "tag": release["tag_name"],
                         "prerelease": release.get("prerelease", False),
+                        "category": source.category,
                     }
                 )
                 items.append(item)

--- a/src/scrapers/hackernews.py
+++ b/src/scrapers/hackernews.py
@@ -138,5 +138,6 @@ class HackerNewsScraper(BaseScraper):
                 "type": story.get("type", "story"),
                 "discussion_url": hn_discussion_url,
                 "comment_count": len(comments),
+                "category": self.config.get("category"),
             }
         )

--- a/src/scrapers/ossinsight.py
+++ b/src/scrapers/ossinsight.py
@@ -125,6 +125,7 @@ class OSSInsightScraper(BaseScraper):
                 "period": self.cfg.period,
                 "collection_names": collections,
                 "description": description,
+                "category": self.cfg.category,
             },
         )
 

--- a/src/scrapers/reddit.py
+++ b/src/scrapers/reddit.py
@@ -105,7 +105,7 @@ class RedditScraper(BaseScraper):
             if child.get("kind") == "t3"
         ]
         return await self._process_posts(
-            posts, since, "subreddit", cfg.subreddit, cfg.min_score
+            posts, since, "subreddit", cfg.subreddit, cfg.min_score, cfg.category
         )
 
     async def _fetch_subreddit_rss(
@@ -159,6 +159,7 @@ class RedditScraper(BaseScraper):
                         "flair": None,
                         "discussion_url": link,
                         "fallback": "rss",
+                        "category": cfg.category,
                     },
                 )
             )
@@ -191,7 +192,7 @@ class RedditScraper(BaseScraper):
 
         posts = self._parse_old_reddit_posts(response.text, cfg)
         return await self._process_posts(
-            posts, since, "subreddit-html", cfg.subreddit, cfg.min_score
+            posts, since, "subreddit-html", cfg.subreddit, cfg.min_score, cfg.category
         )
 
     def _parse_old_reddit_posts(
@@ -300,7 +301,7 @@ class RedditScraper(BaseScraper):
             if child.get("kind") == "t3"
         ]
         return await self._process_posts(
-            posts, since, "user", cfg.username, min_score=0
+            posts, since, "user", cfg.username, min_score=0, category=cfg.category
         )
 
     async def _process_posts(
@@ -310,6 +311,7 @@ class RedditScraper(BaseScraper):
         subtype: str,
         source_name: str,
         min_score: int,
+        category: Optional[str] = None,
     ) -> List[ContentItem]:
         valid_posts = []
         comment_tasks = []
@@ -340,7 +342,7 @@ class RedditScraper(BaseScraper):
         for post, comments in zip(valid_posts, all_comments):
             if isinstance(comments, Exception):
                 comments = []
-            item = self._parse_post(post, cast(List[dict], comments), subtype)
+            item = self._parse_post(post, cast(List[dict], comments), subtype, category)
             if item:
                 items.append(item)
         return items
@@ -442,7 +444,7 @@ class RedditScraper(BaseScraper):
         return comments[:fetch_limit]
 
     def _parse_post(
-        self, post: dict, comments: List[dict], subtype: str
+        self, post: dict, comments: List[dict], subtype: str, category: Optional[str] = None
     ) -> Optional[ContentItem]:
         post_id = post["id"]
         title = post.get("title", "")
@@ -493,6 +495,7 @@ class RedditScraper(BaseScraper):
                 "is_self": is_self,
                 "flair": post.get("link_flair_text"),
                 "discussion_url": discussion_url,
+                "category": category,
             },
         )
 

--- a/src/scrapers/telegram.py
+++ b/src/scrapers/telegram.py
@@ -71,14 +71,15 @@ class TelegramScraper(BaseScraper):
 
         items = []
         for msg in messages[-cfg.fetch_limit:]:
-            item = self._parse_message(msg, cfg.channel, since)
+            item = self._parse_message(msg, cfg, since)
             if item:
                 items.append(item)
         return items
 
     def _parse_message(
-        self, msg_el, channel: str, since: datetime
+        self, msg_el, cfg: TelegramChannelConfig, since: datetime
     ) -> Optional[ContentItem]:
+        channel = cfg.channel
         # Extract message ID
         data_post = msg_el.get("data-post", "")
         msg_id = data_post.split("/")[-1] if "/" in data_post else data_post
@@ -131,7 +132,7 @@ class TelegramScraper(BaseScraper):
             content=text,
             author=channel,
             published_at=published_at,
-            metadata={"msg_url": msg_url, "channel": channel},
+            metadata={"msg_url": msg_url, "channel": channel, "category": cfg.category},
         )
 
     @staticmethod

--- a/src/scrapers/twitter.py
+++ b/src/scrapers/twitter.py
@@ -306,6 +306,7 @@ class TwitterScraper(BaseScraper):
                     "is_reply": item.get("is_reply", False),
                     "in_reply_to_status_id": item.get("in_reply_to_status_id"),
                     "in_reply_to_screen_name": item.get("in_reply_to_screen_name"),
+                    "category": self.config.category,
                 },
             )
         except Exception as exc:

--- a/src/scrapers/twitter_playwright.py
+++ b/src/scrapers/twitter_playwright.py
@@ -382,6 +382,7 @@ class TwitterPlaywrightScraper(BaseScraper):
                     "tweet_id": tweet_id,
                     "is_retweet": tweet.get("is_retweet", False),
                     "images": tweet.get("images", []),
+                    "category": self.twitter_config.category,
                 },
             )
         except Exception as exc:

--- a/tests/test_category_wiring.py
+++ b/tests/test_category_wiring.py
@@ -1,0 +1,335 @@
+"""Tests that category from source config flows into item metadata for all scrapers."""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from bs4 import BeautifulSoup
+
+from src.models import (
+    GitHubSourceConfig,
+    HackerNewsConfig,
+    OSSInsightConfig,
+    RedditSubredditConfig,
+    RedditUserConfig,
+    TelegramChannelConfig,
+    TelegramConfig,
+    TwitterConfig,
+)
+from src.scrapers.github import GitHubScraper
+from src.scrapers.hackernews import HackerNewsScraper
+from src.scrapers.ossinsight import OSSInsightScraper
+from src.scrapers.reddit import RedditScraper
+from src.scrapers.telegram import TelegramScraper
+from src.scrapers.twitter import TwitterScraper
+
+_SINCE = datetime(2020, 1, 1, tzinfo=timezone.utc)
+_NOW = datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# HackerNews
+# ---------------------------------------------------------------------------
+
+
+def test_hackernews_category_in_metadata():
+    cfg = HackerNewsConfig(category="tech")
+    scraper = HackerNewsScraper(cfg, AsyncMock())
+    story = {
+        "id": 1,
+        "title": "A story",
+        "url": "https://example.com",
+        "by": "user",
+        "time": int(_NOW.timestamp()),
+        "score": 200,
+        "type": "story",
+        "descendants": 10,
+    }
+    item = scraper._parse_story(story, [])
+    assert item.metadata["category"] == "tech"
+
+
+def test_hackernews_category_none_when_unset():
+    cfg = HackerNewsConfig()
+    scraper = HackerNewsScraper(cfg, AsyncMock())
+    story = {
+        "id": 2,
+        "title": "Another story",
+        "url": "https://example.com/2",
+        "by": "user",
+        "time": int(_NOW.timestamp()),
+        "score": 150,
+        "type": "story",
+        "descendants": 0,
+    }
+    item = scraper._parse_story(story, [])
+    assert item.metadata["category"] is None
+
+
+# ---------------------------------------------------------------------------
+# GitHub
+# ---------------------------------------------------------------------------
+
+
+def _github_event(event_type: str = "PushEvent") -> dict:
+    return {
+        "id": "42",
+        "type": event_type,
+        "created_at": _NOW.isoformat().replace("+00:00", "Z"),
+        "actor": {"login": "alice"},
+        "repo": {"name": "alice/repo"},
+        "payload": {"commits": [{"message": "init"}]},
+    }
+
+
+def test_github_parse_event_category_in_metadata():
+    source = GitHubSourceConfig(type="user_events", username="alice", category="oss")
+    scraper = GitHubScraper([source], AsyncMock())
+    item = scraper._parse_event(_github_event(), source)
+    assert item is not None
+    assert item.metadata["category"] == "oss"
+
+
+def test_github_parse_event_category_none_when_unset():
+    source = GitHubSourceConfig(type="user_events", username="alice")
+    scraper = GitHubScraper([source], AsyncMock())
+    item = scraper._parse_event(_github_event(), source)
+    assert item is not None
+    assert item.metadata["category"] is None
+
+
+# ---------------------------------------------------------------------------
+# Reddit
+# ---------------------------------------------------------------------------
+
+
+def _reddit_post(subreddit: str = "LocalLLaMA") -> dict:
+    return {
+        "id": "xyz",
+        "title": "Post title",
+        "is_self": True,
+        "subreddit": subreddit,
+        "permalink": f"/r/{subreddit}/comments/xyz/",
+        "author": "tester",
+        "created_utc": _NOW.timestamp(),
+        "score": 100,
+        "upvote_ratio": 0.95,
+        "num_comments": 3,
+        "selftext": "",
+    }
+
+
+def _reddit_config(category: str | None = None):
+    from src.models import RedditConfig
+
+    return RedditConfig(
+        enabled=True,
+        subreddits=[
+            RedditSubredditConfig(
+                subreddit="LocalLLaMA",
+                enabled=True,
+                sort="hot",
+                fetch_limit=5,
+                min_score=1,
+                category=category,
+            )
+        ],
+        fetch_comments=0,
+    )
+
+
+def test_reddit_parse_post_category_in_metadata():
+    scraper = RedditScraper(_reddit_config("ai"), AsyncMock())
+    item = scraper._parse_post(_reddit_post(), [], "subreddit", category="ai")
+    assert item is not None
+    assert item.metadata["category"] == "ai"
+
+
+def test_reddit_parse_post_category_none_when_unset():
+    scraper = RedditScraper(_reddit_config(), AsyncMock())
+    item = scraper._parse_post(_reddit_post(), [], "subreddit")
+    assert item is not None
+    assert item.metadata["category"] is None
+
+
+def test_reddit_rss_fallback_category_in_metadata():
+    from src.models import RedditConfig
+
+    cfg = RedditSubredditConfig(
+        subreddit="LocalLLaMA", sort="hot", fetch_limit=5, min_score=1, category="forum"
+    )
+    config = RedditConfig(enabled=True, subreddits=[cfg], fetch_comments=0)
+    scraper = RedditScraper(config, AsyncMock())
+
+    rss_xml = f"""<?xml version="1.0"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <entry>
+        <id>https://www.reddit.com/r/LocalLLaMA/comments/abc/test/</id>
+        <title>RSS post</title>
+        <link href="https://www.reddit.com/r/LocalLLaMA/comments/abc/test/"/>
+        <updated>{_NOW.strftime('%Y-%m-%dT%H:%M:%S+00:00')}</updated>
+        <author><name>rssuser</name></author>
+        <summary>body text</summary>
+      </entry>
+    </feed>"""
+
+    import feedparser
+
+    feed = feedparser.parse(rss_xml)
+    # Simulate what _fetch_subreddit_rss produces from the parsed feed
+    from src.models import SourceType
+    from src.scrapers.reddit import RedditScraper as RS
+
+    items = []
+    for entry in feed.entries[: cfg.fetch_limit]:
+        published_at = scraper._parse_rss_date(entry)
+        if not published_at or published_at < _SINCE:
+            continue
+        entry_id = str(entry.get("id") or entry.get("link") or "")
+        link = str(entry.get("link") or "https://reddit.com/")
+        from typing import Any, cast
+
+        items.append(
+            __import__("src.models", fromlist=["ContentItem"]).ContentItem(
+                id=scraper._generate_id("reddit", "subreddit-rss", entry_id),
+                source_type=SourceType.REDDIT,
+                title=str(entry.get("title") or "Untitled"),
+                url=cast(Any, link),
+                content="body",
+                author="rssuser",
+                published_at=published_at,
+                metadata={
+                    "score": None,
+                    "upvote_ratio": None,
+                    "num_comments": None,
+                    "subreddit": cfg.subreddit,
+                    "is_self": None,
+                    "flair": None,
+                    "discussion_url": link,
+                    "fallback": "rss",
+                    "category": cfg.category,
+                },
+            )
+        )
+    assert len(items) == 1
+    assert items[0].metadata["category"] == "forum"
+
+
+def test_reddit_user_config_has_category_field():
+    cfg = RedditUserConfig(username="alice", category="personal")
+    assert cfg.category == "personal"
+
+
+# ---------------------------------------------------------------------------
+# Telegram
+# ---------------------------------------------------------------------------
+
+_TELEGRAM_MSG_HTML = """
+<div class="tgme_widget_message" data-post="channel/1">
+  <div class="tgme_widget_message_text js-message_text">Hello world</div>
+  <time datetime="2025-01-01T12:00:00+00:00">12:00</time>
+</div>
+"""
+
+
+def _tg_msg_el():
+    return BeautifulSoup(_TELEGRAM_MSG_HTML, "html.parser").select_one(
+        "div.tgme_widget_message"
+    )
+
+
+def test_telegram_parse_message_category_in_metadata():
+    cfg = TelegramChannelConfig(channel="channel", category="news")
+    scraper = TelegramScraper(TelegramConfig(), AsyncMock())
+    item = scraper._parse_message(_tg_msg_el(), cfg, _SINCE)
+    assert item is not None
+    assert item.metadata["category"] == "news"
+
+
+def test_telegram_parse_message_category_none_when_unset():
+    cfg = TelegramChannelConfig(channel="channel")
+    scraper = TelegramScraper(TelegramConfig(), AsyncMock())
+    item = scraper._parse_message(_tg_msg_el(), cfg, _SINCE)
+    assert item is not None
+    assert item.metadata["category"] is None
+
+
+def test_telegram_parse_channel_html_passes_category():
+    cfg = TelegramChannelConfig(channel="channel", fetch_limit=10, category="ai-news")
+    scraper = TelegramScraper(TelegramConfig(), AsyncMock())
+    items = scraper._parse_channel_html(_TELEGRAM_MSG_HTML, cfg, _SINCE)
+    assert len(items) == 1
+    assert items[0].metadata["category"] == "ai-news"
+
+
+# ---------------------------------------------------------------------------
+# OSSInsight
+# ---------------------------------------------------------------------------
+
+
+def test_ossinsight_row_to_item_category_in_metadata():
+    cfg = OSSInsightConfig(enabled=True, category="oss-trending")
+    scraper = OSSInsightScraper(cfg, AsyncMock())
+    row = {
+        "repo_name": "owner/repo",
+        "repo_id": 123,
+        "stars": 50,
+        "forks": 10,
+        "pushes": 5,
+        "pull_requests": 3,
+    }
+    item = scraper._row_to_item(row, "Python")
+    assert item is not None
+    assert item.metadata["category"] == "oss-trending"
+
+
+def test_ossinsight_row_to_item_category_none_when_unset():
+    cfg = OSSInsightConfig(enabled=True)
+    scraper = OSSInsightScraper(cfg, AsyncMock())
+    row = {
+        "repo_name": "owner/repo",
+        "repo_id": 456,
+        "stars": 20,
+        "forks": 5,
+        "pushes": 2,
+        "pull_requests": 1,
+    }
+    item = scraper._row_to_item(row, "Go")
+    assert item is not None
+    assert item.metadata["category"] is None
+
+
+# ---------------------------------------------------------------------------
+# Twitter (Apify)
+# ---------------------------------------------------------------------------
+
+
+def _twitter_raw_item() -> dict:
+    return {
+        "id": "tweet-999",
+        "tweet_id": "999",
+        "full_text": "Hello twitter",
+        "user": {"screen_name": "alice", "name": "Alice"},
+        "created_at": "Wed Jan 01 12:00:00 +0000 2025",
+        "favorite_count": 10,
+        "retweet_count": 2,
+        "reply_count": 1,
+        "is_reply": False,
+        "conversation_id": "999",
+    }
+
+
+def test_twitter_parse_item_category_in_metadata():
+    cfg = TwitterConfig(enabled=True, users=["alice"], category="social")
+    scraper = TwitterScraper(cfg, AsyncMock())
+    item = scraper._parse_item(_twitter_raw_item(), _SINCE)
+    assert item is not None
+    assert item.metadata["category"] == "social"
+
+
+def test_twitter_parse_item_category_none_when_unset():
+    cfg = TwitterConfig(enabled=True, users=["alice"])
+    scraper = TwitterScraper(cfg, AsyncMock())
+    item = scraper._parse_item(_twitter_raw_item(), _SINCE)
+    assert item is not None
+    assert item.metadata["category"] is None

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -37,7 +37,7 @@ def test_parse_message_ignores_reply_preview_text() -> None:
 
     item = _scraper()._parse_message(
         msg,
-        "zaihuapd",
+        TelegramChannelConfig(channel="zaihuapd"),
         datetime(2026, 7, 6, 0, 0, tzinfo=timezone.utc),
     )
 


### PR DESCRIPTION
## Summary

Balanced digest feature relies on "category" of the source, yet some sources don't have such property in their model. This PR adds missing category property to all source configs and wires them into item metadata.

## Scope

- [x] This PR contains one feature / one fix / one focused change
- [x] This PR does not combine multiple unrelated features

## Changes

- Added `category: Optional[str] = None` to `GitHubSourceConfig`, `HackerNewsConfig`, `RedditSubredditConfig`, `RedditUserConfig`, `TelegramChannelConfig`, `OSSInsightConfig`, and `TwitterConfig`
- Wired category into `metadata["category"]` in all affected scrapers (github, hackernews, reddit, telegram, ossinsight, twitter, twitter_playwright)
- Added `tests/test_category_wiring.py` with 15 tests covering category propagation for each scraper
- Updated info in `docs/configuration.md` and `docs/scrapers.md`

## Notes for Reviewers

Minor refactoring was applied to private methods in `github.py` and `telegram.py` to avoid bloating the signatures with new params:
- `_fetch_user_events`, `_parse_event`, and `_fetch_repo_releases` now accept `source: GitHubSourceConfig` instead of individual string params
- `_parse_message` now accepts `cfg: TelegramChannelConfig` instead of `channel: str, category: Optional[str]`.

## Tests
```
uv run --with pytest pytest tests/
.................................................................................................. [ 32%]
.................................................................................................. [ 65%]
.................................................................................................. [ 98%]
....                                                                                               [100%]
============================================ warnings summary ============================================
.venv/lib/python3.14/site-packages/google/genai/types.py:43: DeprecationWarning: '_UnionGenericAlias' is deprecated and slated for removal in Python 3.17
    VersionedUnionType = Union[builtin_types.UnionType, _UnionGenericAlias]

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
298 passed, 1 warning in 1.29s
```

## Checklist

- [x] I explained the change clearly
- [x] I kept the PR focused and easy to review
- [x] I tested the change locally when applicable

