### PR TITLE
Configure Horizon DeepSeek Codex workflow

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,4 @@
+[mcp_servers.horizon]
+command = "uv"
+args = ["run", "horizon-mcp"]
+cwd = "/Users/tianzhize/.codex/worktrees/770a/workbench/Horizon"

--- a/docs/superpowers/plans/2026-07-11-horizon-deepseek-ai-radar.md
+++ b/docs/superpowers/plans/2026-07-11-horizon-deepseek-ai-radar.md
@@ -1,0 +1,414 @@
+# Horizon + DeepSeek AI Information Radar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Configure the local Horizon checkout as a Chinese AI-engineering news radar powered by the official DeepSeek API, with local Markdown output, Feishu delivery, Codex MCP access, and a daily 08:30 run.
+
+**Architecture:** Keep Horizon's upstream application code unchanged. Store non-secret runtime choices in ignored `data/config.json`, store secrets only in ignored `.env`, register the built-in stdio MCP server in project `.codex/config.toml`, and create the daily automation only after one verified live run.
+
+**Tech Stack:** Python 3.11+, uv, Horizon, DeepSeek OpenAI-compatible API, Codex MCP, Feishu webhook, Markdown
+
+---
+
+## File map
+
+- Create `data/config.json`: ignored local runtime configuration for DeepSeek, sources, filtering, and Feishu.
+- Create `.codex/config.toml`: tracked project configuration that registers the Horizon MCP server; contains no secrets.
+- Create `.env`: ignored local secret file created by the user through silent terminal input.
+- Produce `data/summaries/*.md`: ignored generated Chinese daily reports.
+- Produce `data/mcp-runs/`: ignored staged MCP artifacts.
+- Modify no files under `src/` or `tests/`.
+
+### Task 1: Establish the clean baseline
+
+**Files:**
+- Verify: `pyproject.toml`
+- Verify: `.gitignore`
+- Test: `tests/`
+
+- [ ] **Step 1: Confirm the toolchain and repository state**
+
+Run:
+
+```bash
+cd /Users/tianzhize/.codex/worktrees/770a/workbench/Horizon
+uv --version
+git status --short
+```
+
+Expected: `uv 0.10.8` or newer; only plan/design documentation is tracked and committed; no unrelated changes.
+
+- [ ] **Step 2: Install the project and development dependencies**
+
+Run:
+
+```bash
+uv sync --extra dev
+```
+
+Expected: uv creates or updates `.venv` using Python 3.11+ and installs Horizon plus pytest dependencies without an error.
+
+- [ ] **Step 3: Run the upstream test suite**
+
+Run:
+
+```bash
+uv run pytest
+```
+
+Expected: all existing tests pass. If a test fails, stop configuration work and diagnose the baseline failure before changing project files.
+
+### Task 2: Create the ignored Horizon runtime configuration
+
+**Files:**
+- Create: `data/config.json`
+- Verify: `src/models.py`
+- Verify: `src/ai/client.py`
+
+- [ ] **Step 1: Create `data/config.json` with the approved settings**
+
+Write exactly this JSON:
+
+```json
+{
+  "version": "1.0",
+  "ai": {
+    "provider": "deepseek",
+    "model": "deepseek-v4-flash",
+    "base_url": "https://api.deepseek.com",
+    "api_key_env": "DEEPSEEK_API_KEY",
+    "temperature": 0.3,
+    "max_tokens": 8192,
+    "throttle_sec": 1,
+    "languages": ["zh"],
+    "analysis_concurrency": 3,
+    "enrichment_concurrency": 2
+  },
+  "sources": {
+    "github": [
+      {
+        "type": "user_events",
+        "username": "karpathy",
+        "enabled": true
+      },
+      {
+        "type": "repo_releases",
+        "owner": "openai",
+        "repo": "codex",
+        "enabled": true
+      },
+      {
+        "type": "repo_releases",
+        "owner": "openai",
+        "repo": "openai-agents-python",
+        "enabled": true
+      },
+      {
+        "type": "repo_releases",
+        "owner": "modelcontextprotocol",
+        "repo": "servers",
+        "enabled": true
+      },
+      {
+        "type": "repo_releases",
+        "owner": "vllm-project",
+        "repo": "vllm",
+        "enabled": true
+      },
+      {
+        "type": "repo_releases",
+        "owner": "sgl-project",
+        "repo": "sglang",
+        "enabled": true
+      }
+    ],
+    "hackernews": {
+      "enabled": true,
+      "fetch_top_stories": 30,
+      "min_score": 100
+    },
+    "rss": [
+      {
+        "name": "Simon Willison",
+        "url": "https://simonwillison.net/atom/everything/",
+        "enabled": true,
+        "category": "ai-engineering"
+      },
+      {
+        "name": "GitHub Trending Daily",
+        "url": "https://mshibanami.github.io/GitHubTrendingRSS/daily/all.xml",
+        "enabled": true,
+        "category": "developer-tools"
+      },
+      {
+        "name": "SemiAnalysis",
+        "url": "https://newsletter.semianalysis.com/feed",
+        "enabled": true,
+        "category": "ai-infrastructure"
+      }
+    ],
+    "reddit": {
+      "enabled": true,
+      "subreddits": [
+        {
+          "subreddit": "MachineLearning",
+          "enabled": true,
+          "sort": "hot",
+          "time_filter": "day",
+          "fetch_limit": 10,
+          "min_score": 30
+        },
+        {
+          "subreddit": "LocalLLaMA",
+          "enabled": true,
+          "sort": "hot",
+          "time_filter": "day",
+          "fetch_limit": 10,
+          "min_score": 30
+        }
+      ],
+      "users": [],
+      "fetch_comments": 5
+    },
+    "telegram": {
+      "enabled": true,
+      "channels": [
+        {
+          "channel": "zaihuapd",
+          "enabled": true,
+          "fetch_limit": 20
+        }
+      ]
+    },
+    "ossinsight": {
+      "enabled": true,
+      "period": "past_24_hours",
+      "languages": ["Python", "TypeScript", "Rust"],
+      "keywords": ["agent", "llm", "mcp", "ai", "model", "inference"],
+      "min_stars": 10,
+      "max_items": 25
+    },
+    "gdelt": {
+      "enabled": false,
+      "query": "artificial intelligence",
+      "mode": "ArtList",
+      "max_records": 75,
+      "timespan": null,
+      "language": null,
+      "country": null,
+      "category": "news"
+    },
+    "google_news": {
+      "enabled": false,
+      "query": "artificial intelligence",
+      "language": "en",
+      "country": "US",
+      "ceid": null,
+      "max_results": 100,
+      "category": "news"
+    }
+  },
+  "filtering": {
+    "ai_score_threshold": 7.5,
+    "time_window_hours": 24,
+    "max_items": 15,
+    "category_groups": {},
+    "default_group": "other",
+    "default_group_limit": null
+  },
+  "webhook": {
+    "enabled": true,
+    "url_env": "HORIZON_WEBHOOK_URL",
+    "delivery": "summary_and_items",
+    "overview_position": "last",
+    "platform": "feishu",
+    "layout": "collapsible",
+    "fallback_layout": "markdown",
+    "languages": ["zh"],
+    "request_body": {},
+    "headers": ""
+  }
+}
+```
+
+- [ ] **Step 2: Validate JSON syntax without reading secrets**
+
+Run:
+
+```bash
+uv run python -m json.tool data/config.json >/dev/null
+```
+
+Expected: exit code 0 and no output.
+
+- [ ] **Step 3: Confirm the runtime configuration is ignored**
+
+Run:
+
+```bash
+git check-ignore -v data/config.json
+git status --short
+```
+
+Expected: `.gitignore` reports the `data/config.json` rule and Git does not list the runtime config.
+
+### Task 3: Register Horizon as a project MCP server
+
+**Files:**
+- Create: `.codex/config.toml`
+- Test: `scripts/check_mcp.py`
+
+- [ ] **Step 1: Create the project Codex configuration**
+
+Write exactly:
+
+```toml
+[mcp_servers.horizon]
+command = "uv"
+args = ["run", "horizon-mcp"]
+cwd = "/Users/tianzhize/.codex/worktrees/770a/workbench/Horizon"
+```
+
+- [ ] **Step 2: Run Horizon's MCP smoke check**
+
+Run:
+
+```bash
+uv run python scripts/check_mcp.py
+```
+
+Expected: the script reports successful module import, path resolution, config loading, and metrics access. A missing `DEEPSEEK_API_KEY` may be reported only if the script attempts provider initialization; do not add a fake key.
+
+- [ ] **Step 3: Commit only the non-secret Codex configuration**
+
+Run:
+
+```bash
+git add .codex/config.toml
+git diff --cached --check
+git commit -m "chore: register Horizon MCP for Codex"
+```
+
+Expected: one commit containing only `.codex/config.toml`.
+
+### Task 4: Collect secrets through local silent input
+
+**Files:**
+- Create: `.env`
+
+- [ ] **Step 1: Ask the user to create the ignored secret file locally**
+
+The user runs this in their own terminal from the repository root; secrets are never pasted into chat:
+
+```zsh
+cd /Users/tianzhize/.codex/worktrees/770a/workbench/Horizon
+umask 077
+read -s "DEEPSEEK_API_KEY?DeepSeek API Key: "; echo
+read -s "HORIZON_WEBHOOK_URL?Feishu webhook URL: "; echo
+printf 'DEEPSEEK_API_KEY=%s\nHORIZON_WEBHOOK_URL=%s\n' "$DEEPSEEK_API_KEY" "$HORIZON_WEBHOOK_URL" > .env
+unset DEEPSEEK_API_KEY HORIZON_WEBHOOK_URL
+chmod 600 .env
+```
+
+Expected: the terminal does not echo either value and creates a mode-600 `.env` file.
+
+- [ ] **Step 2: Verify secret presence without printing values**
+
+Run:
+
+```bash
+test "$(stat -f '%Lp' .env)" = "600"
+awk -F= '$1=="DEEPSEEK_API_KEY" && length($2)>8 {deepseek=1} $1=="HORIZON_WEBHOOK_URL" && length($2)>20 {feishu=1} END {exit !(deepseek && feishu)}' .env
+git check-ignore -v .env
+```
+
+Expected: all commands exit 0, `.gitignore` identifies the `.env` rule, and no secret value is printed.
+
+### Task 5: Validate the configured pipeline
+
+**Files:**
+- Verify: `data/config.json`
+- Verify: `.env`
+- Test: `scripts/check_mcp.py`
+
+- [ ] **Step 1: Run the MCP/configuration smoke check with real environment variables**
+
+Run:
+
+```bash
+uv run python scripts/check_mcp.py
+```
+
+Expected: all smoke checks pass.
+
+- [ ] **Step 2: Confirm no secret-bearing file is tracked**
+
+Run:
+
+```bash
+git ls-files --error-unmatch .env >/dev/null 2>&1 && exit 1 || true
+git ls-files --error-unmatch data/config.json >/dev/null 2>&1 && exit 1 || true
+git status --short
+```
+
+Expected: neither ignored file is tracked; only intentional tracked changes, if any, are shown.
+
+### Task 6: Perform the first live DeepSeek and Feishu run
+
+**Files:**
+- Produce: `data/summaries/*.md`
+- Produce: `data/seen.json`
+
+- [ ] **Step 1: Run a bounded first collection**
+
+Run:
+
+```bash
+uv run horizon --hours 24
+```
+
+Expected: Horizon fetches enabled sources, calls `deepseek-v4-flash`, selects at most 15 items, generates Chinese Markdown, and reports Feishu delivery success.
+
+- [ ] **Step 2: Verify a non-empty Chinese report without dumping its contents**
+
+Run:
+
+```bash
+latest="$(find data/summaries -type f -name '*.md' -print | sort | tail -1)"
+test -n "$latest"
+test -s "$latest"
+LC_ALL=C grep -q '[^ -~]' "$latest"
+printf '%s\n' "$latest"
+```
+
+Expected: exit code 0 and one relative Markdown path is printed.
+
+- [ ] **Step 3: Ask the user to confirm Feishu receipt**
+
+Expected: the user confirms that one collapsible Chinese Horizon card arrived. If local Markdown exists but Feishu failed, preserve the report and diagnose only the webhook stage.
+
+### Task 7: Create the verified daily automation
+
+**Files:**
+- External Codex automation record; no repository file change.
+
+- [ ] **Step 1: Create the recurring task only after Task 6 passes**
+
+Create a daily automation at 08:30 in `Asia/Shanghai` with this prompt:
+
+```text
+在 /Users/tianzhize/.codex/worktrees/770a/workbench/Horizon 运行 `uv run horizon --hours 24`。验证 data/summaries 下生成了非空中文 Markdown，并检查飞书推送结果。成功时报告生成文件路径和入选条目数；失败时说明失败阶段，保留已生成的本地产物，不修改信息源或密钥配置。
+```
+
+Expected: automation is enabled, scheduled daily at 08:30, and points to this Horizon checkout.
+
+- [ ] **Step 2: Final verification**
+
+Run:
+
+```bash
+git status --short
+git log -3 --oneline
+```
+
+Expected: the repository is clean; design, plan, and Codex MCP commits are present; `.env`, `data/config.json`, summaries, and MCP run artifacts remain ignored.

--- a/docs/superpowers/specs/2026-07-11-horizon-deepseek-ai-radar-design.md
+++ b/docs/superpowers/specs/2026-07-11-horizon-deepseek-ai-radar-design.md
@@ -1,0 +1,129 @@
+# Horizon + DeepSeek AI 信息雷达设计
+
+## 目标
+
+在本机部署 Horizon，面向 AI 软件工程师持续收集高信噪比信息。Codex 负责交互式操作和定时编排，Horizon 负责抓取、去重、评分、补充背景、生成中文日报，并把同一份结果保存为本地 Markdown、推送到飞书。
+
+首版追求可用、低维护和密钥最少化，不引入 Twitter/Apify、邮件、GitHub Pages、OpenBB 或自定义代码。
+
+## 已确认的选择
+
+| 项目 | 选择 |
+| --- | --- |
+| AI 服务 | DeepSeek 官方 API |
+| API 地址 | `https://api.deepseek.com` |
+| 模型 | `deepseek-v4-flash` |
+| Codex 集成 | Horizon 内置 MCP Server |
+| 主要语言 | 中文 |
+| 输出 | 本地 Markdown + 飞书折叠卡片 |
+| 运行频率 | 每天 08:30，`Asia/Shanghai` |
+| 部署方式 | 本地 `uv` 环境 |
+
+DeepSeek 官方文档当前列出 `deepseek-v4-flash`；Horizon 当前仓库也提供了相同模型的 DeepSeek 配置示例。
+
+## 系统边界
+
+```mermaid
+flowchart LR
+    C["Codex / 每日自动任务"] -->|MCP 或本地命令| H["Horizon 流水线"]
+    S["GitHub / HN / RSS / Reddit / Telegram / OSS Insight"] --> H
+    H --> D["DeepSeek 官方 API"]
+    H --> M["data/summaries/*.md"]
+    H --> F["飞书群机器人"]
+```
+
+Codex 不充当 Horizon 的模型后端，也不把 Codex 登录凭据传给 Horizon。Horizon 只从本机 `.env` 读取 DeepSeek Key 和飞书 Webhook；Codex 通过 MCP 或 `uv run horizon` 触发流水线。
+
+## 运行时文件
+
+以下运行时文件均已被上游 `.gitignore` 排除：
+
+- `.env`：仅保存 `DEEPSEEK_API_KEY`、`HORIZON_WEBHOOK_URL`，以及可选的 `GITHUB_TOKEN`。
+- `data/config.json`：保存非敏感的模型、信息源、过滤和输出配置。
+- `data/summaries/*.md`：每日中文日报。
+- `data/mcp-runs/`：MCP 分阶段运行产物。
+
+密钥不会写入 `data/config.json`、Codex 配置、日志、设计文档或 Git 提交。用户不在聊天中粘贴密钥；实施阶段通过本机终端的静默输入写入 `.env`。
+
+## 信息源设计
+
+首版采用不需要额外密钥的核心来源：
+
+- GitHub：关注代表性研究者动态，以及 Codex、Agents SDK、MCP、vLLM、SGLang 等项目发布。
+- Hacker News：捕捉高讨论度的模型、Agent、开发工具与安全事件。
+- RSS：保留少量高密度技术作者、AI 工程和半导体/基础设施来源。
+- Reddit：`MachineLearning`、`LocalLLaMA`，用于发现社区实践和开源模型信号。
+- Telegram：保留中文 AI 资讯补充源。
+- OSS Insight：发现 Python、TypeScript、Rust 中快速上升的开源项目。
+
+首版不启用 Twitter/X，避免引入 Apify Token、额外成本和较高噪声。后续只有在连续复盘发现明显漏报时才增加来源。
+
+## AI 与过滤策略
+
+DeepSeek 配置采用：
+
+- `provider: deepseek`
+- `model: deepseek-v4-flash`
+- `base_url: https://api.deepseek.com`
+- `api_key_env: DEEPSEEK_API_KEY`
+- `languages: [zh]`
+- `max_tokens: 8192`
+- `temperature: 0.3`
+- `analysis_concurrency: 3`
+- `enrichment_concurrency: 2`
+- `throttle_sec: 1`
+
+首版过滤阈值设为 `7.5`，每期最多保留 15 条。目标是日报可在十分钟内读完，同时为 Agent、Coding、MCP、安全和开发效率类信号保留足够覆盖。运行一周后再依据“入选但不值得读”和“漏掉但值得读”的案例调整阈值与来源，不提前构建复杂评分体系。
+
+## 输出与飞书
+
+Horizon 始终先生成本地 Markdown，再尝试发送飞书。飞书配置采用：
+
+- `platform: feishu`
+- `layout: collapsible`
+- `delivery: summary_and_items`
+- `overview_position: last`
+- `languages: [zh]`
+
+飞书失败不能删除或覆盖本地日报；本地 Markdown 是每次运行的持久结果。Webhook URL 只通过 `HORIZON_WEBHOOK_URL` 注入。
+
+## Codex 与定时运行
+
+项目级 Codex 配置注册名为 `horizon` 的 stdio MCP Server，启动命令为 `uv run horizon-mcp`，工作目录固定为当前 Horizon 仓库根目录。
+
+完成一次真实手动运行后，再创建每天 08:30 的 Codex 自动任务。自动任务只执行以下稳定流程：
+
+1. 在 Horizon 根目录运行最近 24 小时的信息采集。
+2. 验证生成了非空中文 Markdown。
+3. 检查飞书推送结果。
+4. 成功时返回摘要路径，失败时保留本地产物并报告具体阶段。
+
+不在验证之前创建定时任务，避免每天重复运行一个未完成的配置。
+
+## 失败处理
+
+- 缺少 DeepSeek Key 或 Webhook：配置校验必须在正式运行前失败，并明确缺少的环境变量名。
+- DeepSeek 限流或短暂故障：沿用 Horizon 的重试能力，并以较低并发降低触发概率。
+- 单个信息源不可用：允许其他来源继续运行，最终报告中记录降级来源。
+- 飞书发送失败：保留本地 Markdown，运行结果标记推送失败，便于重试。
+- GitHub 未配置 Token：允许按匿名限额运行；只有实际触发限流时才要求补充可选 Token。
+
+## 验证与成功标准
+
+实施完成必须同时满足：
+
+1. `uv sync --extra dev` 成功，仓库现有测试通过。
+2. `data/config.json` 能被 Horizon 加载，且只引用环境变量名，不含明文密钥。
+3. `git status` 和跟踪文件扫描确认 `.env`、运行产物及密钥均未进入版本控制。
+4. `uv run python scripts/check_mcp.py` 通过，Codex 能启动 Horizon MCP Server。
+5. 使用真实 DeepSeek Key 完成一次 24 小时窗口运行，并生成非空中文 Markdown。
+6. 同一次运行的飞书折叠卡片成功送达。
+7. 前六项通过后，创建每天 08:30 的自动任务，并验证其配置指向当前仓库。
+
+## 明确不做
+
+- 不修改 Horizon 上游业务代码。
+- 不建立 `provider: codex` 适配器。
+- 不启用 Twitter/X、邮件、GitHub Pages 或金融数据源。
+- 不在首版加入多模型 fallback、向量数据库或额外 RAG 服务。
+- 不把日报自动编译进此前讨论的持久知识 Wiki；这属于后续独立阶段。


### PR DESCRIPTION
## Summary
- Add project Codex MCP server configuration for Horizon.
- Add the DeepSeek Horizon radar design spec.
- Add the step-by-step setup and verification plan for the daily Horizon workflow.

## Test Plan
- `uv run --no-sync pytest` (283 passed)

## Notes
- Daily generated summaries remain ignored and are not included in this PR.
- No secret values are included; `.env` and `data/config.json` remain ignored local runtime files.
