### PR TITLE
feat(enrich): add pixelrag-style visual extraction for rss/gdelt/goog…

### DIFF
--- a/data/config.example.json
+++ b/data/config.example.json
@@ -45,13 +45,21 @@
         "name": "Simon Willison",
         "url": "https://simonwillison.net/atom/everything/",
         "enabled": true,
-        "category": "ai-tools"
+        "category": "ai-tools",
+        "visual_extraction": {
+          "enabled": false,
+          "timeout_ms": 15000
+        }
       },
       {
         "name": "LWN.net (subscriber full-text)",
         "url": "https://lwn.net/headlines/full_text?key=${LWN_KEY}",
         "enabled": false,
-        "category": "linux"
+        "category": "linux",
+        "visual_extraction": {
+          "enabled": false,
+          "timeout_ms": 15000
+        }
       }
     ],
     "reddit": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -243,12 +243,28 @@ All sources are configured under the top-level `sources` key in `config.json`.
         "name": "Blog Name",
         "url": "https://example.com/feed.xml",
         "enabled": true,
-        "category": "ai-ml"
+        "category": "ai-ml",
+        "visual_extraction": {
+          "enabled": false,
+          "timeout_ms": 15000
+        }
       }
     ]
   }
 }
 ```
+
+- `visual_extraction` — optional, per-feed, disabled by default. When `enabled: true`, high-scoring items from this feed have their article URL rendered to a screenshot (self-hosted headless Chromium via Playwright — no external service, no FAISS/embedding pipeline) during enrichment, and the configured AI provider's vision input is asked whether the real page contains meaningfully more content than the feed's thin summary/teaser. If so, the AI-extracted real content replaces the snippet for that item's background enrichment. Any failure (render timeout, network error, or a non-vision-capable AI provider) degrades gracefully back to the original snippet — items are never dropped.
+  - `timeout_ms` — Playwright page render/screenshot timeout in milliseconds (default: `15000`)
+
+Requires the optional `visual` dependency group and a local Chromium install:
+
+```bash
+uv sync --extra visual
+uv run playwright install chromium
+```
+
+Visual extraction also requires the configured AI provider to support image input (currently Anthropic and OpenAI-compatible providers via `AIClient.complete_vision`); other providers safely skip this step and fall back to the original snippet.
 
 ### Reddit
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ twitter = [
     "playwright>=1.40.0",
     "playwright-stealth>=1.0.0",
 ]
+visual = [
+    "playwright>=1.40.0",
+]
 
 [project.scripts]
 horizon = "src.main:main"

--- a/src/ai/client.py
+++ b/src/ai/client.py
@@ -1,5 +1,6 @@
 """AI client abstraction supporting multiple providers."""
 
+import base64
 import os
 import re
 from abc import ABC, abstractmethod
@@ -110,6 +111,42 @@ class AIClient(ABC):
         """
         pass
 
+    async def complete_vision(
+        self,
+        system: str,
+        user: str,
+        image_data: bytes,
+        image_media_type: str = "image/png",
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+    ) -> str:
+        """Generate a completion grounded in both text and an image.
+
+        Base implementation raises NotImplementedError for providers that
+        don't support vision/image input — callers (e.g. ContentEnricher)
+        must catch this and treat it as a graceful-degradation failure
+        case, not a crash. This is intentionally a concrete (non-abstract)
+        method so existing subclasses that don't override it automatically
+        get this behavior.
+
+        Args:
+            system: System prompt
+            user: User prompt (accompanying text for the image)
+            image_data: Raw image bytes (e.g. a PNG screenshot)
+            image_media_type: MIME type of the image (default "image/png")
+            temperature: Optional sampling temperature override
+            max_tokens: Optional maximum tokens override
+
+        Returns:
+            str: Generated completion text
+
+        Raises:
+            NotImplementedError: If the provider doesn't support vision/image input.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support vision/image input"
+        )
+
 
 class AnthropicClient(AIClient):
     """Client for Anthropic Claude models."""
@@ -160,6 +197,65 @@ class AnthropicClient(AIClient):
             temperature=temperature,
             system=system,
             messages=[{"role": "user", "content": user}]
+        )
+        usage = getattr(message, "usage", None)
+        if usage is not None:
+            record_usage(
+                "anthropic",
+                input_tokens=getattr(usage, "input_tokens", 0),
+                output_tokens=getattr(usage, "output_tokens", 0),
+            )
+        return message.content[0].text
+
+    async def complete_vision(
+        self,
+        system: str,
+        user: str,
+        image_data: bytes,
+        image_media_type: str = "image/png",
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+    ) -> str:
+        """Generate completion grounded in text + an image using Claude's
+        multimodal Messages API.
+
+        Args:
+            system: System prompt
+            user: User prompt (text alongside the image)
+            image_data: Raw image bytes
+            image_media_type: MIME type of the image
+            temperature: Sampling temperature
+            max_tokens: Maximum tokens to generate
+
+        Returns:
+            str: Generated text
+        """
+        temperature = self.temperature if temperature is None else temperature
+        max_tokens = self.max_tokens if max_tokens is None else max_tokens
+
+        encoded_image = base64.b64encode(image_data).decode()
+
+        message = await self.client.messages.create(
+            model=self.model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            system=system,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": image_media_type,
+                                "data": encoded_image,
+                            },
+                        },
+                        {"type": "text", "text": user},
+                    ],
+                }
+            ],
         )
         usage = getattr(message, "usage", None)
         if usage is not None:
@@ -324,6 +420,104 @@ class OpenAIClient(AIClient):
             or "not support" in lowered
             or "unsupported" in lowered
         )
+
+    async def complete_vision(
+        self,
+        system: str,
+        user: str,
+        image_data: bytes,
+        image_media_type: str = "image/png",
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+    ) -> str:
+        """Generate completion grounded in text + an image using the
+        OpenAI-compatible chat completions `image_url` content-part format.
+
+        Args:
+            system: System prompt
+            user: User prompt (text alongside the image)
+            image_data: Raw image bytes
+            image_media_type: MIME type of the image
+            temperature: Sampling temperature
+            max_tokens: Maximum tokens to generate
+
+        Returns:
+            str: Generated text
+        """
+        temperature = self.temperature if temperature is None else temperature
+        max_tokens = self.max_tokens if max_tokens is None else max_tokens
+
+        if self.provider in self._TEMP_CLAMP and temperature <= 0:
+            temperature = 0.01
+
+        try:
+            response = await self._do_vision_request(
+                system=system,
+                user=user,
+                image_data=image_data,
+                image_media_type=image_media_type,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                include_temperature=self._supports_temperature,
+            )
+        except Exception as exc:
+            if self._supports_temperature and self._is_temperature_unsupported(
+                str(exc)
+            ):
+                self._supports_temperature = False
+                response = await self._do_vision_request(
+                    system=system,
+                    user=user,
+                    image_data=image_data,
+                    image_media_type=image_media_type,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    include_temperature=False,
+                )
+            else:
+                raise
+        usage = getattr(response, "usage", None)
+        if usage is not None:
+            record_usage(
+                self.provider,
+                input_tokens=getattr(usage, "prompt_tokens", 0),
+                output_tokens=getattr(usage, "completion_tokens", 0),
+            )
+        return response.choices[0].message.content
+
+    async def _do_vision_request(
+        self,
+        *,
+        system: str,
+        user: str,
+        image_data: bytes,
+        image_media_type: str,
+        temperature: float,
+        max_tokens: int,
+        include_temperature: bool,
+    ):
+        encoded_image = base64.b64encode(image_data).decode()
+        data_url = f"data:{image_media_type};base64,{encoded_image}"
+
+        request_kwargs = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": user},
+                        {"type": "image_url", "image_url": {"url": data_url}},
+                    ],
+                },
+            ],
+            "max_tokens": max_tokens,
+        }
+        if include_temperature:
+            request_kwargs["temperature"] = temperature
+        if self.provider not in self._NO_RESPONSE_FORMAT:
+            request_kwargs["response_format"] = {"type": "json_object"}
+        return await self.client.chat.completions.create(**request_kwargs)
 
 
 class AzureOpenAIClient(AIClient):
@@ -590,6 +784,34 @@ class ChainedAIClient(AIClient):
                         f"falling back to {self.configs[i + 1].provider.value}...[/yellow]"
                     )
         raise RuntimeError(f"All providers failed. Last error: {last_error}")
+
+    async def complete_vision(
+        self,
+        system: str,
+        user: str,
+        image_data: bytes,
+        image_media_type: str = "image/png",
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+    ) -> str:
+        """Delegate to the current (first) client in the chain only.
+
+        Unlike `complete()`, this does not replicate the full multi-provider
+        fallback logic — that would be scope creep for a vision-specific
+        path. If the current provider doesn't support vision, its
+        NotImplementedError propagates so the caller's graceful-degradation
+        handling (e.g. ContentEnricher) can catch it, rather than silently
+        trying every provider in the chain.
+        """
+        client = self._get_client(0)
+        return await client.complete_vision(
+            system,
+            user,
+            image_data,
+            image_media_type=image_media_type,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
 
     @staticmethod
     def _should_fallback(exc: Exception) -> bool:

--- a/src/ai/enricher.py
+++ b/src/ai/enricher.py
@@ -10,7 +10,7 @@ import json
 import re
 import sys
 import os
-from typing import List, Optional
+from typing import Any, List, Optional
 from tenacity import retry, stop_after_attempt, wait_exponential
 from rich.progress import Progress, SpinnerColumn, BarColumn, TextColumn, MofNCompleteColumn
 from ddgs import DDGS
@@ -19,22 +19,97 @@ from .client import AIClient
 from .prompts import (
     CONCEPT_EXTRACTION_SYSTEM, CONCEPT_EXTRACTION_USER,
     CONTENT_ENRICHMENT_SYSTEM, CONTENT_ENRICHMENT_USER,
+    VISUAL_EXTRACTION_SYSTEM, VISUAL_EXTRACTION_USER,
 )
 from .utils import parse_json_response
-from ..models import ContentItem
+from ..models import ContentItem, SourceType, SourcesConfig, VisualExtractionConfig
+
+# Source types eligible for the render-only visual extraction sub-step. Any
+# other source type (GitHub, HackerNews, Reddit, Telegram, Twitter, OpenBB,
+# OSSInsight) never even reaches the gating check.
+_VISUAL_EXTRACTION_SOURCE_TYPES = {
+    SourceType.RSS,
+    SourceType.GDELT,
+    SourceType.GOOGLE_NEWS,
+}
 
 
 class ContentEnricher:
     """Enriches high-scoring content items with background knowledge."""
 
-    def __init__(self, ai_client: AIClient):
+    def __init__(
+        self,
+        ai_client: AIClient,
+        sources_config: Optional[SourcesConfig] = None,
+        visual_renderer: Optional[Any] = None,
+    ):
+        """Initialize the enricher.
+
+        Args:
+            ai_client: AI client used for concept extraction, enrichment,
+                translation, and (if the provider supports it) vision calls.
+            sources_config: Optional `SourcesConfig` used only to resolve the
+                per-item visual-extraction toggle (RSS per-feed, or GDELT /
+                Google News source-level). `None` (the default) disables the
+                visual-extraction sub-step entirely for this instance, which
+                keeps `ContentEnricher(ai_client)` a fully backward-compatible
+                call pattern.
+            visual_renderer: Optional pre-constructed renderer object exposing
+                an async `render(url: str) -> Optional[bytes]` method (e.g. a
+                `VisualRenderer` already entered via `async with`, or a mock
+                for tests). If not provided, `enrich_batch` lazily constructs
+                and manages a real `VisualRenderer` for the duration of the
+                batch, but only if at least one item in that batch actually
+                needs it.
+        """
         self.client = ai_client
+        self.sources_config = sources_config
+        self._visual_renderer = visual_renderer
 
     def _get_concurrency(self) -> int:
         """Return the configured enrichment concurrency, clamped to 1 or above."""
         config = getattr(self.client, "config", None)
         concurrency = getattr(config, "enrichment_concurrency", 1)
         return max(concurrency, 1)
+
+    def _resolve_visual_extraction(
+        self, item: ContentItem
+    ) -> Optional[VisualExtractionConfig]:
+        """Resolve the per-item visual-extraction config, or None if disabled.
+
+        Returns None (treat as disabled, no-op) whenever:
+        - `sources_config` was never provided to this instance.
+        - `item.source_type` is not RSS/GDELT/GOOGLE_NEWS.
+        - The resolved config's `.enabled` is False.
+        - No matching RSS feed config is found by `feed_name`.
+        - The GDELT/Google News source config is not set (`None`).
+        """
+        if self.sources_config is None:
+            return None
+        if item.source_type not in _VISUAL_EXTRACTION_SOURCE_TYPES:
+            return None
+
+        ve_config: Optional[VisualExtractionConfig] = None
+        if item.source_type == SourceType.RSS:
+            feed_name = item.metadata.get("feed_name")
+            for rss_source in self.sources_config.rss:
+                if rss_source.name == feed_name:
+                    ve_config = rss_source.visual_extraction
+                    break
+        elif item.source_type == SourceType.GDELT:
+            if self.sources_config.gdelt is not None:
+                ve_config = self.sources_config.gdelt.visual_extraction
+        elif item.source_type == SourceType.GOOGLE_NEWS:
+            if self.sources_config.google_news is not None:
+                ve_config = self.sources_config.google_news.visual_extraction
+
+        if ve_config is None or not ve_config.enabled:
+            return None
+        return ve_config
+
+    def _batch_needs_visual_extraction(self, items: List[ContentItem]) -> bool:
+        """True if at least one item in the batch resolves to an enabled toggle."""
+        return any(self._resolve_visual_extraction(item) is not None for item in items)
 
     async def enrich_batch(self, items: List[ContentItem]) -> None:
         """Enrich items in-place with background knowledge.
@@ -45,27 +120,51 @@ class ContentEnricher:
         concurrency = self._get_concurrency()
         semaphore = asyncio.Semaphore(concurrency)
 
-        async def _process(item: ContentItem, progress_task) -> None:
-            async with semaphore:
-                try:
-                    await self._enrich_item(item)
-                except Exception as e:
-                    print(f"Error enriching item {item.id}: {e}, falling back to translation")
-                    await self._translate_item(item)
-            progress.advance(progress_task)
+        # Lazily construct and enter a real VisualRenderer for this batch only
+        # if: (a) no renderer was already injected via the constructor, and
+        # (b) at least one item in this batch actually needs one. This keeps
+        # the toggle-off path free of any Playwright import/launch attempt.
+        owns_renderer = False
+        renderer_cm = None
+        if self._visual_renderer is None and self._batch_needs_visual_extraction(items):
+            from .visual_renderer import VisualRenderer
 
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
-            MofNCompleteColumn(),
-            transient=True,
-        ) as progress:
-            task = progress.add_task("Enriching", total=len(items))
-            coros = [
-                _process(item, task) for item in items
+            timeout_candidates = [
+                cfg.timeout_ms
+                for item in items
+                if (cfg := self._resolve_visual_extraction(item)) is not None
             ]
-            await asyncio.gather(*coros)
+            timeout_ms = max(timeout_candidates) if timeout_candidates else 15000
+            renderer_cm = VisualRenderer(timeout_ms=timeout_ms)
+            self._visual_renderer = await renderer_cm.__aenter__()
+            owns_renderer = True
+
+        try:
+            async def _process(item: ContentItem, progress_task) -> None:
+                async with semaphore:
+                    try:
+                        await self._enrich_item(item)
+                    except Exception as e:
+                        print(f"Error enriching item {item.id}: {e}, falling back to translation")
+                        await self._translate_item(item)
+                progress.advance(progress_task)
+
+            with Progress(
+                SpinnerColumn(),
+                TextColumn("[progress.description]{task.description}"),
+                BarColumn(),
+                MofNCompleteColumn(),
+                transient=True,
+            ) as progress:
+                task = progress.add_task("Enriching", total=len(items))
+                coros = [
+                    _process(item, task) for item in items
+                ]
+                await asyncio.gather(*coros)
+        finally:
+            if owns_renderer and renderer_cm is not None:
+                await renderer_cm.__aexit__(None, None, None)
+                self._visual_renderer = None
 
     async def _web_search(self, query: str, max_results: int = 3) -> list:
         """Search the web for context via DuckDuckGo.
@@ -129,6 +228,63 @@ class ContentEnricher:
         except Exception:
             return []
 
+    async def _maybe_visual_extract(self, item: ContentItem, content_text: str) -> str:
+        """Render-and-vision sub-step: try to replace the thin snippet with the
+        real rendered article content, for RSS/GDELT/Google News items whose
+        per-source visual-extraction toggle is enabled.
+
+        This never raises: any failure (gate doesn't match, no renderer
+        available, render failure/timeout, non-vision-capable AI client,
+        malformed JSON response, etc.) is swallowed and the original
+        `content_text` is returned unchanged, exactly as if the toggle were
+        off.
+
+        Args:
+            item: Content item (may be updated in-place via metadata)
+            content_text: The existing (thin) content text already extracted
+                from the item's feed/API snippet
+
+        Returns:
+            str: Either the original `content_text`, or AI-extracted real
+            article content if the vision step succeeded and indicated the
+            real page differs meaningfully from the snippet.
+        """
+        ve_config = self._resolve_visual_extraction(item)
+        if ve_config is None:
+            return content_text
+
+        renderer = self._visual_renderer
+        if renderer is None:
+            return content_text
+
+        try:
+            png_bytes = await renderer.render(str(item.url))
+            if png_bytes is None:
+                return content_text
+
+            user_prompt = VISUAL_EXTRACTION_USER.format(
+                title=item.title,
+                snippet=content_text[:4000] if content_text else "(no snippet content available)",
+            )
+            response = await self.client.complete_vision(
+                system=VISUAL_EXTRACTION_SYSTEM,
+                user=user_prompt,
+                image_data=png_bytes,
+            )
+            result = self._parse_json_response(response)
+            if not result:
+                return content_text
+
+            if result.get("differs_meaningfully") and result.get("extracted_content"):
+                extracted = str(result["extracted_content"]).strip()[:4000]
+                if extracted:
+                    item.metadata["visual_extracted_content"] = extracted
+                    return extracted
+            return content_text
+        except Exception as e:
+            print(f"Visual extraction failed for item {item.id}: {e}")
+            return content_text
+
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(min=2, max=10)
@@ -137,6 +293,10 @@ class ContentEnricher:
         """Enrich a single item with background knowledge.
 
         Steps:
+        0. (RSS/GDELT/Google News, if enabled) Render the article URL and ask
+           a vision-capable AI whether the real page differs meaningfully
+           from the thin snippet, using the extracted real content in place
+           of the snippet if so
         1. Ask AI which concepts in the news need explanation
         2. Search the web for those concepts
         3. Ask AI to generate background based on search results
@@ -154,6 +314,13 @@ class ContentEnricher:
                 comments_text = comments_part.strip()[:2000]
             else:
                 content_text = item.content[:4000]
+
+        # Step 0: render-only visual extraction sub-step (RSS/GDELT/Google
+        # News only, opt-in, gracefully degrades on any failure). May
+        # replace content_text with AI-extracted real article content,
+        # which then grounds the rest of this method (concept extraction,
+        # web search, and the final enrichment call).
+        content_text = await self._maybe_visual_extract(item, content_text)
 
         # Step 1: AI identifies concepts to explain
         queries = await self._extract_concepts(item, content_text)

--- a/src/ai/prompts.py
+++ b/src/ai/prompts.py
@@ -170,3 +170,26 @@ Respond with valid JSON only. Each _en field must be in English; each _zh field 
   "community_discussion_zh": "<用中文写1-3句话，或空字符串>",
   "sources": ["<url from search results>", "..."]
 }}"""
+
+VISUAL_EXTRACTION_SYSTEM = """You are a meticulous research assistant that reads full web pages of news articles by looking at rendered screenshots.
+
+You will be shown a screenshot of the actual, live article page alongside a thin text snippet (title + a short summary/teaser) which is all that a feed/API currently exposes for the same item.
+
+Your job:
+1. Read the screenshot carefully and determine whether the real article page contains substantially more or different information than the thin snippet already provided (e.g. the snippet is a truncated teaser, a paywall placeholder, or missing key facts/quotes/numbers that are visible on the page).
+2. If it does, extract the real article's main text content as plain text (title/body paragraphs; skip navigation, ads, cookie banners, related-article widgets, and other page chrome).
+3. If the snippet already captures the substance of the page (no meaningful difference), say so and do not fabricate additional content.
+
+Never invent facts that are not visible in the screenshot. Never include your own commentary in the extracted content field."""
+
+VISUAL_EXTRACTION_USER = """Compare the rendered screenshot of the live article page against the thin snippet below, and report whether the real page contains meaningfully more/different content.
+
+Title: {title}
+Existing thin snippet/summary:
+{snippet}
+
+Respond with valid JSON only:
+{{
+  "differs_meaningfully": <true or false>,
+  "extracted_content": "<the real article's main text extracted from the screenshot, plain text, up to ~4000 characters; empty string if differs_meaningfully is false or extraction isn't possible>"
+}}"""

--- a/src/ai/visual_renderer.py
+++ b/src/ai/visual_renderer.py
@@ -1,0 +1,180 @@
+"""Render-only visual extraction primitive: screenshot a URL with Playwright.
+
+This module renders a URL to a raw PNG screenshot so that a vision-capable
+AI client can inspect the real, rendered page content (as opposed to the
+thin snippet/teaser text an RSS/GDELT/Google News feed already provides).
+
+Design notes (see `.handoffs/00-ceo-brief.md`):
+- This is a self-hosted render step only. It does not depend on the
+  PixelRAG package, FAISS, or any embedding model — those were explicitly
+  ruled out. A lightweight `pixelrag_render`-style PyPI package was not a
+  realistic dependency (PixelRAG's render primitive isn't published as a
+  standalone installable package), so the render step is implemented
+  directly with Playwright's `page.screenshot()`, which is exactly the
+  primitive PixelRAG itself uses under the hood.
+- Mirrors the "optional dependency" pattern used by
+  `src/scrapers/twitter_playwright.py`: Playwright is only imported inside
+  a try/except so the rest of the codebase (including this module's own
+  import) works fine even when Playwright/Chromium isn't installed. The
+  `playwright` package is expected to live under a new `visual` extra in
+  `pyproject.toml` (owned by a sibling task), not the existing `twitter`
+  extra.
+- `VisualRenderer` is a plain, config-agnostic, injectable primitive — it
+  does not read Horizon's global `Config`/pydantic models. Callers (the
+  enrichment/orchestrator wiring layer) are expected to construct it once
+  with simple values (e.g. `timeout_ms` sourced from
+  `visual_extraction.timeout_ms`) and inject it, matching `BaseScraper`'s
+  constructor-injected `httpx.AsyncClient` pattern.
+- Implemented as an async context manager that launches a single shared
+  Chromium browser instance on `__aenter__` and closes it on `__aexit__`,
+  reusing that browser across many `render()` calls (each call opens and
+  closes its own page/context for isolation). This gives better
+  performance than a launch-per-call design while still matching the
+  "construct once, inject, reuse" DI spirit requested in the brief.
+  Calling contract: `async with VisualRenderer(...) as renderer:` then
+  `await renderer.render(url)` per item.
+"""
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Optional Playwright import — gracefully degraded if not installed.
+# Nothing else in this module requires Playwright to be importable.
+try:
+    from playwright.async_api import Browser, async_playwright
+
+    PLAYWRIGHT_AVAILABLE = True
+except ImportError:
+    PLAYWRIGHT_AVAILABLE = False
+    Browser = None  # type: ignore[misc,assignment]
+
+
+class VisualRenderer:
+    """Renders a URL to a PNG screenshot using a shared headless Chromium browser.
+
+    Usage:
+        async with VisualRenderer(timeout_ms=15000) as renderer:
+            png_bytes = await renderer.render("https://example.com/article")
+            if png_bytes is not None:
+                ...  # pass to a vision-capable AIClient
+
+    `render()` never raises: it returns `None` on any failure (Playwright
+    not installed, navigation timeout, network error, or any other
+    exception), logging a warning instead. This is a hard requirement so
+    that render failures degrade gracefully rather than dropping items or
+    crashing the enrichment pipeline.
+    """
+
+    def __init__(
+        self,
+        timeout_ms: int = 15000,
+        viewport_width: int = 1280,
+        viewport_height: int = 1600,
+        headless: bool = True,
+    ):
+        """Initialize renderer configuration (no browser is launched yet).
+
+        Args:
+            timeout_ms: Navigation timeout in milliseconds for `page.goto`.
+            viewport_width: Viewport width in pixels for the rendered page.
+            viewport_height: Viewport height in pixels for the rendered page.
+            headless: Whether to launch Chromium headless (should stay True
+                for server-side use).
+        """
+        self.timeout_ms = timeout_ms
+        self.viewport_width = viewport_width
+        self.viewport_height = viewport_height
+        self.headless = headless
+
+        self._playwright_cm = None
+        self._playwright = None
+        self._browser: Optional["Browser"] = None
+
+    async def __aenter__(self) -> "VisualRenderer":
+        if not PLAYWRIGHT_AVAILABLE:
+            logger.warning(
+                "Playwright not installed; VisualRenderer will no-op. "
+                "Run: uv sync --extra visual && uv run playwright install chromium"
+            )
+            return self
+
+        try:
+            self._playwright_cm = async_playwright()
+            self._playwright = await self._playwright_cm.__aenter__()
+            self._browser = await self._playwright.chromium.launch(
+                headless=self.headless
+            )
+        except Exception as exc:
+            logger.warning("Failed to launch Playwright/Chromium: %s", exc)
+            self._browser = None
+            self._playwright = None
+            self._playwright_cm = None
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        try:
+            if self._browser is not None:
+                await self._browser.close()
+        except Exception as exc:
+            logger.warning("Error closing Playwright browser: %s", exc)
+        finally:
+            self._browser = None
+
+        if self._playwright_cm is not None:
+            try:
+                await self._playwright_cm.__aexit__(exc_type, exc_val, exc_tb)
+            except Exception as exc:
+                logger.warning("Error tearing down Playwright: %s", exc)
+            finally:
+                self._playwright_cm = None
+                self._playwright = None
+
+    async def render(self, url: str) -> Optional[bytes]:
+        """Render `url` and return raw PNG screenshot bytes, or None on failure.
+
+        Never raises. Returns None immediately if Playwright isn't
+        installed, the shared browser failed to launch, or the browser
+        wasn't started via `async with`. Any navigation/timeout/network
+        error during rendering is caught, logged as a warning, and also
+        results in None.
+        """
+        if not PLAYWRIGHT_AVAILABLE:
+            logger.warning("Playwright not installed; cannot render %s", url)
+            return None
+
+        if self._browser is None:
+            logger.warning(
+                "VisualRenderer browser is not started (use 'async with "
+                "VisualRenderer() as renderer:'); cannot render %s",
+                url,
+            )
+            return None
+
+        context = None
+        try:
+            context = await self._browser.new_context(
+                viewport={
+                    "width": self.viewport_width,
+                    "height": self.viewport_height,
+                }
+            )
+            page = await context.new_page()
+            await page.goto(url, wait_until="domcontentloaded", timeout=self.timeout_ms)
+            # Brief extra wait so above-the-fold content (lazy images, JS
+            # rendered text) has a chance to settle. Full network-idle is
+            # unnecessary for a "does the real page differ from the RSS
+            # snippet" check.
+            await page.wait_for_timeout(min(2000, self.timeout_ms))
+            screenshot_bytes = await page.screenshot(type="png")
+            return screenshot_bytes
+        except Exception as exc:
+            logger.warning("Failed to render %s: %s", url, exc)
+            return None
+        finally:
+            if context is not None:
+                try:
+                    await context.close()
+                except Exception as exc:
+                    logger.debug("Error closing render context for %s: %s", url, exc)

--- a/src/models.py
+++ b/src/models.py
@@ -17,6 +17,8 @@ class SourceType(str, Enum):
     TWITTER = "twitter"
     OPENBB = "openbb"
     OSSINSIGHT = "ossinsight"
+    GDELT = "gdelt"
+    GOOGLE_NEWS = "google_news"
 
 
 class ContentItem(BaseModel):
@@ -131,6 +133,22 @@ class HackerNewsConfig(BaseModel):
     min_score: int = 100
 
 
+class VisualExtractionConfig(BaseModel):
+    """Render-only visual extraction sub-step configuration.
+
+    Gates the optional second-pass enrichment sub-step that renders an
+    item's article URL to a screenshot (self-hosted Playwright render, no
+    FAISS/embedding pipeline, no hosted PixelRAG API) and asks the
+    configured vision-capable AI client whether the real page content
+    differs meaningfully from the thin RSS/GDELT/Google News snippet.
+    Disabled by default, matching the opt-in convention used for every
+    other new source/feature in this repo.
+    """
+
+    enabled: bool = False
+    timeout_ms: int = 15000  # Playwright page render/screenshot timeout
+
+
 class RSSSourceConfig(BaseModel):
     """RSS feed source configuration."""
 
@@ -138,6 +156,12 @@ class RSSSourceConfig(BaseModel):
     url: HttpUrl
     enabled: bool = True
     category: Optional[str] = None
+    # Per-feed toggle: RSS has no source-type-level wrapper object (it is a
+    # List[RSSSourceConfig] on SourcesConfig), so visual extraction is
+    # configured per-feed rather than globally for all RSS sources.
+    visual_extraction: VisualExtractionConfig = Field(
+        default_factory=VisualExtractionConfig
+    )
 
 
 class RedditSubredditConfig(BaseModel):
@@ -264,6 +288,43 @@ class OSSInsightConfig(BaseModel):
     max_items: int = 30
 
 
+class GDELTConfig(BaseModel):
+    """GDELT source configuration — minimal forward-compatible placeholder.
+
+    NOTE: The actual GDELT scraper and its full config surface (query,
+    mode, max_records, timespan, language, country filters, etc.) live in
+    the unmerged `news-api-scrapers` branch. This placeholder exists only
+    so `SourceType.GDELT` and the visual-extraction toggle can be gated
+    here without a naming mismatch when the two branches are eventually
+    merged. Intentionally minimal — do NOT add unrelated fields (API
+    endpoints, query params, etc.) here; reconcile with the full config
+    shape from `news-api-scrapers` at merge time instead.
+    """
+
+    enabled: bool = True
+    visual_extraction: VisualExtractionConfig = Field(
+        default_factory=VisualExtractionConfig
+    )
+
+
+class GoogleNewsConfig(BaseModel):
+    """Google News source configuration — minimal forward-compatible placeholder.
+
+    NOTE: The actual Google News RSS-search scraper and its full config
+    surface live in the unmerged `news-api-scrapers` branch. This
+    placeholder exists only so `SourceType.GOOGLE_NEWS` and the
+    visual-extraction toggle can be gated here without a naming mismatch
+    when the two branches are eventually merged. Intentionally minimal —
+    do NOT add unrelated fields here; reconcile with the full config shape
+    from `news-api-scrapers` at merge time instead.
+    """
+
+    enabled: bool = True
+    visual_extraction: VisualExtractionConfig = Field(
+        default_factory=VisualExtractionConfig
+    )
+
+
 class SourcesConfig(BaseModel):
     """All sources configuration."""
 
@@ -275,6 +336,8 @@ class SourcesConfig(BaseModel):
     twitter: Optional[TwitterConfig] = None
     openbb: Optional[OpenBBConfig] = None
     ossinsight: OSSInsightConfig = Field(default_factory=OSSInsightConfig)
+    gdelt: Optional[GDELTConfig] = None
+    google_news: Optional[GoogleNewsConfig] = None
 
 
 class WebhookConfig(BaseModel):

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -664,7 +664,7 @@ class HorizonOrchestrator:
 
         self.console.print("📚 Enriching with background knowledge...")
         ai_client = create_ai_client(self.config.ai)
-        enricher = ContentEnricher(ai_client)
+        enricher = ContentEnricher(ai_client, sources_config=self.config.sources)
         await enricher.enrich_batch(items)
         self.console.print(f"   Enriched {len(items)} items\n")
 

--- a/tests/test_ai_client_vision.py
+++ b/tests/test_ai_client_vision.py
@@ -1,0 +1,352 @@
+"""Tests for AIClient.complete_vision and its provider-specific overrides.
+
+Covers:
+- AnthropicClient.complete_vision: multimodal Messages API content block.
+- OpenAIClient.complete_vision: OpenAI-compatible `image_url` data-URI content part.
+- The base AIClient.complete_vision default (NotImplementedError), verified
+  both via a minimal fake subclass and via AzureOpenAIClient/GeminiClient
+  (the two concrete clients that intentionally do NOT override it).
+- ChainedAIClient.complete_vision delegating to its first/current client only.
+
+All AI SDK clients are mocked; no live network or vision calls are made.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.ai.client import (
+    AIClient,
+    AnthropicClient,
+    AzureOpenAIClient,
+    ChainedAIClient,
+    GeminiClient,
+    OpenAIClient,
+)
+from src.models import AIConfig, AIProvider
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n-fake-screenshot-bytes"
+
+
+def _anthropic_config(**overrides) -> AIConfig:
+    defaults = {
+        "provider": AIProvider.ANTHROPIC,
+        "model": "claude-3-5-sonnet-20241022",
+        "api_key_env": "ANTHROPIC_API_KEY",
+        "temperature": 0.3,
+        "max_tokens": 4096,
+    }
+    defaults.update(overrides)
+    return AIConfig(**defaults)
+
+
+def _openai_config(**overrides) -> AIConfig:
+    defaults = {
+        "provider": AIProvider.OPENAI,
+        "model": "gpt-4o",
+        "api_key_env": "OPENAI_API_KEY",
+        "temperature": 0.3,
+        "max_tokens": 4096,
+    }
+    defaults.update(overrides)
+    return AIConfig(**defaults)
+
+
+def _azure_config(**overrides) -> AIConfig:
+    defaults = {
+        "provider": AIProvider.AZURE,
+        "model": "gpt-4o-deployment",
+        "api_key_env": "AZURE_OPENAI_API_KEY",
+        "azure_endpoint_env": "AZURE_OPENAI_ENDPOINT",
+        "api_version": "2024-10-21",
+        "temperature": 0.3,
+        "max_tokens": 4096,
+    }
+    defaults.update(overrides)
+    return AIConfig(**defaults)
+
+
+def _gemini_config(**overrides) -> AIConfig:
+    defaults = {
+        "provider": AIProvider.GEMINI,
+        "model": "gemini-1.5-flash",
+        "api_key_env": "GOOGLE_API_KEY",
+        "temperature": 0.3,
+        "max_tokens": 4096,
+    }
+    defaults.update(overrides)
+    return AIConfig(**defaults)
+
+
+class TestAnthropicCompleteVision:
+    def test_builds_multimodal_content_block_and_returns_text(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        client = AnthropicClient(_anthropic_config())
+
+        mock_message = SimpleNamespace(
+            content=[SimpleNamespace(text="the real article says X, Y, Z")],
+            usage=SimpleNamespace(input_tokens=42, output_tokens=7),
+        )
+
+        with patch.object(
+            client.client.messages, "create", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.return_value = mock_message
+            result = asyncio.run(
+                client.complete_vision(
+                    system="vision system prompt",
+                    user="Compare screenshot vs snippet",
+                    image_data=PNG_BYTES,
+                )
+            )
+
+        assert result == "the real article says X, Y, Z"
+        call_kwargs = mock_create.call_args[1]
+        assert call_kwargs["model"] == "claude-3-5-sonnet-20241022"
+        assert call_kwargs["system"] == "vision system prompt"
+
+        messages = call_kwargs["messages"]
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+        content_blocks = messages[0]["content"]
+
+        image_blocks = [b for b in content_blocks if b["type"] == "image"]
+        text_blocks = [b for b in content_blocks if b["type"] == "text"]
+        assert len(image_blocks) == 1
+        assert len(text_blocks) == 1
+        assert text_blocks[0]["text"] == "Compare screenshot vs snippet"
+
+        image_source = image_blocks[0]["source"]
+        assert image_source["type"] == "base64"
+        assert image_source["media_type"] == "image/png"
+        assert image_source["data"] == base64.b64encode(PNG_BYTES).decode()
+
+    def test_respects_custom_image_media_type(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        client = AnthropicClient(_anthropic_config())
+
+        mock_message = SimpleNamespace(
+            content=[SimpleNamespace(text="ok")],
+            usage=None,
+        )
+
+        with patch.object(
+            client.client.messages, "create", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.return_value = mock_message
+            asyncio.run(
+                client.complete_vision(
+                    system="sys",
+                    user="usr",
+                    image_data=PNG_BYTES,
+                    image_media_type="image/jpeg",
+                )
+            )
+
+        content_blocks = mock_create.call_args[1]["messages"][0]["content"]
+        image_block = next(b for b in content_blocks if b["type"] == "image")
+        assert image_block["source"]["media_type"] == "image/jpeg"
+
+
+class TestOpenAICompleteVision:
+    def test_builds_image_url_data_uri_and_returns_text(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        client = OpenAIClient(_openai_config())
+
+        mock_response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="extracted real content"))],
+            usage=SimpleNamespace(prompt_tokens=100, completion_tokens=20),
+        )
+
+        with patch.object(
+            client.client.chat.completions, "create", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.return_value = mock_response
+            result = asyncio.run(
+                client.complete_vision(
+                    system="vision system prompt",
+                    user="Compare screenshot vs snippet",
+                    image_data=PNG_BYTES,
+                )
+            )
+
+        assert result == "extracted real content"
+        call_kwargs = mock_create.call_args[1]
+        assert call_kwargs["model"] == "gpt-4o"
+
+        messages = call_kwargs["messages"]
+        assert messages[0] == {"role": "system", "content": "vision system prompt"}
+        user_content = messages[1]["content"]
+        text_parts = [p for p in user_content if p["type"] == "text"]
+        image_parts = [p for p in user_content if p["type"] == "image_url"]
+        assert text_parts[0]["text"] == "Compare screenshot vs snippet"
+
+        expected_data_url = f"data:image/png;base64,{base64.b64encode(PNG_BYTES).decode()}"
+        assert image_parts[0]["image_url"]["url"] == expected_data_url
+
+    def test_minimax_provider_skips_response_format_for_vision(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+        client = OpenAIClient(
+            _openai_config(provider=AIProvider.MINIMAX, model="MiniMax-M3", api_key_env="MINIMAX_API_KEY")
+        )
+
+        mock_response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))],
+            usage=None,
+        )
+
+        with patch.object(
+            client.client.chat.completions, "create", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.return_value = mock_response
+            asyncio.run(
+                client.complete_vision(system="s", user="u", image_data=PNG_BYTES)
+            )
+
+        assert "response_format" not in mock_create.call_args[1]
+
+    def test_retries_without_temperature_on_deprecated_error(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        client = OpenAIClient(_openai_config())
+
+        mock_response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))],
+            usage=None,
+        )
+
+        with patch.object(
+            client.client.chat.completions, "create", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.side_effect = [
+                Exception("`temperature` is deprecated for this model."),
+                mock_response,
+            ]
+            result = asyncio.run(
+                client.complete_vision(system="s", user="u", image_data=PNG_BYTES)
+            )
+
+        assert result == "ok"
+        assert mock_create.call_count == 2
+        assert "temperature" in mock_create.call_args_list[0][1]
+        assert "temperature" not in mock_create.call_args_list[1][1]
+
+
+class TestBaseCompleteVisionDefault:
+    """Providers that don't override complete_vision inherit NotImplementedError."""
+
+    def test_minimal_subclass_without_override_raises_not_implemented(self):
+        class _MinimalClient(AIClient):
+            async def complete(self, system, user, temperature=None, max_tokens=None):
+                return "unused"
+
+        client = _MinimalClient()
+
+        with pytest.raises(NotImplementedError, match="_MinimalClient"):
+            asyncio.run(
+                client.complete_vision(system="s", user="u", image_data=PNG_BYTES)
+            )
+
+    def test_azure_client_does_not_override_complete_vision(self, monkeypatch):
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-key")
+        monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com")
+        client = AzureOpenAIClient(_azure_config())
+
+        with pytest.raises(NotImplementedError, match="AzureOpenAIClient"):
+            asyncio.run(
+                client.complete_vision(system="s", user="u", image_data=PNG_BYTES)
+            )
+
+    def test_gemini_client_does_not_override_complete_vision(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+        client = GeminiClient(_gemini_config())
+
+        with pytest.raises(NotImplementedError, match="GeminiClient"):
+            asyncio.run(
+                client.complete_vision(system="s", user="u", image_data=PNG_BYTES)
+            )
+
+
+class TestChainedCompleteVision:
+    """ChainedAIClient.complete_vision delegates to its first/current client only."""
+
+    def test_delegates_to_first_client_on_success(self):
+        cfg1 = AIConfig(provider=AIProvider.OPENAI, model="m1", api_key_env="K1")
+        cfg2 = AIConfig(provider=AIProvider.OLLAMA, model="m2", api_key_env="")
+
+        class _VisionCapableDummy:
+            def __init__(self, result):
+                self.result = result
+                self.calls = []
+
+            async def complete_vision(self, system, user, image_data, image_media_type="image/png", temperature=None, max_tokens=None):
+                self.calls.append((system, user, image_data, image_media_type, temperature, max_tokens))
+                return self.result
+
+        client1 = _VisionCapableDummy(result="vision text from provider 1")
+        client2 = _VisionCapableDummy(result="should never be called")
+
+        chained = ChainedAIClient([cfg1, cfg2], clients=[client1, client2])
+        result = asyncio.run(
+            chained.complete_vision(system="sys", user="usr", image_data=PNG_BYTES)
+        )
+
+        assert result == "vision text from provider 1"
+        assert len(client1.calls) == 1
+        assert len(client2.calls) == 0
+
+    def test_propagates_not_implemented_error_from_first_client_without_fallback(self):
+        cfg1 = AIConfig(provider=AIProvider.AZURE, model="m1", api_key_env="K1")
+        cfg2 = AIConfig(provider=AIProvider.OPENAI, model="m2", api_key_env="K2")
+
+        class _NonVisionDummy:
+            async def complete_vision(self, *args, **kwargs):
+                raise NotImplementedError("_NonVisionDummy does not support vision/image input")
+
+        class _NeverCalledDummy:
+            def __init__(self):
+                self.called = False
+
+            async def complete_vision(self, *args, **kwargs):
+                self.called = True
+                return "should not happen"
+
+        client1 = _NonVisionDummy()
+        client2 = _NeverCalledDummy()
+
+        chained = ChainedAIClient([cfg1, cfg2], clients=[client1, client2])
+
+        with pytest.raises(NotImplementedError):
+            asyncio.run(
+                chained.complete_vision(system="sys", user="usr", image_data=PNG_BYTES)
+            )
+
+        # Unlike complete(), complete_vision does NOT fall back to the next provider.
+        assert client2.called is False
+
+    def test_does_not_construct_downstream_clients_when_first_succeeds(self):
+        cfg1 = AIConfig(provider=AIProvider.OPENAI, model="m1", api_key_env="K1")
+        cfg2 = AIConfig(provider=AIProvider.OLLAMA, model="m2", api_key_env="")
+
+        class _VisionCapableDummy:
+            async def complete_vision(self, *args, **kwargs):
+                return "ok"
+
+        factory_calls = []
+
+        def factory(cfg):
+            factory_calls.append(cfg)
+            return _VisionCapableDummy()
+
+        chained = ChainedAIClient([cfg1, cfg2], client_factory=factory)
+        result = asyncio.run(
+            chained.complete_vision(system="sys", user="usr", image_data=PNG_BYTES)
+        )
+
+        assert result == "ok"
+        assert len(factory_calls) == 1
+        assert factory_calls[0].provider == AIProvider.OPENAI

--- a/tests/test_enricher_visual_extraction.py
+++ b/tests/test_enricher_visual_extraction.py
@@ -1,0 +1,553 @@
+"""Tests for the visual-extraction sub-step wired into ContentEnricher
+(src/ai/enricher.py): the gate matrix (_resolve_visual_extraction), the
+render+vision sub-step (_maybe_visual_extract), and enrich_batch's lazy
+VisualRenderer construction/teardown.
+
+Fully mocked: no real Playwright browser, no live AI/vision calls. The AI
+client and visual renderer are both simple fake objects with async methods
+recording their calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import List, Optional
+from unittest.mock import AsyncMock, patch
+
+from src.ai.enricher import ContentEnricher
+from src.models import (
+    ContentItem,
+    GDELTConfig,
+    GoogleNewsConfig,
+    RSSSourceConfig,
+    SourceType,
+    SourcesConfig,
+    VisualExtractionConfig,
+)
+
+PNG_BYTES = b"fake-screenshot-bytes"
+
+
+def _valid_enrichment_json() -> str:
+    """A minimal but well-formed CONTENT_ENRICHMENT_USER-shaped JSON response."""
+    return json.dumps(
+        {
+            "title_en": "Title",
+            "title_zh": "标题",
+            "whats_new_en": "Something new happened.",
+            "whats_new_zh": "发生了新事情。",
+            "why_it_matters_en": "It matters because reasons.",
+            "why_it_matters_zh": "这很重要。",
+            "key_details_en": "Some key detail.",
+            "key_details_zh": "一些关键细节。",
+            "background_en": "",
+            "background_zh": "",
+            "community_discussion_en": "",
+            "community_discussion_zh": "",
+            "sources": [],
+        }
+    )
+
+
+class _FakeAIClient:
+    """Fake AIClient recording calls to complete() and complete_vision()."""
+
+    def __init__(
+        self,
+        complete_result: str = None,
+        vision_result: Optional[str] = None,
+        vision_exc: Optional[Exception] = None,
+    ):
+        self.complete_result = complete_result or _valid_enrichment_json()
+        self.vision_result = vision_result
+        self.vision_exc = vision_exc
+        self.complete_calls: List[tuple] = []
+        self.vision_calls: List[tuple] = []
+        self.config = SimpleNamespace(enrichment_concurrency=1)
+
+    async def complete(self, system, user, temperature=None, max_tokens=None):
+        self.complete_calls.append((system, user))
+        return self.complete_result
+
+    async def complete_vision(
+        self,
+        system,
+        user,
+        image_data,
+        image_media_type="image/png",
+        temperature=None,
+        max_tokens=None,
+    ):
+        self.vision_calls.append((system, user, image_data, image_media_type))
+        if self.vision_exc is not None:
+            raise self.vision_exc
+        return self.vision_result
+
+
+class _FakeRenderer:
+    """Fake VisualRenderer-like object recording render() calls."""
+
+    def __init__(self, render_result: Optional[bytes] = PNG_BYTES, render_exc: Optional[Exception] = None):
+        self.render_result = render_result
+        self.render_exc = render_exc
+        self.render_calls: List[str] = []
+
+    async def render(self, url: str) -> Optional[bytes]:
+        self.render_calls.append(url)
+        if self.render_exc is not None:
+            raise self.render_exc
+        return self.render_result
+
+
+def _rss_item(feed_name: str = "TestFeed", content: str = "Thin RSS snippet.") -> ContentItem:
+    return ContentItem(
+        id="rss:test:1",
+        source_type=SourceType.RSS,
+        title="RSS Article Title",
+        url="https://example.com/article",
+        content=content,
+        published_at=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        metadata={"feed_name": feed_name},
+    )
+
+
+def _gdelt_item(content: str = "Thin GDELT snippet.") -> ContentItem:
+    return ContentItem(
+        id="gdelt:test:1",
+        source_type=SourceType.GDELT,
+        title="GDELT Article Title",
+        url="https://news.example.com/gdelt-story",
+        content=content,
+        published_at=datetime(2026, 7, 1, tzinfo=timezone.utc),
+    )
+
+
+def _google_news_item(content: str = "Thin Google News snippet.") -> ContentItem:
+    return ContentItem(
+        id="google_news:test:1",
+        source_type=SourceType.GOOGLE_NEWS,
+        title="Google News Article Title",
+        url="https://news.example.com/gnews-story",
+        content=content,
+        published_at=datetime(2026, 7, 1, tzinfo=timezone.utc),
+    )
+
+
+def _github_item(content: str = "Github release notes.") -> ContentItem:
+    return ContentItem(
+        id="github:test:1",
+        source_type=SourceType.GITHUB,
+        title="Github Release",
+        url="https://github.com/example/repo/releases/tag/v1",
+        content=content,
+        published_at=datetime(2026, 7, 1, tzinfo=timezone.utc),
+    )
+
+
+def _sources_config_with_rss_enabled(feed_name: str = "TestFeed", enabled: bool = True) -> SourcesConfig:
+    return SourcesConfig(
+        rss=[
+            RSSSourceConfig(
+                name=feed_name,
+                url="https://example.com/feed.xml",
+                visual_extraction=VisualExtractionConfig(enabled=enabled),
+            )
+        ]
+    )
+
+
+def _assert_normal_enrichment_happened(item: ContentItem) -> None:
+    """Assert the rest of _enrich_item ran to completion (existing behavior)."""
+    assert item.metadata.get("detailed_summary_en"), "expected normal enrichment fields to be set"
+    assert item.metadata.get("detailed_summary") == item.metadata.get("detailed_summary_en")
+
+
+class TestResolveVisualExtractionGateMatrix:
+    """Directly exercises _resolve_visual_extraction across the full gate matrix."""
+
+    def test_rss_matching_feed_enabled_resolves_config(self):
+        sources_config = _sources_config_with_rss_enabled("TestFeed", enabled=True)
+        enricher = ContentEnricher(_FakeAIClient(), sources_config=sources_config)
+        item = _rss_item(feed_name="TestFeed")
+
+        resolved = enricher._resolve_visual_extraction(item)
+
+        assert resolved is not None
+        assert resolved.enabled is True
+
+    def test_rss_disabled_by_default_resolves_none(self):
+        # Default RSSSourceConfig.visual_extraction.enabled is False.
+        sources_config = SourcesConfig(
+            rss=[RSSSourceConfig(name="TestFeed", url="https://example.com/feed.xml")]
+        )
+        enricher = ContentEnricher(_FakeAIClient(), sources_config=sources_config)
+        item = _rss_item(feed_name="TestFeed")
+
+        assert enricher._resolve_visual_extraction(item) is None
+
+    def test_rss_feed_name_mismatch_resolves_none(self):
+        sources_config = _sources_config_with_rss_enabled("ConfiguredFeed", enabled=True)
+        enricher = ContentEnricher(_FakeAIClient(), sources_config=sources_config)
+        item = _rss_item(feed_name="SomeOtherFeed")
+
+        assert enricher._resolve_visual_extraction(item) is None
+
+    def test_sources_config_none_resolves_none(self):
+        enricher = ContentEnricher(_FakeAIClient(), sources_config=None)
+        item = _rss_item(feed_name="TestFeed")
+
+        assert enricher._resolve_visual_extraction(item) is None
+
+    def test_non_eligible_source_type_resolves_none_even_if_enabled_elsewhere(self):
+        sources_config = _sources_config_with_rss_enabled("TestFeed", enabled=True)
+        sources_config.gdelt = GDELTConfig(visual_extraction=VisualExtractionConfig(enabled=True))
+        sources_config.google_news = GoogleNewsConfig(visual_extraction=VisualExtractionConfig(enabled=True))
+        enricher = ContentEnricher(_FakeAIClient(), sources_config=sources_config)
+
+        for item in (_github_item(),):
+            assert enricher._resolve_visual_extraction(item) is None
+
+    def test_gdelt_enabled_when_configured(self):
+        sources_config = SourcesConfig(gdelt=GDELTConfig(visual_extraction=VisualExtractionConfig(enabled=True)))
+        enricher = ContentEnricher(_FakeAIClient(), sources_config=sources_config)
+        item = _gdelt_item()
+
+        resolved = enricher._resolve_visual_extraction(item)
+        assert resolved is not None
+        assert resolved.enabled is True
+
+    def test_gdelt_none_by_default_resolves_none(self):
+        sources_config = SourcesConfig()  # gdelt defaults to None
+        enricher = ContentEnricher(_FakeAIClient(), sources_config=sources_config)
+        item = _gdelt_item()
+
+        assert sources_config.gdelt is None
+        assert enricher._resolve_visual_extraction(item) is None
+
+    def test_google_news_enabled_when_configured(self):
+        sources_config = SourcesConfig(
+            google_news=GoogleNewsConfig(visual_extraction=VisualExtractionConfig(enabled=True))
+        )
+        enricher = ContentEnricher(_FakeAIClient(), sources_config=sources_config)
+        item = _google_news_item()
+
+        resolved = enricher._resolve_visual_extraction(item)
+        assert resolved is not None
+
+    def test_google_news_none_by_default_resolves_none(self):
+        sources_config = SourcesConfig()  # google_news defaults to None
+        enricher = ContentEnricher(_FakeAIClient(), sources_config=sources_config)
+        item = _google_news_item()
+
+        assert sources_config.google_news is None
+        assert enricher._resolve_visual_extraction(item) is None
+
+
+class TestMaybeVisualExtractSuccessPaths:
+    def test_differs_meaningfully_true_sets_metadata_and_returns_extracted_text(self):
+        ai_client = _FakeAIClient(
+            vision_result=json.dumps(
+                {"differs_meaningfully": True, "extracted_content": "The real, full article text..."}
+            )
+        )
+        renderer = _FakeRenderer(render_result=PNG_BYTES)
+        sources_config = _sources_config_with_rss_enabled("TestFeed", enabled=True)
+        enricher = ContentEnricher(ai_client, sources_config=sources_config, visual_renderer=renderer)
+        item = _rss_item(feed_name="TestFeed", content="Thin snippet.")
+
+        result = asyncio.run(enricher._maybe_visual_extract(item, "Thin snippet."))
+
+        assert result == "The real, full article text..."
+        assert item.metadata["visual_extracted_content"] == "The real, full article text..."
+        assert renderer.render_calls == ["https://example.com/article"]
+        assert len(ai_client.vision_calls) == 1
+
+    def test_differs_meaningfully_false_leaves_metadata_and_content_unchanged(self):
+        ai_client = _FakeAIClient(
+            vision_result=json.dumps({"differs_meaningfully": False, "extracted_content": ""})
+        )
+        renderer = _FakeRenderer(render_result=PNG_BYTES)
+        sources_config = _sources_config_with_rss_enabled("TestFeed", enabled=True)
+        enricher = ContentEnricher(ai_client, sources_config=sources_config, visual_renderer=renderer)
+        item = _rss_item(feed_name="TestFeed", content="Thin snippet.")
+
+        result = asyncio.run(enricher._maybe_visual_extract(item, "Thin snippet."))
+
+        assert result == "Thin snippet."
+        assert "visual_extracted_content" not in item.metadata
+        assert len(ai_client.vision_calls) == 1
+
+    def test_full_enrich_item_completes_and_reflects_extracted_content(self):
+        ai_client = _FakeAIClient(
+            vision_result=json.dumps(
+                {"differs_meaningfully": True, "extracted_content": "Real article body."}
+            )
+        )
+        renderer = _FakeRenderer(render_result=PNG_BYTES)
+        sources_config = _sources_config_with_rss_enabled("TestFeed", enabled=True)
+        enricher = ContentEnricher(ai_client, sources_config=sources_config, visual_renderer=renderer)
+        item = _rss_item(feed_name="TestFeed", content="Thin snippet.")
+
+        asyncio.run(enricher._enrich_item(item))
+
+        assert item.metadata["visual_extracted_content"] == "Real article body."
+        _assert_normal_enrichment_happened(item)
+        assert len(renderer.render_calls) == 1
+        assert len(ai_client.vision_calls) == 1
+
+
+class TestMaybeVisualExtractDisabledPath:
+    def test_toggle_disabled_never_calls_render_or_vision(self):
+        ai_client = _FakeAIClient()
+        renderer = _FakeRenderer()
+        # visual_extraction.enabled defaults to False
+        sources_config = SourcesConfig(
+            rss=[RSSSourceConfig(name="TestFeed", url="https://example.com/feed.xml")]
+        )
+        enricher = ContentEnricher(ai_client, sources_config=sources_config, visual_renderer=renderer)
+        item = _rss_item(feed_name="TestFeed", content="Thin snippet.")
+
+        asyncio.run(enricher._enrich_item(item))
+
+        assert renderer.render_calls == []
+        assert ai_client.vision_calls == []
+        assert "visual_extracted_content" not in item.metadata
+        _assert_normal_enrichment_happened(item)
+
+    def test_sources_config_none_default_pattern_fully_unaffected(self):
+        """ContentEnricher(ai_client) — today's existing call pattern."""
+        ai_client = _FakeAIClient()
+        enricher = ContentEnricher(ai_client)  # no sources_config, no visual_renderer
+        item = _rss_item(feed_name="TestFeed", content="Thin snippet.")
+
+        asyncio.run(enricher._enrich_item(item))
+
+        assert ai_client.vision_calls == []
+        assert "visual_extracted_content" not in item.metadata
+        _assert_normal_enrichment_happened(item)
+
+    def test_feed_name_mismatch_treated_as_disabled_no_crash(self):
+        ai_client = _FakeAIClient()
+        renderer = _FakeRenderer()
+        sources_config = _sources_config_with_rss_enabled("ConfiguredFeed", enabled=True)
+        enricher = ContentEnricher(ai_client, sources_config=sources_config, visual_renderer=renderer)
+        item = _rss_item(feed_name="UnrelatedFeed", content="Thin snippet.")
+
+        asyncio.run(enricher._enrich_item(item))
+
+        assert renderer.render_calls == []
+        assert ai_client.vision_calls == []
+        _assert_normal_enrichment_happened(item)
+
+    def test_non_eligible_source_type_is_complete_noop(self):
+        ai_client = _FakeAIClient()
+        renderer = _FakeRenderer()
+        sources_config = _sources_config_with_rss_enabled("TestFeed", enabled=True)
+        sources_config.gdelt = GDELTConfig(visual_extraction=VisualExtractionConfig(enabled=True))
+        sources_config.google_news = GoogleNewsConfig(visual_extraction=VisualExtractionConfig(enabled=True))
+        enricher = ContentEnricher(ai_client, sources_config=sources_config, visual_renderer=renderer)
+        item = _github_item()
+
+        asyncio.run(enricher._enrich_item(item))
+
+        assert renderer.render_calls == []
+        assert ai_client.vision_calls == []
+        _assert_normal_enrichment_happened(item)
+
+
+class TestGracefulDegradation:
+    """Every failure mode must fall back cleanly to the original content_text
+    and let _enrich_item / enrich_batch complete without raising."""
+
+    def test_render_returns_none_falls_back_cleanly(self):
+        ai_client = _FakeAIClient()
+        renderer = _FakeRenderer(render_result=None)
+        sources_config = _sources_config_with_rss_enabled("TestFeed", enabled=True)
+        enricher = ContentEnricher(ai_client, sources_config=sources_config, visual_renderer=renderer)
+        item = _rss_item(feed_name="TestFeed", content="Thin snippet.")
+
+        asyncio.run(enricher._enrich_item(item))
+
+        assert renderer.render_calls == ["https://example.com/article"]
+        assert ai_client.vision_calls == []  # never reached — render short-circuited
+        assert "visual_extracted_content" not in item.metadata
+        _assert_normal_enrichment_happened(item)
+
+    def test_render_raises_exception_falls_back_cleanly(self):
+        ai_client = _FakeAIClient()
+        renderer = _FakeRenderer(render_exc=RuntimeError("playwright exploded"))
+        sources_config = _sources_config_with_rss_enabled("TestFeed", enabled=True)
+        enricher = ContentEnricher(ai_client, sources_config=sources_config, visual_renderer=renderer)
+        item = _rss_item(feed_name="TestFeed", content="Thin snippet.")
+
+        # Must not raise.
+        asyncio.run(enricher._enrich_item(item))
+
+        assert "visual_extracted_content" not in item.metadata
+        _assert_normal_enrichment_happened(item)
+
+    def test_complete_vision_not_implemented_error_falls_back_cleanly(self):
+        ai_client = _FakeAIClient(vision_exc=NotImplementedError("AzureOpenAIClient does not support vision"))
+        renderer = _FakeRenderer(render_result=PNG_BYTES)
+        sources_config = _sources_config_with_rss_enabled("TestFeed", enabled=True)
+        enricher = ContentEnricher(ai_client, sources_config=sources_config, visual_renderer=renderer)
+        item = _rss_item(feed_name="TestFeed", content="Thin snippet.")
+
+        asyncio.run(enricher._enrich_item(item))
+
+        assert "visual_extracted_content" not in item.metadata
+        _assert_normal_enrichment_happened(item)
+
+    def test_complete_vision_malformed_json_falls_back_cleanly(self):
+        ai_client = _FakeAIClient(vision_result="this is not json at all, sorry")
+        renderer = _FakeRenderer(render_result=PNG_BYTES)
+        sources_config = _sources_config_with_rss_enabled("TestFeed", enabled=True)
+        enricher = ContentEnricher(ai_client, sources_config=sources_config, visual_renderer=renderer)
+        item = _rss_item(feed_name="TestFeed", content="Thin snippet.")
+
+        asyncio.run(enricher._enrich_item(item))
+
+        assert "visual_extracted_content" not in item.metadata
+        _assert_normal_enrichment_happened(item)
+
+    def test_maybe_visual_extract_swallows_any_exception_directly(self):
+        """Direct unit check that _maybe_visual_extract's try/except covers
+        render() raising, independent of the full _enrich_item flow."""
+        ai_client = _FakeAIClient()
+        renderer = _FakeRenderer(render_exc=ValueError("boom"))
+        sources_config = _sources_config_with_rss_enabled("TestFeed", enabled=True)
+        enricher = ContentEnricher(ai_client, sources_config=sources_config, visual_renderer=renderer)
+        item = _rss_item(feed_name="TestFeed", content="Original snippet.")
+
+        result = asyncio.run(enricher._maybe_visual_extract(item, "Original snippet."))
+
+        assert result == "Original snippet."
+
+
+class TestEnrichBatchLazyRendererConstruction:
+    def test_constructs_and_enters_renderer_when_batch_needs_it(self):
+        class _FakeVisualRendererCM:
+            instances: List["_FakeVisualRendererCM"] = []
+
+            def __init__(self, timeout_ms=15000, **kwargs):
+                self.timeout_ms = timeout_ms
+                self.entered = False
+                self.exited = False
+                self.render = AsyncMock(return_value=PNG_BYTES)
+                type(self).instances.append(self)
+
+            async def __aenter__(self):
+                self.entered = True
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                self.exited = True
+
+        _FakeVisualRendererCM.instances = []
+
+        ai_client = _FakeAIClient(
+            vision_result=json.dumps({"differs_meaningfully": False, "extracted_content": ""})
+        )
+        sources_config = _sources_config_with_rss_enabled("TestFeed", enabled=True)
+        enricher = ContentEnricher(ai_client, sources_config=sources_config)  # no injected renderer
+        items = [_rss_item(feed_name="TestFeed")]
+
+        with patch("src.ai.visual_renderer.VisualRenderer", _FakeVisualRendererCM):
+            asyncio.run(enricher.enrich_batch(items))
+
+        assert len(_FakeVisualRendererCM.instances) == 1
+        instance = _FakeVisualRendererCM.instances[0]
+        assert instance.entered is True
+        assert instance.exited is True
+        # Renderer reset to None after the batch tears it down.
+        assert enricher._visual_renderer is None
+        instance.render.assert_awaited_once()
+
+    def test_uses_max_timeout_across_items_needing_extraction(self):
+        class _FakeVisualRendererCM:
+            instances: List["_FakeVisualRendererCM"] = []
+
+            def __init__(self, timeout_ms=15000, **kwargs):
+                self.timeout_ms = timeout_ms
+                self.render = AsyncMock(return_value=None)
+                type(self).instances.append(self)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                pass
+
+        _FakeVisualRendererCM.instances = []
+
+        ai_client = _FakeAIClient()
+        sources_config = SourcesConfig(
+            rss=[
+                RSSSourceConfig(
+                    name="FastFeed",
+                    url="https://example.com/fast.xml",
+                    visual_extraction=VisualExtractionConfig(enabled=True, timeout_ms=5000),
+                ),
+                RSSSourceConfig(
+                    name="SlowFeed",
+                    url="https://example.com/slow.xml",
+                    visual_extraction=VisualExtractionConfig(enabled=True, timeout_ms=20000),
+                ),
+            ]
+        )
+        enricher = ContentEnricher(ai_client, sources_config=sources_config)
+        items = [
+            _rss_item(feed_name="FastFeed"),
+            _rss_item(feed_name="SlowFeed"),
+        ]
+        items[1].id = "rss:test:2"
+
+        with patch("src.ai.visual_renderer.VisualRenderer", _FakeVisualRendererCM):
+            asyncio.run(enricher.enrich_batch(items))
+
+        assert _FakeVisualRendererCM.instances[0].timeout_ms == 20000
+
+    def test_never_constructs_renderer_when_no_item_needs_it(self):
+        class _ExplodingVisualRenderer:
+            def __init__(self, *args, **kwargs):
+                raise AssertionError(
+                    "VisualRenderer must not be constructed when the toggle is off for all items"
+                )
+
+        ai_client = _FakeAIClient()
+        # Toggle left disabled (default) for the only configured feed.
+        sources_config = SourcesConfig(
+            rss=[RSSSourceConfig(name="TestFeed", url="https://example.com/feed.xml")]
+        )
+        enricher = ContentEnricher(ai_client, sources_config=sources_config)
+        items = [_rss_item(feed_name="TestFeed")]
+
+        with patch("src.ai.visual_renderer.VisualRenderer", _ExplodingVisualRenderer):
+            # Must not raise — proves VisualRenderer() is never called.
+            asyncio.run(enricher.enrich_batch(items))
+
+        assert "visual_extracted_content" not in items[0].metadata
+        _assert_normal_enrichment_happened(items[0])
+
+    def test_injected_renderer_bypasses_lazy_construction_entirely(self):
+        class _ExplodingVisualRenderer:
+            def __init__(self, *args, **kwargs):
+                raise AssertionError("VisualRenderer must not be constructed when one was injected")
+
+        ai_client = _FakeAIClient(
+            vision_result=json.dumps({"differs_meaningfully": False, "extracted_content": ""})
+        )
+        renderer = _FakeRenderer(render_result=PNG_BYTES)
+        sources_config = _sources_config_with_rss_enabled("TestFeed", enabled=True)
+        enricher = ContentEnricher(ai_client, sources_config=sources_config, visual_renderer=renderer)
+        items = [_rss_item(feed_name="TestFeed")]
+
+        with patch("src.ai.visual_renderer.VisualRenderer", _ExplodingVisualRenderer):
+            asyncio.run(enricher.enrich_batch(items))
+
+        assert len(renderer.render_calls) == 1
+        # Injected renderer stays set after the batch (not owned/torn down by enrich_batch).
+        assert enricher._visual_renderer is renderer

--- a/tests/test_visual_renderer.py
+++ b/tests/test_visual_renderer.py
@@ -1,0 +1,226 @@
+"""Tests for VisualRenderer (src/ai/visual_renderer.py).
+
+Playwright is NOT installed in this environment (confirmed), so every test
+here fakes the Playwright surface via unittest.mock — no real browser is
+ever launched and no network call is ever made. Success-path tests patch
+`PLAYWRIGHT_AVAILABLE` to True and inject a fake `async_playwright` hook
+directly onto the module (the module only binds that name when the real
+import succeeds, so we add it back with monkeypatch's `raising=False`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import src.ai.visual_renderer as visual_renderer_module
+from src.ai.visual_renderer import VisualRenderer
+
+
+def _make_fake_playwright(mock_browser, launch_side_effect=None):
+    """Build a fake `async_playwright()` callable plus its launch chain."""
+    fake_playwright_cm = AsyncMock()
+    fake_playwright_instance = MagicMock()
+    if launch_side_effect is not None:
+        fake_playwright_instance.chromium.launch = AsyncMock(side_effect=launch_side_effect)
+    else:
+        fake_playwright_instance.chromium.launch = AsyncMock(return_value=mock_browser)
+    fake_playwright_cm.__aenter__ = AsyncMock(return_value=fake_playwright_instance)
+    fake_playwright_cm.__aexit__ = AsyncMock(return_value=None)
+
+    def _async_playwright():
+        return fake_playwright_cm
+
+    return _async_playwright, fake_playwright_cm, fake_playwright_instance
+
+
+class TestPlaywrightUnavailable:
+    """PLAYWRIGHT_AVAILABLE = False (Playwright not installed) is a no-op, never raises."""
+
+    def test_render_returns_none_when_playwright_not_installed(self, monkeypatch):
+        monkeypatch.setattr(visual_renderer_module, "PLAYWRIGHT_AVAILABLE", False)
+        renderer = VisualRenderer()
+
+        result = asyncio.run(renderer.render("https://example.com/article"))
+
+        assert result is None
+
+    def test_aenter_is_noop_when_playwright_not_installed(self, monkeypatch, caplog):
+        monkeypatch.setattr(visual_renderer_module, "PLAYWRIGHT_AVAILABLE", False)
+        renderer = VisualRenderer()
+
+        with caplog.at_level(logging.WARNING):
+            entered = asyncio.run(renderer.__aenter__())
+
+        assert entered is renderer
+        assert renderer._browser is None
+        assert any("Playwright not installed" in r.message for r in caplog.records)
+
+    def test_full_context_manager_usage_never_raises_when_unavailable(self, monkeypatch):
+        monkeypatch.setattr(visual_renderer_module, "PLAYWRIGHT_AVAILABLE", False)
+
+        async def scenario():
+            async with VisualRenderer() as renderer:
+                return await renderer.render("https://example.com")
+
+        result = asyncio.run(scenario())
+        assert result is None
+
+
+class TestContextManagerLifecycle:
+    """__aenter__/__aexit__ launch and close a single shared browser instance."""
+
+    def test_aenter_launches_browser_and_aexit_closes_it(self, monkeypatch):
+        mock_browser = AsyncMock()
+        fake_async_playwright, fake_cm, fake_instance = _make_fake_playwright(mock_browser)
+
+        monkeypatch.setattr(visual_renderer_module, "PLAYWRIGHT_AVAILABLE", True)
+        monkeypatch.setattr(
+            visual_renderer_module, "async_playwright", fake_async_playwright, raising=False
+        )
+
+        captured = {}
+
+        async def scenario():
+            async with VisualRenderer(headless=True) as renderer:
+                captured["browser_during"] = renderer._browser
+            captured["browser_after"] = renderer._browser
+
+        asyncio.run(scenario())
+
+        fake_instance.chromium.launch.assert_awaited_once_with(headless=True)
+        assert captured["browser_during"] is mock_browser
+        mock_browser.close.assert_awaited_once()
+        fake_cm.__aexit__.assert_awaited_once()
+        # Browser reference is cleared after teardown.
+        assert captured["browser_after"] is None
+
+    def test_aenter_handles_launch_failure_gracefully(self, monkeypatch, caplog):
+        fake_async_playwright, fake_cm, fake_instance = _make_fake_playwright(
+            None, launch_side_effect=RuntimeError("chromium failed to launch")
+        )
+
+        monkeypatch.setattr(visual_renderer_module, "PLAYWRIGHT_AVAILABLE", True)
+        monkeypatch.setattr(
+            visual_renderer_module, "async_playwright", fake_async_playwright, raising=False
+        )
+
+        async def scenario():
+            async with VisualRenderer() as renderer:
+                return renderer
+
+        with caplog.at_level(logging.WARNING):
+            renderer = asyncio.run(scenario())
+
+        assert renderer._browser is None
+        assert any("Failed to launch Playwright" in r.message for r in caplog.records)
+
+    def test_aexit_handles_close_failure_without_raising(self, monkeypatch):
+        mock_browser = AsyncMock()
+        mock_browser.close = AsyncMock(side_effect=RuntimeError("close failed"))
+        fake_async_playwright, fake_cm, fake_instance = _make_fake_playwright(mock_browser)
+
+        monkeypatch.setattr(visual_renderer_module, "PLAYWRIGHT_AVAILABLE", True)
+        monkeypatch.setattr(
+            visual_renderer_module, "async_playwright", fake_async_playwright, raising=False
+        )
+
+        async def scenario():
+            async with VisualRenderer() as renderer:
+                pass
+
+        # Must not raise even though browser.close() blew up.
+        asyncio.run(scenario())
+        mock_browser.close.assert_awaited_once()
+
+
+class TestRenderSuccess:
+    """render() returns screenshot bytes from a mocked page.screenshot()."""
+
+    def test_render_returns_screenshot_bytes(self, monkeypatch):
+        png_bytes = b"\x89PNG-fake-bytes"
+
+        mock_page = AsyncMock()
+        mock_page.screenshot = AsyncMock(return_value=png_bytes)
+        mock_context = AsyncMock()
+        mock_context.new_page = AsyncMock(return_value=mock_page)
+        mock_browser = AsyncMock()
+        mock_browser.new_context = AsyncMock(return_value=mock_context)
+
+        monkeypatch.setattr(visual_renderer_module, "PLAYWRIGHT_AVAILABLE", True)
+
+        renderer = VisualRenderer(timeout_ms=5000)
+        renderer._browser = mock_browser  # simulate an already-entered renderer
+
+        result = asyncio.run(renderer.render("https://example.com/article"))
+
+        assert result == png_bytes
+        mock_page.goto.assert_awaited_once()
+        goto_args, goto_kwargs = mock_page.goto.call_args
+        assert goto_args[0] == "https://example.com/article"
+        assert goto_kwargs["timeout"] == 5000
+        mock_page.screenshot.assert_awaited_once_with(type="png")
+        mock_context.close.assert_awaited_once()
+
+    def test_render_returns_none_when_browser_not_started(self, monkeypatch):
+        monkeypatch.setattr(visual_renderer_module, "PLAYWRIGHT_AVAILABLE", True)
+        renderer = VisualRenderer()  # never entered via `async with`
+
+        result = asyncio.run(renderer.render("https://example.com"))
+
+        assert result is None
+
+
+class TestRenderFailureModes:
+    """Any failure during render() degrades to None + a warning log, never raises."""
+
+    def test_render_returns_none_and_logs_warning_on_navigation_timeout(self, monkeypatch, caplog):
+        mock_page = AsyncMock()
+        mock_page.goto = AsyncMock(side_effect=TimeoutError("Navigation timeout of 15000ms exceeded"))
+        mock_context = AsyncMock()
+        mock_context.new_page = AsyncMock(return_value=mock_page)
+        mock_browser = AsyncMock()
+        mock_browser.new_context = AsyncMock(return_value=mock_context)
+
+        monkeypatch.setattr(visual_renderer_module, "PLAYWRIGHT_AVAILABLE", True)
+        renderer = VisualRenderer()
+        renderer._browser = mock_browser
+
+        with caplog.at_level(logging.WARNING):
+            result = asyncio.run(renderer.render("https://example.com/slow-page"))
+
+        assert result is None
+        assert any("Failed to render" in r.message for r in caplog.records)
+        # Context must still be cleaned up even on failure.
+        mock_context.close.assert_awaited_once()
+
+    def test_render_returns_none_on_new_context_failure(self, monkeypatch):
+        mock_browser = AsyncMock()
+        mock_browser.new_context = AsyncMock(side_effect=RuntimeError("network down"))
+
+        monkeypatch.setattr(visual_renderer_module, "PLAYWRIGHT_AVAILABLE", True)
+        renderer = VisualRenderer()
+        renderer._browser = mock_browser
+
+        result = asyncio.run(renderer.render("https://example.com"))
+
+        assert result is None
+
+    def test_render_never_raises_out_of_the_coroutine(self, monkeypatch):
+        """Belt-and-suspenders: render() must not propagate ANY exception type."""
+        mock_context = AsyncMock()
+        mock_context.new_page = AsyncMock(side_effect=Exception("anything at all"))
+        mock_browser = AsyncMock()
+        mock_browser.new_context = AsyncMock(return_value=mock_context)
+
+        monkeypatch.setattr(visual_renderer_module, "PLAYWRIGHT_AVAILABLE", True)
+        renderer = VisualRenderer()
+        renderer._browser = mock_browser
+
+        try:
+            result = asyncio.run(renderer.render("https://example.com"))
+        except Exception as exc:  # pragma: no cover - this is exactly what we assert against
+            raise AssertionError(f"render() must never raise, but raised: {exc}")
+
+        assert result is None

--- a/uv.lock
+++ b/uv.lock
@@ -1089,6 +1089,9 @@ twitter = [
     { name = "playwright" },
     { name = "playwright-stealth" },
 ]
+visual = [
+    { name = "playwright" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1104,6 +1107,7 @@ requires-dist = [
     { name = "openbb", marker = "extra == 'openbb'", specifier = ">=4.4.0" },
     { name = "openbb-benzinga", marker = "extra == 'openbb'", specifier = ">=1.6.0" },
     { name = "playwright", marker = "extra == 'twitter'", specifier = ">=1.40.0" },
+    { name = "playwright", marker = "extra == 'visual'", specifier = ">=1.40.0" },
     { name = "playwright-stealth", marker = "extra == 'twitter'", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.9.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -1113,7 +1117,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.9.0" },
     { name = "tenacity", specifier = ">=9.0.0" },
 ]
-provides-extras = ["dev", "openbb", "twitter"]
+provides-extras = ["dev", "openbb", "twitter", "visual"]
 
 [[package]]
 name = "hpack"


### PR DESCRIPTION
# feat(enrich): add pixelrag-style visual extraction for rss/gdelt/google-news

**Branch:** `pixelrag-visual-enrichment` → **Base:** `main`
**Tip commit:** `b77b5d7`

---

## Summary

Add a self-hosted, render-only visual-extraction sub-step inside `ContentEnricher._enrich_item` for high-scoring RSS/GDELT/Google News items: render the item's article URL to a screenshot (Playwright Chromium) and ask the configured vision-capable AI client whether the real page content differs meaningfully from the thin feed snippet, using the extracted content when it does. Gated behind an opt-in `visual_extraction.enabled` toggle (per-feed for RSS, per-source for GDELT/Google News), disabled by default. No FAISS index, embedding model, or hosted PixelRAG API involved — this evaluates PixelRAG's approach (render pages as images to preserve visual structure HTML parsing throws away) but implements only the render primitive against Horizon's own AI-client abstraction, not PixelRAG's package/infra itself.

Adds `AIClient.complete_vision` for Anthropic and OpenAI-compatible clients; Azure/Gemini raise `NotImplementedError`, caught by the enrichment step's existing graceful-degradation handling — same fallback path as any other render/vision failure. Adds a new opt-in `visual` dependency group (Playwright only) requiring a manual `uv run playwright install chromium` step (plus system deps via `playwright install-deps chromium`, not bundled). `GDELTConfig`/`GoogleNewsConfig` are minimal forward-compatible placeholders since those scrapers don't exist on `main` yet (they live on the unmerged `news-api-scrapers` branch) — the GDELT/Google News code paths are inert until that branch merges; only the RSS path is exercisable end-to-end today.

## Scope

- [x] This PR contains **one feature / one fix / one focused change**
- [x] This PR does **not** combine multiple unrelated features

## Changes

- **`src/ai/visual_renderer.py`** (new) — `VisualRenderer`: async Playwright Chromium screenshot primitive, shared browser instance reused across a batch, `render(url) -> Optional[bytes]`, never raises (returns `None` + logs a warning on any failure — missing Playwright, launch/nav/network errors, timeout).
- **`src/ai/client.py`** — new `AIClient.complete_vision(...)` method: `NotImplementedError` on the base class by default; implemented for `AnthropicClient` (native multimodal content blocks) and `OpenAIClient` (covers OpenAI-compatible providers — Ali, Doubao, MiniMax, DeepSeek, Ollama — via `image_url` data-URI parts); delegated through `ChainedAIClient` (first client only). Azure OpenAI and Gemini clients intentionally left unimplemented.
- **`src/ai/enricher.py`** — `_enrich_item` extended (not a new pipeline stage) with a render/vision sub-step gated on `item.source_type ∈ {RSS, GDELT, GOOGLE_NEWS}` and the resolved per-source `visual_extraction` toggle. On success, AI-extracted real content replaces the snippet text for the rest of the existing flow (concept extraction, web search, grounded-background generation) and is recorded in `item.metadata["visual_extracted_content"]`. Any failure anywhere in the sub-step (render failure, non-vision-capable provider, malformed response, any exception) is caught, logged, and the item proceeds with its original content — same pattern as the existing `_translate_item` fallback. `ContentEnricher.__init__` gains optional `sources_config`/`visual_renderer` params, backward compatible with the existing `ContentEnricher(ai_client)` call.
- **`src/ai/prompts.py`** — new prompt(s) for the vision-based content-check/extraction step.
- **`src/models.py`** — new `visual_extraction: VisualExtractionConfig` field (`enabled: bool = False`, `timeout_ms: int = 15000`) added per-feed on `RSSSourceConfig`; minimal placeholder `GDELTConfig`/`GoogleNewsConfig` (+ matching `SourceType` enum values) carrying the same toggle, for forward compatibility with the unmerged `news-api-scrapers` branch.
- **`src/orchestrator.py`** — minor wiring change to pass `sources_config` into `ContentEnricher`.
- **`pyproject.toml` / `uv.lock`** — new optional `visual` dependency group (`playwright>=1.40.0` only), separate from the existing `twitter` extra, not required by default install.
- **`data/config.example.json`** — `visual_extraction: { enabled: false }` shown on the example RSS feeds.
- **`docs/configuration.md`** — documents the new RSS `visual_extraction` block, mirroring the existing Twitter/OpenBB doc format.
- **`tests/test_visual_renderer.py`, `tests/test_ai_client_vision.py`, `tests/test_enricher_visual_extraction.py`** (new) — 47 new tests, fully mocked (no live browser launches, no live AI/vision calls).

## Notes for Reviewers


- **Vision support covers 2 of 5 AI provider classes** (Anthropic, OpenAI-compatible — 6 of 9 `AIProvider` values). Azure/Gemini fall through to the same graceful-degradation path as any other failure; this is intentional, not a gap to fix in this PR.
- **`visual_extraction.timeout_ms` is batch-shared, not strictly per-call** — since the browser instance is reused across a batch for performance, the batch's renderer construction uses the max `timeout_ms` across items needing render rather than a per-item timeout. Minor granularity trade-off, not a functional issue.
- **Not usable out of the box in production**: requires `uv sync --extra visual && uv run playwright install chromium` (plus system deps — `playwright install-deps chromium`, verified needing ~26 packages like `libatk1.0-0`, `libcups2`, `xvfb`, various font packages — not bundled, install separately) and a vision-capable AI provider key configured. With the toggle at its default (`false`), none of this is touched — zero behavior change for existing users.
- **Live end-to-end verification not performed on this branch** — all 47 new tests are fully mocked, matching this repo's convention for new-source PRs. Chromium launch was manually smoke-tested separately (renders and screenshots correctly once system deps are installed) but a full render→vision→enrichment run against a real RSS item with a live AI key was not part of this PR's testing.

## Checklist

- [x] I explained the change clearly
- [x] I kept the PR focused and easy to review
- [x] I tested the change locally when applicable — `uv run --extra dev pytest` → **308 passed** (+47 new), 0 failures
