### PR TITLE
feat(ai): add MiniMax M3 endpoint support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,18 +95,46 @@ Set `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_ENDPOINT` in your `.env`. The `mode
 
 **MiniMax**:
 
+The built-in provider defaults to `MiniMax-M3` and the global
+OpenAI-compatible endpoint:
+
 ```json
 {
   "ai": {
     "provider": "minimax",
     "model": "MiniMax-M3",
     "api_key_env": "MINIMAX_API_KEY",
+    "base_url": "https://api.minimax.io/v1",
     "throttle_sec": 0
   }
 }
 ```
 
-Available models: `MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`
+Available models: `MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`.
+
+Use the endpoint for your account region and preferred compatible API:
+
+| Region | OpenAI-compatible base URL | Anthropic-compatible base URL |
+| --- | --- | --- |
+| Global | `https://api.minimax.io/v1` | `https://api.minimax.io/anthropic` |
+| China | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic` |
+
+For the Anthropic-compatible API, keep `provider` set to `minimax` and pass
+the base URL directly without adding `/v1`. Horizon selects its Anthropic
+client for this endpoint, and the SDK appends `/v1/messages` when sending a
+request:
+
+```json
+{
+  "ai": {
+    "provider": "minimax",
+    "model": "MiniMax-M3",
+    "api_key_env": "MINIMAX_API_KEY",
+    "base_url": "https://api.minimax.io/anthropic",
+    "throttle_sec": 0
+  }
+}
+```
 
 **Aliyun DashScope** (OpenAI-compatible):
 

--- a/src/ai/client.py
+++ b/src/ai/client.py
@@ -112,7 +112,7 @@ class AIClient(ABC):
 
 
 class AnthropicClient(AIClient):
-    """Client for Anthropic Claude models."""
+    """Client for Anthropic-compatible models."""
 
     def __init__(self, config: AIConfig):
         """Initialize Anthropic client.
@@ -164,7 +164,7 @@ class AnthropicClient(AIClient):
         usage = getattr(message, "usage", None)
         if usage is not None:
             record_usage(
-                "anthropic",
+                self.config.provider.value,
                 input_tokens=getattr(usage, "input_tokens", 0),
                 output_tokens=getattr(usage, "output_tokens", 0),
             )
@@ -530,9 +530,18 @@ class GeminiClient(AIClient):
         return response.text
 
 
+def _uses_anthropic_compatible_api(config: AIConfig) -> bool:
+    """Return whether MiniMax is configured for its Anthropic-compatible API."""
+    base_url = (config.base_url or "").rstrip("/")
+    return config.provider == AIProvider.MINIMAX and base_url.endswith("/anthropic")
+
+
 def _create_single_client(config: AIConfig) -> AIClient:
     """Create a single AI client instance."""
-    if config.provider == AIProvider.ANTHROPIC:
+    if (
+        config.provider == AIProvider.ANTHROPIC
+        or _uses_anthropic_compatible_api(config)
+    ):
         return AnthropicClient(config)
     elif config.provider == AIProvider.AZURE:
         return AzureOpenAIClient(config)

--- a/src/models.py
+++ b/src/models.py
@@ -113,7 +113,7 @@ AI_PROVIDER_DEFAULTS = {
         "base_url": "https://ark.cn-beijing.volces.com/api/v3",
     },
     AIProvider.MINIMAX: {
-        "model": "MiniMax-Text-01",
+        "model": "MiniMax-M3",
         "api_key_env": "MINIMAX_API_KEY",
         "base_url": "https://api.minimax.io/v1",
     },

--- a/tests/test_minimax_client.py
+++ b/tests/test_minimax_client.py
@@ -6,10 +6,12 @@ import asyncio
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
+from anthropic import AsyncAnthropic
 
-from src.ai.client import OpenAIClient, create_ai_client
-from src.models import AIConfig, AIProvider
+from src.ai.client import AnthropicClient, OpenAIClient, create_ai_client
+from src.models import AIConfig, AIProvider, AI_PROVIDER_DEFAULTS
 
 
 def _make_config(**overrides) -> AIConfig:
@@ -79,10 +81,10 @@ class TestOpenAIClientInit:
         client = OpenAIClient(_make_config())
         assert str(client.client.base_url).rstrip("/").endswith("api.minimax.io/v1")
 
-    def test_uses_custom_base_url(self, monkeypatch):
+    def test_uses_china_openai_compatible_base_url(self, monkeypatch):
         monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
         client = OpenAIClient(_make_config(base_url="https://api.minimaxi.com/v1"))
-        assert "minimaxi.com" in str(client.client.base_url)
+        assert str(client.client.base_url).rstrip("/") == "https://api.minimaxi.com/v1"
 
     def test_uses_default_base_url_for_ali(self, monkeypatch):
         monkeypatch.setenv("ALI_API_KEY", "test-key")
@@ -320,12 +322,65 @@ class TestTemperatureFallback:
 
 
 class TestFactoryFunction:
+    def test_minimax_provider_defaults(self):
+        defaults = AI_PROVIDER_DEFAULTS[AIProvider.MINIMAX]
+        assert defaults["model"] == "MiniMax-M3"
+        assert defaults["base_url"] == "https://api.minimax.io/v1"
+
     def test_creates_openai_client_for_minimax(self, monkeypatch):
         monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
         config = _make_config()
         client = create_ai_client(config)
         assert isinstance(client, OpenAIClient)
         assert client.provider == "minimax"
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://api.minimax.io/anthropic",
+            "https://api.minimaxi.com/anthropic",
+        ],
+    )
+    def test_anthropic_compatible_base_url_builds_messages_path(
+        self, monkeypatch, base_url
+    ):
+        monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+        requests = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return httpx.Response(
+                200,
+                json={
+                    "id": "msg_test",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "MiniMax-M3",
+                    "content": [{"type": "text", "text": "ok"}],
+                    "stop_reason": "end_turn",
+                    "stop_sequence": None,
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                },
+            )
+
+        async def run_request() -> str:
+            async with httpx.AsyncClient(
+                transport=httpx.MockTransport(handler)
+            ) as http_client:
+                sdk_client = AsyncAnthropic(
+                    api_key="test-key",
+                    base_url=base_url,
+                    http_client=http_client,
+                )
+                with patch("src.ai.client.AsyncAnthropic", return_value=sdk_client):
+                    client = create_ai_client(_make_config(base_url=base_url))
+                    assert isinstance(client, AnthropicClient)
+                    return await client.complete(system="test", user="hello")
+
+        assert asyncio.run(run_request()) == "ok"
+        assert [str(request.url) for request in requests] == [
+            f"{base_url}/v1/messages"
+        ]
 
     def test_creates_openai_client_for_deepseek(self, monkeypatch):
         monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry.

## Summary

- Set MiniMax M3 as the provider registry default.
- Route MiniMax `/anthropic` base URLs through the existing messages client while keeping `/v1` bases on the chat completions client.
- Document both account regions and add request-path coverage for both compatible endpoint styles.

## Checks

- `uv run pytest tests/test_minimax_client.py`
- `uv run pytest`
- `uv run python -m compileall -q src tests`
- `git diff --check`

## Checklist

- [x] I explained the change clearly
- [x] I kept the PR focused and easy to review
- [x] I tested the change locally