### PR TITLE
feat(docker): add EXTRAS build-arg for optional dependency groups 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,10 @@ COPY src ./src
 COPY data ./data
 COPY .env.example .env.example
 
-# Install dependencies
-RUN uv sync --frozen --no-dev
+# Install dependencies (EXTRAS: comma-separated optional groups, e.g. "trafilatura,twitter")
+ARG EXTRAS=""
+RUN uv sync --frozen --no-dev \
+    $([ -n "$EXTRAS" ] && echo "$EXTRAS" | tr ',' '\n' | sed 's/^/--extra /' | tr '\n' ' ')
 
 # Runtime data is mounted here; keep the image and process unprivileged.
 RUN useradd --create-home --uid 10001 horizon \

--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ docker compose run --rm horizon
 
 # Or run with custom time window
 docker compose run --rm horizon --hours 48
+
+# Build with optional extras (comma-separated)
+docker build --build-arg EXTRAS=trafilatura .
 ```
 
 ### 2. Configure

--- a/README_ja.md
+++ b/README_ja.md
@@ -219,6 +219,9 @@ docker compose run --rm horizon
 
 # またはカスタムの時間枠で実行
 docker compose run --rm horizon --hours 48
+
+# オプションの依存関係グループを含めてビルド（カンマ区切り）
+docker build --build-arg EXTRAS=trafilatura .
 ```
 
 ### 2. 設定

--- a/README_zh.md
+++ b/README_zh.md
@@ -227,6 +227,9 @@ docker compose run --rm horizon
 
 # 或自定义时间窗口
 docker compose run --rm horizon --hours 48
+
+# 构建时启用可选扩展（逗号分隔）
+docker build --build-arg EXTRAS=trafilatura .
 ```
 
 ### 2. 配置

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   horizon:
-    build: .
+    build:
+      context: .
+      # args:
+      #   EXTRAS: trafilatura  # comma-separated optional extras, e.g. "trafilatura,openbb"
     container_name: horizon
     volumes:
       - ./data:/app/data

--- a/docs/extractors.md
+++ b/docs/extractors.md
@@ -50,7 +50,11 @@ Using a type name directly (e.g. `"content_extractor": "trafilatura"`) also work
 Uses the [trafilatura](https://trafilatura.readthedocs.io/) library to extract main article text from HTML. Requires the `trafilatura` optional dependency:
 
 ```bash
+# Local
 uv sync --extra trafilatura
+
+# Docker
+docker build --build-arg EXTRAS=trafilatura .
 ```
 
 **Config fields**:


### PR DESCRIPTION
## Summary

Adds a `EXTRAS` build argument to the Dockerfile so optional dependency groups can be included at image build time without maintaining multiple Dockerfiles. Callers pass a comma-separated list which the build translates into `uv sync --extra` flags. All docs and config examples are updated to match.

## Scope

- [x] This PR contains **one feature / one fix / one focused change**
- [x] This PR does **not** combine multiple unrelated features

## Changes

 - **`Dockerfile`**: Add `ARG EXTRAS=""` and wire it into `uv sync` so comma-separated extras are passed as `--extra` flags at build time
  - **`docker-compose.yml`**: Add a commented `args: EXTRAS:` block as a usage example
  - **`README.md` / `README_zh.md` / `README_ja.md`**: Add `docker build --build-arg EXTRAS=trafilatura .` example to the Docker install section

## Notes for Reviewers

Docker support for the `twitter` extra is not fully covered here — Playwright requires a separate browser installation step that the Dockerfile does not yet handle. Passing EXTRAS=twitter would install the Python package but wont be able to run – this is left as a follow-up.

## Checklist

- [x] I explained the change clearly
- [x] I kept the PR focused and easy to review
- [x] I tested the change locally when applicable

