### PR TITLE
feat(cli): add flags for specifying data directory and config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,18 +315,21 @@ For the full reference, see the [Configuration Guide](docs/configuration.md).
 #### Local Installation
 
 ```bash
-uv run horizon           # Run with default 24h window
-uv run horizon --hours 48  # Fetch from last 48 hours
+uv run horizon                          # Run with default 24h window
+uv run horizon --hours 48               # Fetch from last 48 hours
+uv run horizon -d /path/to/data         # Use a custom data directory
+uv run horizon -c /path/to/config.json  # Use a custom config file
 ```
 
 #### With Docker
 
 ```bash
-docker compose run --rm horizon           # Run with default 24h window
-docker compose run --rm horizon --hours 48  # Fetch from last 48 hours
+docker compose run --rm horizon                          # Run with default 24h window
+docker compose run --rm horizon --hours 48               # Fetch from last 48 hours
+docker compose run --rm horizon -c /app/data/alt.json   # Use a custom config file
 ```
 
-The generated report will be saved to `data/summaries/`.
+The generated report will be saved to `data/summaries/` (or `<data-dir>/summaries/` if `--data-dir` is set).
 
 ### 4. Automate (Optional)
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -312,18 +312,21 @@ Geminiの場合は`GOOGLE_API_KEY`を使用します。
 #### ローカルインストール
 
 ```bash
-uv run horizon           # デフォルトの24時間枠で実行
-uv run horizon --hours 48  # 過去48時間から取得
+uv run horizon                          # デフォルトの24時間枠で実行
+uv run horizon --hours 48               # 過去48時間から取得
+uv run horizon -d /path/to/data         # カスタムデータディレクトリを使用
+uv run horizon -c /path/to/config.json  # カスタム設定ファイルを使用
 ```
 
 #### Dockerで
 
 ```bash
-docker compose run --rm horizon           # デフォルトの24時間枠で実行
-docker compose run --rm horizon --hours 48  # 過去48時間から取得
+docker compose run --rm horizon                          # デフォルトの24時間枠で実行
+docker compose run --rm horizon --hours 48               # 過去48時間から取得
+docker compose run --rm horizon -c /app/data/alt.json   # カスタム設定ファイルを使用
 ```
 
-生成されたレポートは`data/summaries/`に保存されます。
+生成されたレポートは`data/summaries/`に保存されます（`--data-dir`を指定した場合は`<data-dir>/summaries/`）。
 
 ### 4. 自動化（オプション）
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -304,18 +304,21 @@ cp data/config.example.json data/config.json  # 自定义信息源
 #### 本地安装
 
 ```bash
-uv run horizon              # 使用默认 24 小时窗口
-uv run horizon --hours 48   # 抓取最近 48 小时的内容
+uv run horizon                          # 使用默认 24 小时窗口
+uv run horizon --hours 48               # 抓取最近 48 小时的内容
+uv run horizon -d /path/to/data         # 使用自定义数据目录
+uv run horizon -c /path/to/config.json  # 使用自定义配置文件
 ```
 
 #### 使用 Docker
 
 ```bash
-docker compose run --rm horizon              # 使用默认 24 小时窗口
-docker compose run --rm horizon --hours 48   # 抓取最近 48 小时的内容
+docker compose run --rm horizon                          # 使用默认 24 小时窗口
+docker compose run --rm horizon --hours 48               # 抓取最近 48 小时的内容
+docker compose run --rm horizon -c /app/data/alt.json   # 使用自定义配置文件
 ```
 
-生成的日报将保存在 `data/summaries/` 目录中。
+生成的日报将保存在 `data/summaries/` 目录中（如设置了 `--data-dir`，则保存在 `<data-dir>/summaries/`）。
 
 ### 4. 自动化（可选）
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@ title: Configuration Guide
 
 # Configuration Guide
 
-Horizon is configured through two files: a `.env` file for API keys and a `data/config.json` file for sources, AI provider, and filtering options.
+Horizon is configured through two files: a `.env` file for API keys and a `data/config.json` file for sources, AI provider, and filtering options. The config file path can be overridden with the `-c` / `--config` flag, and the data directory with `-d` / `--data-dir`.
 
 ## AI Providers
 
@@ -772,7 +772,7 @@ With this layout, Horizon sends one interactive card containing the overview and
 
 ## Static Site
 
-Horizon writes generated summaries to `data/summaries/` and copies publishable Markdown into `docs/` for the GitHub Pages site. The repository includes a ready-to-use workflow at `.github/workflows/daily-summary.yml`.
+Horizon writes generated summaries to `data/summaries/` (or `<data-dir>/summaries/` when `--data-dir` is set) and copies publishable Markdown into `docs/` for the GitHub Pages site. The repository includes a ready-to-use workflow at `.github/workflows/daily-summary.yml`.
 
 To use GitHub Pages, enable Pages for the repository and run the scheduled workflow or trigger it manually. The generated site is built from the `docs/` directory.
 

--- a/src/main.py
+++ b/src/main.py
@@ -37,17 +37,20 @@ def main():
 
     parser = argparse.ArgumentParser(description="Horizon - AI-Driven Information Aggregation System")
     parser.add_argument("--hours", type=int, help="Force fetch from last N hours")
+    parser.add_argument("-d", "--data-dir", default="data", metavar="PATH",
+                        help="Path to the data directory (default: 'data')")
+    parser.add_argument("-c", "--config", default=None, metavar="PATH",
+                        help="Path to config file (default: <data-dir>/config.json)")
     args = parser.parse_args()
 
     try:
         # Load environment variables from .env file
         load_dotenv()
 
-        # Ensure we're in the project directory or use data/ in current dir
-        data_dir = Path("data")
+        data_dir = Path(args.data_dir)
 
         # Initialize storage manager
-        storage = StorageManager(data_dir=str(data_dir))
+        storage = StorageManager(data_dir=str(data_dir), config_path=args.config)
 
         # Load configuration
         try:

--- a/src/storage/manager.py
+++ b/src/storage/manager.py
@@ -63,9 +63,9 @@ class ConfigError(ValueError):
 class StorageManager:
     """Manages file-based storage for configuration and state."""
 
-    def __init__(self, data_dir: str = "data"):
+    def __init__(self, data_dir: str = "data", config_path: str | None = None):
         self.data_dir = Path(data_dir)
-        self.config_path = self.data_dir / "config.json"
+        self.config_path = Path(config_path) if config_path is not None else self.data_dir / "config.json"
         self.summaries_dir = self.data_dir / "summaries"
 
         self.data_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Adds `-d`/`--data-dir` and `-c`/`--config` CLI flags to the `horizon` binary, making the data directory and config file path configurable at runtime. Defaults are unchanged so existing usage is unaffected.

## Scope

- [x] This PR contains **one feature / one focused change**
- [x] This PR does **not** combine multiple unrelated features

## Changes

- `src/storage/manager.py`: `StorageManager.__init__` gains an optional `config_path` parameter; overrides the default `<data_dir>/config.json` when provided
- `src/main.py`: adds `-d`/`--data-dir` and `-c`/`--config` argparse flags wired to `StorageManager`
- `README.md`, `README_zh.md`, `README_ja.md`, `docs/configuration.md`: documents the new flags with examples across all language variants

## Notes for Reviewers

<details><summary>Tests</summary>
<p>

```
 uv run --with pytest pytest tests/
.................................................................................................. [ 25%]
.................................................................................................. [ 50%]
.................................................................................................. [ 75%]
.............................................................................................      [100%]
============================================ warnings summary ============================================
.venv/lib/python3.14/site-packages/google/genai/types.py:43: DeprecationWarning: '_UnionGenericAlias' is deprecated and slated for removal in Python 3.17
    VersionedUnionType = Union[builtin_types.UnionType, _UnionGenericAlias]

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
387 passed, 1 warning in 1.88s
```

</p>
</details> 

## Checklist

- [x] I explained the change clearly
- [x] I kept the PR focused and easy to review
- [x] I tested the change locally when applicable