### PR TITLE
refactor(output): unify all console output

### DIFF
--- a/src/ai/analyzer.py
+++ b/src/ai/analyzer.py
@@ -2,11 +2,15 @@
 
 import asyncio
 import json
+import logging
 import re
 from typing import List, Optional
 from pydantic import BaseModel, Field, ValidationError
-from tenacity import retry, stop_after_attempt, wait_exponential
+from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, BarColumn, TextColumn, MofNCompleteColumn
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+logger = logging.getLogger(__name__)
 
 from .client import AIClient
 from .prompts import CONTENT_ANALYSIS_SYSTEM, CONTENT_ANALYSIS_USER
@@ -28,8 +32,9 @@ class AnalysisResult(BaseModel):
 class ContentAnalyzer:
     """Analyzes content items using AI to determine importance."""
 
-    def __init__(self, ai_client: AIClient):
+    def __init__(self, ai_client: AIClient, console: Optional[Console] = None):
         self.client = ai_client
+        self.console = console or Console(stderr=True)
 
     @staticmethod
     def _parse_json_response(response: str) -> Optional[dict]:
@@ -61,7 +66,7 @@ class ContentAnalyzer:
                 try:
                     await self._analyze_item(item)
                 except Exception as e:
-                    print(f"Error analyzing item {item.id}: {e}")
+                    logger.error("Error analyzing item %s: %s", item.id, e)
                     item.ai_score = 0.0
                     item.ai_reason = "Analysis failed"
                     item.ai_summary = item.title
@@ -76,6 +81,7 @@ class ContentAnalyzer:
             BarColumn(),
             MofNCompleteColumn(),
             transient=True,
+            console=self.console,
         ) as progress:
             task = progress.add_task("Analyzing", total=len(items))
             coros = [
@@ -162,7 +168,7 @@ class ContentAnalyzer:
         except ValidationError:
             result = None
         if result is None:
-            print(f"Warning: could not parse analysis response for {item.id}, using defaults")
+            logger.warning("Could not parse analysis response for %s, using defaults", item.id)
             item.ai_score = 0.0
             item.ai_reason = "Analysis response parse failed"
             item.ai_summary = item.title

--- a/src/ai/client.py
+++ b/src/ai/client.py
@@ -10,9 +10,12 @@ from google import genai
 from google.genai import types
 
 
+import logging
+
 from ..models import AIConfig, AIProvider, AI_PROVIDER_DEFAULTS
-from rich import print as rich_print
 from .tokens import record_usage
+
+logger = logging.getLogger(__name__)
 
 
 _ENV_VAR_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -610,9 +613,9 @@ class ChainedAIClient(AIClient):
                     raise
                 last_error = exc
                 if i < len(self.configs) - 1:
-                    rich_print(
-                        f"\n[yellow]Provider {self.configs[i].provider.value} failed ({exc}), "
-                        f"falling back to {self.configs[i + 1].provider.value}...[/yellow]"
+                    logger.warning(
+                        "Provider %s failed (%s), falling back to %s...",
+                        self.configs[i].provider.value, exc, self.configs[i + 1].provider.value,
                     )
         raise RuntimeError(f"All providers failed. Last error: {last_error}")
 

--- a/src/ai/enricher.py
+++ b/src/ai/enricher.py
@@ -7,13 +7,17 @@ For items that pass the score threshold, this module:
 
 import asyncio
 import json
+import logging
 import re
 import sys
 import os
 from typing import List, Optional
-from tenacity import retry, stop_after_attempt, wait_exponential
+from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, BarColumn, TextColumn, MofNCompleteColumn
+from tenacity import retry, stop_after_attempt, wait_exponential
 from ddgs import DDGS
+
+logger = logging.getLogger(__name__)
 
 from .client import AIClient
 from .prompts import (
@@ -27,8 +31,9 @@ from ..models import ContentItem
 class ContentEnricher:
     """Enriches high-scoring content items with background knowledge."""
 
-    def __init__(self, ai_client: AIClient):
+    def __init__(self, ai_client: AIClient, console: Optional[Console] = None):
         self.client = ai_client
+        self.console = console or Console(stderr=True)
 
     def _get_concurrency(self) -> int:
         """Return the configured enrichment concurrency, clamped to 1 or above."""
@@ -50,7 +55,7 @@ class ContentEnricher:
                 try:
                     await self._enrich_item(item)
                 except Exception as e:
-                    print(f"Error enriching item {item.id}: {e}, falling back to translation")
+                    logger.error("Error enriching item %s: %s, falling back to translation", item.id, e)
                     await self._translate_item(item)
             progress.advance(progress_task)
 
@@ -60,6 +65,7 @@ class ContentEnricher:
             BarColumn(),
             MofNCompleteColumn(),
             transient=True,
+            console=self.console,
         ) as progress:
             task = progress.add_task("Enriching", total=len(items))
             coros = [
@@ -195,7 +201,7 @@ class ContentEnricher:
         if result is None:
             # Gracefully degrade: fall back to a lightweight translation
             # instead of dropping the item untranslated.
-            print(f"Warning: could not parse enrichment response for {item.id}, falling back to translation")
+            logger.warning("Could not parse enrichment response for %s, falling back to translation", item.id)
             await self._translate_item(item)
             return
 

--- a/src/main.py
+++ b/src/main.py
@@ -2,17 +2,25 @@
 
 import argparse
 import asyncio
+import logging
 import sys
 from pathlib import Path
 
 from dotenv import load_dotenv
 from rich.console import Console
+from rich.logging import RichHandler
 
 from .storage.manager import ConfigError, StorageManager
 from .orchestrator import HorizonOrchestrator
 
 
-console = Console()
+console = Console(stderr=True)
+logging.basicConfig(
+    level=logging.WARNING,
+    format="%(message)s",
+    handlers=[RichHandler(console=console, show_path=False)],
+)
+logger = logging.getLogger(__name__)
 
 
 def print_banner():
@@ -73,7 +81,7 @@ def main():
             sys.exit(1)
 
         # Create and run orchestrator
-        orchestrator = HorizonOrchestrator(config, storage)
+        orchestrator = HorizonOrchestrator(config, storage, console=console)
         asyncio.run(orchestrator.run(force_hours=args.hours))
 
     except KeyboardInterrupt:
@@ -81,8 +89,7 @@ def main():
         sys.exit(0)
     except Exception as e:
         console.print(f"\n[bold red]❌ Fatal error: {e}[/bold red]")
-        import traceback
-        traceback.print_exc()
+        console.print_exception()
         sys.exit(1)
 
 

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -164,16 +164,17 @@ class FetchReport:
 class HorizonOrchestrator:
     """Orchestrates the complete workflow for content aggregation and analysis."""
 
-    def __init__(self, config: Config, storage: StorageManager):
+    def __init__(self, config: Config, storage: StorageManager, console: Optional[Console] = None):
         """Initialize orchestrator.
 
         Args:
             config: Application configuration
             storage: Storage manager
+            console: Shared Rich Console instance
         """
         self.config = config
         self.storage = storage
-        self.console = Console()
+        self.console = console or Console(stderr=True)
         self.email_manager = EmailManager(config.email, console=self.console) if config.email else None
         self.webhook_notifier = (
             WebhookNotifier(config.webhook, console=self.console)
@@ -845,7 +846,7 @@ class HorizonOrchestrator:
             f"   Re-analyzing {len(expanded)} Twitter items with reply context...\n"
         )
         ai_client = create_ai_client(self.config.ai)
-        analyzer = ContentAnalyzer(ai_client)
+        analyzer = ContentAnalyzer(ai_client, console=self.console)
         await analyzer.analyze_batch(expanded)
 
     async def _enrich_important_items(self, items: List[ContentItem]) -> None:
@@ -862,7 +863,7 @@ class HorizonOrchestrator:
 
         self.console.print("📚 Enriching with background knowledge...")
         ai_client = create_ai_client(self.config.ai)
-        enricher = ContentEnricher(ai_client)
+        enricher = ContentEnricher(ai_client, console=self.console)
         await enricher.enrich_batch(items)
         self.console.print(f"   Enriched {len(items)} items\n")
 
@@ -878,7 +879,7 @@ class HorizonOrchestrator:
         self.console.print("🤖 Analyzing content with AI...")
 
         ai_client = create_ai_client(self.config.ai)
-        analyzer = ContentAnalyzer(ai_client)
+        analyzer = ContentAnalyzer(ai_client, console=self.console)
 
         return await analyzer.analyze_batch(items)
 

--- a/src/services/email.py
+++ b/src/services/email.py
@@ -16,6 +16,8 @@ try:
 except ImportError:
     markdown = None
 
+from rich.console import Console
+
 from ..ai.markdown_utils import clean_app_summary_markdown
 from ..models import EmailConfig
 
@@ -28,20 +30,7 @@ class EmailManager:
     def __init__(self, config: EmailConfig, console=None):
         self.config = config
         self.pwd = os.getenv(self.config.password_env)
-        if console is None:
-            try:
-                from rich.console import Console
-
-                self.console = Console()
-            except ImportError:
-
-                class DummyConsole:
-                    def print(self, *args, **kwargs):
-                        print(*args, **kwargs)
-
-                self.console = DummyConsole()
-        else:
-            self.console = console
+        self.console = console if console is not None else Console(stderr=True)
 
         if not self.pwd and self.config.enabled:
             logger.warning(

--- a/src/services/webhook.py
+++ b/src/services/webhook.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import re
+from rich.console import Console
 from dataclasses import asdict, dataclass
 from enum import Enum
 from urllib.parse import urlsplit, urlunsplit
@@ -250,20 +251,7 @@ class WebhookNotifier:
 
     def __init__(self, config: WebhookConfig, console=None):
         self.config = config
-        if console is None:
-            try:
-                from rich.console import Console
-
-                self.console = Console()
-            except ImportError:
-
-                class DummyConsole:
-                    def print(self, *args, **kwargs):
-                        print(*args, **kwargs)
-
-                self.console = DummyConsole()
-        else:
-            self.console = console
+        self.console = console if console is not None else Console(stderr=True)
         self.url = None
         self._validate_config()  # sets self.url or raises ValueError
 

--- a/src/services/webhook_cli.py
+++ b/src/services/webhook_cli.py
@@ -16,7 +16,7 @@ from ..models import ContentItem, SourceType
 from ..storage.manager import ConfigError, StorageManager
 from .webhook import WebhookNotifier
 
-console = Console()
+console = Console(stderr=True)
 
 
 def _make_test_items() -> list[ContentItem]:
@@ -208,9 +208,7 @@ def main() -> None:
         sys.exit(0)
     except Exception as e:
         console.print(f"\n[bold red]Error: {e}[/bold red]")
-        import traceback
-
-        traceback.print_exc()
+        console.print_exception()
         sys.exit(1)
 
 

--- a/src/setup/wizard.py
+++ b/src/setup/wizard.py
@@ -22,7 +22,7 @@ from ..storage.manager import StorageManager
 from .presets import load_presets, match_sources
 
 
-console = Console()
+console = Console(stderr=True)
 
 
 def print_banner():


### PR DESCRIPTION
## Summary

Unifies all diagnostic output through a single shared `rich.Console(stderr=True)` instance and wires stdlib `logging` to it via `RichHandler`, so progress bars and log messages coordinate correctly and everything goes to stderr consistently.

## Scope

- [x] This PR contains **one feature / one focused change**
- [x] This PR does **not** combine multiple unrelated features

## Changes

- `src/main.py`: create one `Console(stderr=True)` at startup; configure `logging.basicConfig` with `RichHandler` pointed at it; pass the console into `HorizonOrchestrator`; replace `traceback.print_exc()` with `console.print_exception()`
- `src/orchestrator.py`: accept optional `console` parameter instead of constructing its own; pass it down to `ContentAnalyzer`, `ContentEnricher`, `EmailManager`, `WebhookNotifier`
- `src/ai/analyzer.py`, `src/ai/enricher.py`: accept optional `console` parameter; pass it to `Progress(console=...)` so the live display and `RichHandler` share the same console instance and can coordinate rendering
- `src/ai/client.py`: replace `from rich import print as rich_print` with `logger.warning()` for provider-fallback messages
- `src/ai/analyzer.py`, `src/ai/enricher.py`: replace bare `print()` on error paths with `logger.error()` / `logger.warning()`
- `src/services/webhook.py`, `src/services/email.py`: remove unreachable `try/except ImportError` + `DummyConsole` blocks; move `Console` import to module level; simplify `__init__` to a one-liner fallback with `Console(stderr=True)`
- `src/services/webhook_cli.py`, `src/setup/wizard.py`: switch to `Console(stderr=True)`; replace `traceback.print_exc()` with `console.print_exception()`

## Notes for Reviewers

- **Why stderr?** Horizon produces no machine-readable stdout output — all results go to a webhook. Putting diagnostics on stderr follows Unix convention.
- **Why share one Console instance?** both `rich.Progress` and `RichHandler` register with a Console. If those consoles differ, log messages emitted during a progress bar corrupt the display. With a shared instance Rich serialises writes and redraws the bar cleanly.
- **DummyConsole removal:** `rich` is a required dependency in `pyproject.toml`. The `ImportError` path was unreachable — if Rich were missing, the process would fail at import time before any constructor ran.

<details><summary>Screenshots</summary>
<p>

warnings example:

<img width="2648" height="1332" alt="image" src="https://github.com/user-attachments/assets/9d67b1f1-ede4-4573-835a-3e574120ace8" />


errors example:

<img width="1376" height="440" alt="Screenshot 2026-07-20 at 16 09 11" src="https://github.com/user-attachments/assets/00b44554-baa5-42c7-b2cd-19fb8db2aeda" />


</p>
</details> 

## Checklist

- [x] I explained the change clearly
- [x] I kept the PR focused and easy to review
- [x] I tested the change locally when applicable