### PR TITLE
feat: support configurable scoring criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ But Horizon is not just another summarizer. AI is great at reducing noise, but n
 - **📧 Deliver by Email** — Run a self-hosted SMTP/IMAP newsletter with automatic subscribe and unsubscribe handling
 - **🔔 Push to Chat or Automations** — Send templated results to Feishu/Lark, DingTalk, Slack, Discord, or custom webhook endpoints
 - **🧙 Start From Your Interests** — Use the setup wizard to generate a personalized source configuration
-- **⚙️ Tune the Radar** — Customize sources, thresholds, models, languages, and delivery channels from one JSON config
+- **⚙️ Tune the Radar** — Customize sources, scoring dimensions, thresholds, filter logic, models, languages, and delivery channels from one JSON config
 
 ## How It Works
 
@@ -256,6 +256,36 @@ Minimal manual configuration:
   }
 }
 ```
+
+**Custom scoring criteria (optional)**
+
+Define domain-specific scoring dimensions under `filtering.score_criteria`.
+`filter_mode: "any"` keeps an item that reaches at least one configured
+threshold; `"all"` requires every configured threshold:
+
+```jsonc
+{
+  "filtering": {
+    "filter_mode": "any",
+    "score_criteria": [
+      {
+        "name": "tech",
+        "description": "Relevance to software engineering, AI/ML, and systems research",
+        "threshold": 7.0
+      },
+      {
+        "name": "finance",
+        "description": "Relevance to financial markets, macroeconomics, or investment decisions",
+        "threshold": 6.0
+      }
+    ]
+  }
+}
+```
+
+Omit `score_criteria` (or set it to `null`) to preserve the original
+single-score prompt and `ai_score_threshold` behavior. See
+[Scoring](docs/scoring.md) for validation and model-response error handling.
 
 **Balanced digest (optional)**
 

--- a/data/config.example.json
+++ b/data/config.example.json
@@ -130,6 +130,8 @@
   },
   "filtering": {
     "ai_score_threshold": 6.0,
+    "filter_mode": "any",
+    "score_criteria": null,
     "time_window_hours": 24,
     "max_items": null,
     "category_groups": {},

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -449,7 +449,8 @@ No API key is required.
 
 ## Filtering
 
-Content is scored 0-10:
+Without `score_criteria`, Horizon uses its original technical-news prompt and
+one 0-10 score:
 
 - **9-10**: Groundbreaking - Major breakthroughs, paradigm shifts
 - **7-8**: High Value - Important developments, deep technical content
@@ -461,6 +462,8 @@ Content is scored 0-10:
 {
   "filtering": {
     "ai_score_threshold": 7.0,
+    "filter_mode": "any",
+    "score_criteria": null,
     "time_window_hours": 24,
     "max_items": 20,
     "category_groups": {
@@ -481,7 +484,14 @@ Content is scored 0-10:
 }
 ```
 
-- `ai_score_threshold`: Only include content scoring >= this value
+- `ai_score_threshold`: Only include content scoring >= this value when
+  `score_criteria` is omitted or `null`
+- `filter_mode`: Custom-criteria logic. `any` keeps an item when at least one
+  criterion reaches its threshold; `all` requires every criterion. Default:
+  `any`
+- `score_criteria`: Optional list of custom scoring dimensions. Omit it or set
+  it to `null` to preserve the original prompt, response format, and
+  `ai_score_threshold` behavior
 - `time_window_hours`: Fetch content from last N hours
 - `max_items`: Optional final cap after all group limits are applied
 - `category_groups`: Optional map of quota groups. Each group requires a positive
@@ -492,6 +502,59 @@ Content is scored 0-10:
   configured group. Default is `other`.
 - `default_group_limit`: Optional positive limit for unmatched items. If omitted,
   unmatched items are unlimited except for `max_items`.
+
+### User-defined scoring criteria
+
+Each criterion has a stable machine-readable `name`, a prompt
+`description`, and its own inclusive `threshold`:
+
+```json
+{
+  "filtering": {
+    "filter_mode": "any",
+    "score_criteria": [
+      {
+        "name": "tech",
+        "description": "Relevance to software engineering, AI/ML, and systems research",
+        "threshold": 7.0
+      },
+      {
+        "name": "english_learning",
+        "description": "High-quality authentic English suitable for B2-C1 learners",
+        "threshold": 6.0
+      },
+      {
+        "name": "finance",
+        "description": "Relevance to financial markets, macroeconomics, or investment decisions",
+        "threshold": 6.0
+      }
+    ]
+  }
+}
+```
+
+Configuration rules are intentionally strict so mistakes fail during startup:
+
+- `name` must be 1-64 characters, begin with an ASCII letter, and contain only
+  ASCII letters, digits, `_`, or `-`
+- names must be unique ignoring letter case
+- `description` must contain non-whitespace text
+- `threshold` and legacy `ai_score_threshold` must be finite numbers from 0
+  through 10
+- `filter_mode` must be exactly `any` or `all`
+- an explicit empty `score_criteria: []` is invalid; omit the field or use
+  `null` for legacy scoring
+
+For custom criteria, Horizon asks the model for a `scores` object containing
+exactly one numeric score for every configured name. Missing, extra,
+non-numeric, non-finite, or out-of-range scores leave the item unscored and
+record a diagnostic in `ai_analysis_error`; they are never converted to a low
+score. The filtering stage reports how many unscored items it excludes.
+
+Horizon still stores one aggregate `ai_score` for existing sorting, summaries,
+and delivery templates: `any` uses the highest configured score and `all` uses
+the lowest. Passing or failing is always calculated from every configured
+criterion and its own threshold, using an inclusive `>=` comparison.
 
 Balanced digest filtering runs after AI score threshold filtering and topic
 deduplication, but before enrichment. This reduces enrichment calls to only the

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -9,10 +9,17 @@ After fetching content from all sources, Horizon uses an AI model to score each 
 
 ## Pipeline
 
-1. **Batch processing** — Items are scored in batches of 10 with a progress bar. Failed items receive a score of 0.
+1. **Batch processing** — Items are scored concurrently according to
+   `ai.analysis_concurrency`, with a progress bar. Failed items remain
+   explicitly unscored.
 2. **Content preparation** — For each item, the content is truncated (800 chars if comments are present, 1000 otherwise) and engagement metrics are assembled from metadata (HN score, Reddit upvote ratio, etc.).
-3. **AI analysis** — The prepared content is sent to the configured AI model (temperature 0.3) with a system prompt defining the scoring criteria.
-4. **Response parsing** — The AI response is parsed as JSON (with fallbacks for code-block-wrapped JSON). Each item gets: `ai_score` (float), `ai_reason` (string), `ai_summary` (string), and `ai_tags` (list).
+3. **AI analysis** — The prepared content is sent to the configured AI model
+   with either the legacy technical-news prompt or a prompt generated from
+   `filtering.score_criteria`.
+4. **Response parsing** — The AI response is parsed as JSON (with fallbacks for
+   code-block-wrapped JSON). Legacy responses contain `score`; custom responses
+   contain a `scores` object keyed by configured criterion names. Each item also
+   gets `ai_reason`, `ai_summary`, and `ai_tags`.
 5. **Retry** — Failed AI calls are retried up to 3 times with exponential backoff (2-10 seconds).
 
 ## Scoring Scale
@@ -25,9 +32,9 @@ After fetching content from all sources, Horizon uses an AI model to score each 
 | 3-4 | Low Priority | Minor updates, common knowledge, overly promotional |
 | 0-2 | Noise | Spam, off-topic, trivial updates |
 
-## Scoring Factors
+## Legacy Scoring Factors
 
-The AI evaluates each item based on:
+When `score_criteria` is omitted or `null`, the AI evaluates each item based on:
 
 - **Technical depth and novelty** — original ideas, new techniques, research contributions
 - **Potential impact** — how broadly this affects software engineering, AI/ML, or systems research
@@ -39,7 +46,9 @@ Engagement metadata is source-specific: HN provides score and comment count, Red
 
 ## Filtering
 
-After scoring, items are filtered by `filtering.ai_score_threshold` (default: `7.0`) and sorted by score descending. Optional balanced digest quotas are then applied before enrichment.
+Without custom criteria, items are filtered by
+`filtering.ai_score_threshold` (default: `7.0`) and sorted by score descending.
+Optional balanced digest quotas are then applied before enrichment.
 
 ```json
 {
@@ -60,6 +69,37 @@ After scoring, items are filtered by `filtering.ai_score_threshold` (default: `7
 `category_groups` limits each configured category group independently.
 `max_items` caps the merged result. Both fields are optional; without them,
 scoring and filtering behave as before.
+
+### Custom criteria and filter modes
+
+When `filtering.score_criteria` is configured, every criterion defines a
+stable name, a description used to generate the scoring prompt, and an
+inclusive 0-10 threshold.
+
+- `filter_mode: "any"` keeps an item when at least one score is `>=` its
+  criterion threshold.
+- `filter_mode: "all"` keeps an item only when every score is `>=` its
+  criterion threshold.
+
+An explicit empty list is invalid. Criterion names are case-insensitively
+unique and restricted to stable ASCII identifier characters. Thresholds must
+be finite values from 0 through 10. See the
+[Configuration Guide](configuration.md#user-defined-scoring-criteria) for a
+complete example.
+
+For compatibility with existing summaries and integrations, `ai_score` remains
+available as an aggregate: the maximum criterion score for `any`, or the
+minimum for `all`. Actual filtering never compares this aggregate with
+`ai_score_threshold`; it evaluates each configured score and threshold.
+
+### Invalid model responses
+
+Custom responses must contain exactly one numeric score for every configured
+criterion. Missing or extra criterion names, strings in place of numbers,
+non-finite values, out-of-range scores, invalid JSON, and missing common fields
+are diagnostic failures. Horizon leaves the item unscored, records
+`ai_analysis_error`, and reports its exclusion during filtering. It does not
+turn parsing or provider failures into a score of zero.
 
 Items scoring 9.0 or above are featured in the "Today's Highlights" section of the summary.
 

--- a/src/ai/analyzer.py
+++ b/src/ai/analyzer.py
@@ -1,35 +1,107 @@
 """Content analysis using AI."""
 
 import asyncio
-import json
-import re
+from math import isfinite
 from typing import List, Optional
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, ValidationError, field_validator
 from tenacity import retry, stop_after_attempt, wait_exponential
 from rich.progress import Progress, SpinnerColumn, BarColumn, TextColumn, MofNCompleteColumn
 
 from .client import AIClient
-from .prompts import CONTENT_ANALYSIS_SYSTEM, CONTENT_ANALYSIS_USER
+from .prompts import build_content_analysis_system, build_content_analysis_user
 from .utils import parse_json_response
-from ..models import ContentItem
+from ..models import ContentItem, FilteringConfig, ScoreCriterionConfig
+from ..scoring import aggregate_custom_score
 
 DEFAULT_THROTTLE_SEC = 0.0
 
 
-class AnalysisResult(BaseModel):
-    """Validated structured result returned by the analysis model."""
+def _validated_score(value: object, *, field_name: str) -> float:
+    """Accept only finite JSON numbers in the documented 0-10 range."""
 
-    score: float = Field(ge=0, le=10, allow_inf_nan=False)
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not isfinite(float(value))
+        or not 0 <= float(value) <= 10
+    ):
+        raise ValueError(f"{field_name} must be a finite number from 0 to 10")
+    return float(value)
+
+
+class BaseAnalysisResult(BaseModel):
+    """Fields shared by legacy and user-defined analysis responses."""
+
     reason: str
     summary: str
     tags: list[str]
+
+    @field_validator("reason", "summary", mode="before")
+    @classmethod
+    def validate_text(cls, value: object) -> object:
+        if not isinstance(value, str):
+            raise ValueError("must be a string")
+        return value
+
+    @field_validator("tags", mode="before")
+    @classmethod
+    def validate_tags(cls, value: object) -> object:
+        if not isinstance(value, list) or any(not isinstance(tag, str) for tag in value):
+            raise ValueError("tags must be a list of strings")
+        return value
+
+
+class AnalysisResult(BaseAnalysisResult):
+    """Validated structured result returned by the legacy analysis prompt."""
+
+    score: float
+
+    @field_validator("score", mode="before")
+    @classmethod
+    def validate_score(cls, value: object) -> float:
+        return _validated_score(value, field_name="score")
+
+
+class CustomAnalysisResult(BaseAnalysisResult):
+    """Validated structured result for user-defined criteria."""
+
+    scores: dict[str, float]
+
+    @field_validator("scores", mode="before")
+    @classmethod
+    def validate_scores(cls, value: object) -> dict[str, float]:
+        if not isinstance(value, dict):
+            raise ValueError("scores must be an object")
+
+        result: dict[str, float] = {}
+        for name, score in value.items():
+            if not isinstance(name, str):
+                raise ValueError("score names must be strings")
+            result[name] = _validated_score(
+                score,
+                field_name=f"score '{name}'",
+            )
+        return result
 
 
 class ContentAnalyzer:
     """Analyzes content items using AI to determine importance."""
 
-    def __init__(self, ai_client: AIClient):
+    def __init__(
+        self,
+        ai_client: AIClient,
+        filtering: FilteringConfig | None = None,
+    ):
         self.client = ai_client
+        self.filtering = filtering
+
+    @property
+    def criteria(self) -> list[ScoreCriterionConfig] | None:
+        """Return configured criteria, or None for the legacy scoring contract."""
+
+        if self.filtering is None:
+            return None
+        return self.filtering.score_criteria
 
     @staticmethod
     def _parse_json_response(response: str) -> Optional[dict]:
@@ -51,6 +123,25 @@ class ContentAnalyzer:
         concurrency = getattr(config, "analysis_concurrency", 1)
         return max(concurrency, 1)
 
+    @staticmethod
+    def _validation_error_message(error: ValidationError) -> str:
+        details = []
+        for item in error.errors(include_url=False):
+            location = ".".join(str(part) for part in item["loc"]) or "response"
+            details.append(f"{location}: {item['msg']}")
+        return "; ".join(details)
+
+    @staticmethod
+    def _mark_analysis_error(item: ContentItem, message: str) -> None:
+        """Leave an item explicitly unscored and retain a safe diagnostic."""
+
+        item.ai_score = None
+        item.ai_scores = {}
+        item.ai_reason = None
+        item.ai_summary = item.title
+        item.ai_tags = []
+        item.ai_analysis_error = message
+
     async def analyze_batch(self, items: List[ContentItem]) -> List[ContentItem]:
         throttle_sec = self._get_throttle_sec()
         concurrency = self._get_concurrency()
@@ -61,10 +152,10 @@ class ContentAnalyzer:
                 try:
                     await self._analyze_item(item)
                 except Exception as e:
-                    print(f"Error analyzing item {item.id}: {e}")
-                    item.ai_score = 0.0
-                    item.ai_reason = "Analysis failed"
-                    item.ai_summary = item.title
+                    error_type = type(e).__name__
+                    message = f"AI analysis failed after retries ({error_type})"
+                    print(f"Error analyzing item {item.id}: {message}")
+                    self._mark_analysis_error(item, message)
                 if throttle_sec > 0 and index < len(items) - 1:
                     await asyncio.sleep(throttle_sec)
             progress.advance(progress_task)
@@ -139,38 +230,77 @@ class ContentAnalyzer:
 
         discussion_section = "\n".join(discussion_parts) if discussion_parts else ""
 
-        # Generate user prompt
-        user_prompt = CONTENT_ANALYSIS_USER.format(
+        # Generate prompts from either the legacy contract or configured criteria.
+        criteria = self.criteria
+        system_prompt = build_content_analysis_system(criteria)
+        user_prompt = build_content_analysis_user(
+            criteria=criteria,
             title=item.title,
             source=f"{item.source_type.value}",
             author=item.author or "Unknown",
             url=str(item.url),
             content_section=content_section,
-            discussion_section=discussion_section
+            discussion_section=discussion_section,
         )
 
         # Get AI completion
         response = await self.client.complete(
-            system=CONTENT_ANALYSIS_SYSTEM,
+            system=system_prompt,
             user=user_prompt,
         )
 
-        # Parse JSON response with robust fallback
+        # Parse JSON response without converting malformed output into a low score.
         parsed = self._parse_json_response(response)
-        try:
-            result = AnalysisResult.model_validate(parsed) if parsed is not None else None
-        except ValidationError:
-            result = None
-        if result is None:
-            print(f"Warning: could not parse analysis response for {item.id}, using defaults")
-            item.ai_score = 0.0
-            item.ai_reason = "Analysis response parse failed"
-            item.ai_summary = item.title
-            item.ai_tags = []
+        if parsed is None:
+            message = "Analysis response was not a valid JSON object"
+            print(f"Warning: {message} for {item.id}; item left unscored")
+            self._mark_analysis_error(item, message)
             return
 
+        try:
+            if criteria is None:
+                result = AnalysisResult.model_validate(parsed)
+            else:
+                result = CustomAnalysisResult.model_validate(parsed)
+        except ValidationError as error:
+            message = (
+                "Analysis response validation failed: "
+                + self._validation_error_message(error)
+            )
+            print(f"Warning: {message} for {item.id}; item left unscored")
+            self._mark_analysis_error(item, message)
+            return
+
+        if criteria is not None:
+            expected_names = [criterion.name for criterion in criteria]
+            expected = set(expected_names)
+            actual = set(result.scores)
+            missing = [name for name in expected_names if name not in actual]
+            unexpected = sorted(actual - expected)
+            if missing or unexpected:
+                details = []
+                if missing:
+                    details.append(f"missing criteria: {', '.join(missing)}")
+                if unexpected:
+                    details.append(f"unexpected criteria: {', '.join(unexpected)}")
+                message = "Analysis response score keys invalid (" + "; ".join(details) + ")"
+                print(f"Warning: {message} for {item.id}; item left unscored")
+                self._mark_analysis_error(item, message)
+                return
+
+            ordered_scores = {
+                name: result.scores[name]
+                for name in expected_names
+            }
+            filter_mode = self.filtering.filter_mode if self.filtering else "any"
+            item.ai_scores = ordered_scores
+            item.ai_score = aggregate_custom_score(ordered_scores, filter_mode)
+        else:
+            item.ai_scores = {}
+            item.ai_score = result.score
+
         # Update item with analysis results
-        item.ai_score = result.score
         item.ai_reason = result.reason
         item.ai_summary = result.summary
         item.ai_tags = result.tags
+        item.ai_analysis_error = None

--- a/src/ai/prompts.py
+++ b/src/ai/prompts.py
@@ -1,5 +1,11 @@
 """AI prompts for content analysis and summarization."""
 
+import json
+from typing import TYPE_CHECKING, Sequence
+
+if TYPE_CHECKING:
+    from ..models import ScoreCriterionConfig
+
 TOPIC_DEDUP_SYSTEM = """You are a news deduplication assistant. Identify groups of news items that cover the exact same real-world event, release, or announcement.
 
 Rules:
@@ -80,6 +86,98 @@ Respond with valid JSON only:
   "summary": "<one-sentence-summary>",
   "tags": ["<tag1>", "<tag2>", ...]
 }}"""
+
+
+def build_content_analysis_system(
+    criteria: Sequence["ScoreCriterionConfig"] | None,
+) -> str:
+    """Build the legacy or user-defined scoring system prompt."""
+
+    if criteria is None:
+        return CONTENT_ANALYSIS_SYSTEM
+
+    criteria_payload = json.dumps(
+        [
+            {
+                "name": criterion.name,
+                "description": criterion.description,
+                "filter_threshold": criterion.threshold,
+            }
+            for criterion in criteria
+        ],
+        ensure_ascii=False,
+        indent=2,
+    )
+    return f"""You are an expert content curator. Score each configured criterion independently on a 0-10 scale.
+
+Use the criterion descriptions as the complete definition of relevance. The filter
+thresholds are shown for transparency only; do not inflate or deflate a score to
+force an item through the filter.
+
+Configured criteria:
+{criteria_payload}
+
+General score calibration:
+- 9-10: exceptional match with strong evidence, depth, or impact
+- 7-8: high-value match worth immediate attention
+- 5-6: meaningful but moderate match
+- 3-4: weak or incidental match
+- 0-2: no meaningful match, noise, or off-topic
+
+Consider writing quality, evidence, substantive community discussion, and
+engagement signals where they are relevant. Return one score for every configured
+criterion, using each configured name exactly. Never add, remove, or rename score
+keys."""
+
+
+def build_content_analysis_user(
+    *,
+    criteria: Sequence["ScoreCriterionConfig"] | None,
+    title: str,
+    source: str,
+    author: str,
+    url: str,
+    content_section: str,
+    discussion_section: str,
+) -> str:
+    """Build the legacy or user-defined analysis request."""
+
+    fields = {
+        "title": title,
+        "source": source,
+        "author": author,
+        "url": url,
+        "content_section": content_section,
+        "discussion_section": discussion_section,
+    }
+    if criteria is None:
+        return CONTENT_ANALYSIS_USER.format(**fields)
+
+    response_shape = {
+        "scores": {
+            criterion.name: "<number 0-10>"
+            for criterion in criteria
+        },
+        "reason": "<brief explanation covering the configured criteria>",
+        "summary": "<one-sentence-summary>",
+        "tags": ["<tag1>", "<tag2>", "..."],
+    }
+    return f"""Analyze the following content and provide a JSON response with:
+- scores: An object with exactly one numeric 0-10 score for every configured criterion
+- reason: Brief explanation for the scores (mention discussion quality if comments are provided)
+- summary: One-sentence summary of the content
+- tags: Relevant topic tags (3-5 tags)
+
+Content:
+Title: {title}
+Source: {source}
+Author: {author}
+URL: {url}
+{content_section}
+{discussion_section}
+
+Respond with valid JSON only:
+{json.dumps(response_shape, ensure_ascii=False, indent=2)}"""
 
 CONCEPT_EXTRACTION_SYSTEM = """You identify technical concepts in news that a reader might not know.
 Given a news item, return 1-3 search queries for concepts that need explanation.

--- a/src/mcp/service.py
+++ b/src/mcp/service.py
@@ -260,6 +260,9 @@ class HorizonPipelineService:
                 if ctx.config.webhook.url_env and not os.getenv(ctx.config.webhook.url_env):
                     missing_env.append(ctx.config.webhook.url_env)
 
+        score_criteria = getattr(ctx.config.filtering, "score_criteria", None)
+        filter_mode = getattr(ctx.config.filtering, "filter_mode", "any")
+
         return {
             "horizon_path": str(ctx.horizon_path),
             "config_path": str(ctx.config_path),
@@ -271,6 +274,15 @@ class HorizonPipelineService:
             },
             "filtering": {
                 "ai_score_threshold": ctx.config.filtering.ai_score_threshold,
+                "filter_mode": filter_mode,
+                "score_criteria": (
+                    [
+                        criterion.model_dump(mode="json")
+                        for criterion in score_criteria
+                    ]
+                    if score_criteria is not None
+                    else None
+                ),
                 "time_window_hours": ctx.config.filtering.time_window_hours,
                 "max_items": ctx.config.filtering.max_items,
                 "category_groups": {
@@ -361,12 +373,32 @@ class HorizonPipelineService:
             raise HorizonMcpError(code="HZ_EMPTY_INPUT", message="No items available for scoring.")
 
         ai_client = ctx.runtime.create_ai_client(ctx.config.ai)
-        analyzer = ctx.runtime.ContentAnalyzer(ai_client)
+        try:
+            analyzer = ctx.runtime.ContentAnalyzer(ai_client, ctx.config.filtering)
+        except TypeError:
+            if getattr(ctx.config.filtering, "score_criteria", None) is not None:
+                raise
+            analyzer = ctx.runtime.ContentAnalyzer(ai_client)
         scored_items = await analyzer.analyze_batch(items)
 
         self.run_store.save_items(run_id, "scored", items_to_dicts(scored_items))
-        score_threshold = ctx.config.filtering.ai_score_threshold
-        above_threshold = [x for x in scored_items if x.ai_score and x.ai_score >= score_threshold]
+        storage = make_storage(ctx.runtime, ctx.config_path)
+        orchestrator = make_orchestrator(ctx.runtime, ctx.config, storage)
+        score_filter_result = await orchestrator.filter_items(
+            scored_items,
+            topic_dedup=False,
+            apply_balance=False,
+            log=False,
+        )
+        above_threshold = score_filter_result.items
+        score_criteria = getattr(ctx.config.filtering, "score_criteria", None)
+        filter_mode = getattr(ctx.config.filtering, "filter_mode", "any")
+        unscored_count = getattr(score_filter_result, "unscored_count", 0)
+        score_threshold = (
+            ctx.config.filtering.ai_score_threshold
+            if score_criteria is None
+            else None
+        )
 
         meta = self.run_store.update_meta(
             run_id,
@@ -374,6 +406,8 @@ class HorizonPipelineService:
                 "scored_count": len(scored_items),
                 "scored_threshold": score_threshold,
                 "scored_above_threshold": len(above_threshold),
+                "scored_unscored": unscored_count,
+                "filter_mode": filter_mode,
             },
         )
 
@@ -381,6 +415,8 @@ class HorizonPipelineService:
             "run_id": run_id,
             "scored": len(scored_items),
             "above_threshold": len(above_threshold),
+            "unscored": unscored_count,
+            "filter_mode": filter_mode,
             "score_distribution": self._score_distribution(scored_items),
             "artifact": str((self.run_store.run_dir(run_id) / "scored_items.json").resolve()),
             "meta": meta,
@@ -402,16 +438,21 @@ class HorizonPipelineService:
             config_path=config_path,
         )
 
-        effective_threshold = (
-            threshold
-            if threshold is not None
-            else ctx.config.filtering.ai_score_threshold
+        score_criteria = getattr(ctx.config.filtering, "score_criteria", None)
+        filter_mode = getattr(ctx.config.filtering, "filter_mode", "any")
+        effective_threshold = threshold
+        if effective_threshold is None and score_criteria is None:
+            effective_threshold = ctx.config.filtering.ai_score_threshold
+        orchestrator_threshold = (
+            effective_threshold
+            if score_criteria is None
+            else threshold
         )
         storage = make_storage(ctx.runtime, ctx.config_path)
         orchestrator = make_orchestrator(ctx.runtime, ctx.config, storage)
         filtering_result = await orchestrator.filter_items(
             items,
-            threshold=effective_threshold,
+            threshold=orchestrator_threshold,
             topic_dedup=topic_dedup,
             log=False,
         )
@@ -426,6 +467,8 @@ class HorizonPipelineService:
             {
                 "filtered_count": len(important_items),
                 "filter_threshold": effective_threshold,
+                "filter_mode": filter_mode,
+                "filter_unscored": getattr(filtering_result, "unscored_count", 0),
                 "topic_dedup_enabled": topic_dedup,
                 "topic_dedup_removed": filtering_result.topic_dedup_removed,
                 "balanced_digest_enabled": balanced_enabled,
@@ -440,6 +483,8 @@ class HorizonPipelineService:
             "run_id": run_id,
             "kept": len(important_items),
             "threshold": effective_threshold,
+            "filter_mode": filter_mode,
+            "unscored": getattr(filtering_result, "unscored_count", 0),
             "removed_by_topic_dedup": filtering_result.topic_dedup_removed,
             "removed_by_balanced_digest": (
                 filtering_result.topic_dedup_count - len(important_items)

--- a/src/models.py
+++ b/src/models.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timezone
 from enum import Enum
+from math import isfinite
 import re
 from typing import Annotated, Literal, Optional, List, Dict, Any, NamedTuple, Union
 from pydantic import BaseModel, HttpUrl, Field, field_validator
@@ -59,9 +60,11 @@ class ContentItem(BaseModel):
 
     # AI analysis results
     ai_score: Optional[float] = None  # 0-10 importance score
+    ai_scores: Dict[str, float] = Field(default_factory=dict)
     ai_reason: Optional[str] = None
     ai_summary: Optional[str] = None
     ai_tags: List[str] = Field(default_factory=list)
+    ai_analysis_error: Optional[str] = None
 
 
 class AIProvider(str, Enum):
@@ -478,15 +481,89 @@ class CategoryGroupConfig(BaseModel):
     categories: List[str] = Field(min_length=1)
 
 
+class ScoreCriterionConfig(BaseModel):
+    """One stable, user-defined scoring dimension."""
+
+    name: str = Field(
+        min_length=1,
+        max_length=64,
+        pattern=r"^[A-Za-z][A-Za-z0-9_-]*$",
+    )
+    description: str = Field(min_length=1, max_length=2000)
+    threshold: float = Field(ge=0, le=10, allow_inf_nan=False)
+
+    @field_validator("threshold", mode="before")
+    @classmethod
+    def validate_threshold(cls, value: object) -> object:
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not isfinite(float(value))
+        ):
+            raise ValueError("score criterion threshold must be a finite number")
+        return value
+
+    @field_validator("description")
+    @classmethod
+    def validate_description(cls, value: str) -> str:
+        description = value.strip()
+        if not description:
+            raise ValueError("score criterion description must not be blank")
+        return description
+
+
 class FilteringConfig(BaseModel):
     """Content filtering configuration."""
 
-    ai_score_threshold: float = 7.0
+    ai_score_threshold: float = Field(
+        default=7.0,
+        ge=0,
+        le=10,
+        allow_inf_nan=False,
+    )
+    filter_mode: Literal["any", "all"] = "any"
+    score_criteria: Optional[List[ScoreCriterionConfig]] = None
     time_window_hours: int = 24
     max_items: Optional[int] = Field(default=None, gt=0)
     category_groups: Dict[str, CategoryGroupConfig] = Field(default_factory=dict)
     default_group: str = "other"
     default_group_limit: Optional[int] = Field(default=None, gt=0)
+
+    @field_validator("ai_score_threshold", mode="before")
+    @classmethod
+    def validate_legacy_threshold(cls, value: object) -> object:
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not isfinite(float(value))
+        ):
+            raise ValueError("filtering.ai_score_threshold must be a finite number")
+        return value
+
+    @field_validator("score_criteria")
+    @classmethod
+    def validate_score_criteria(
+        cls,
+        criteria: Optional[List[ScoreCriterionConfig]],
+    ) -> Optional[List[ScoreCriterionConfig]]:
+        if criteria is None:
+            return None
+        if not criteria:
+            raise ValueError(
+                "filtering.score_criteria must contain at least one criterion "
+                "when configured; omit the field to use legacy scoring"
+            )
+
+        seen: Dict[str, str] = {}
+        for criterion in criteria:
+            normalized = criterion.name.casefold()
+            if normalized in seen:
+                raise ValueError(
+                    "filtering.score_criteria contains duplicate names "
+                    f"'{seen[normalized]}' and '{criterion.name}'"
+                )
+            seen[normalized] = criterion.name
+        return criteria
 
 
 class Config(BaseModel):

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -29,6 +29,7 @@ from .ai.analyzer import ContentAnalyzer
 from .ai.summarizer import DailySummarizer
 from .ai.enricher import ContentEnricher
 from .ai.tokens import get_usage_snapshot
+from .scoring import evaluate_item_score
 
 
 _TRACKING_QUERY_PARAMETERS = {
@@ -92,6 +93,7 @@ class FilteringPipelineResult:
 
     items: List[ContentItem]
     threshold_count: int
+    unscored_count: int
     topic_dedup_count: int
     topic_dedup_removed: int
     balanced_digest: BalancedDigestResult
@@ -238,8 +240,17 @@ class HorizonOrchestrator:
             # 5.5 Optional second-stage Twitter reply expansion + targeted re-analysis
             await self._expand_twitter_discussion(important_items)
 
-            # 5.6 Apply digest limits after any targeted re-analysis changes scores.
-            important_items = self.apply_balanced_digest(important_items).items
+            # 5.6 Re-apply score semantics and digest limits after targeted
+            # re-analysis changes either scalar or per-criterion scores.
+            post_expansion_result = await self.filter_items(
+                important_items,
+                topic_dedup=False,
+                apply_balance=False,
+                log=False,
+            )
+            important_items = self.apply_balanced_digest(
+                post_expansion_result.items
+            ).items
 
             # Show per-sub-source selection breakdown
             selected_counts: Dict[str, int] = defaultdict(int)
@@ -642,22 +653,57 @@ class HorizonOrchestrator:
         log: bool = True,
     ) -> FilteringPipelineResult:
         """Apply score thresholding, optional topic dedup, and digest balancing."""
-        effective_threshold = (
-            threshold
-            if threshold is not None
-            else self.config.filtering.ai_score_threshold
+        filtering = self.config.filtering
+        threshold_items: List[ContentItem] = []
+        unscored_count = 0
+        for item in items:
+            evaluation = evaluate_item_score(
+                item,
+                filtering,
+                threshold_override=threshold,
+            )
+            if evaluation.error is not None:
+                unscored_count += 1
+                if item.ai_analysis_error is None:
+                    item.ai_analysis_error = evaluation.error
+                continue
+            item.ai_analysis_error = None
+            item.ai_score = evaluation.aggregate_score
+            if evaluation.passed:
+                threshold_items.append(item)
+
+        threshold_items.sort(
+            key=lambda item: (
+                item.ai_score if item.ai_score is not None else -1.0
+            ),
+            reverse=True,
         )
-        threshold_items = [
-            item
-            for item in items
-            if item.ai_score is not None and item.ai_score >= effective_threshold
-        ]
-        threshold_items.sort(key=lambda item: item.ai_score or 0, reverse=True)
 
         if log:
-            self.console.print(
-                f"⭐️ {len(threshold_items)} items scored ≥ {effective_threshold}\n"
-            )
+            if filtering.score_criteria is None:
+                effective_threshold = (
+                    threshold
+                    if threshold is not None
+                    else filtering.ai_score_threshold
+                )
+                self.console.print(
+                    f"⭐️ {len(threshold_items)} items scored ≥ {effective_threshold}\n"
+                )
+            else:
+                override_label = (
+                    f" with uniform threshold override {threshold}"
+                    if threshold is not None
+                    else ""
+                )
+                self.console.print(
+                    f"⭐️ {len(threshold_items)} items matched "
+                    f"'{filtering.filter_mode}' scoring criteria{override_label}\n"
+                )
+            if unscored_count:
+                self.console.print(
+                    f"[yellow]⚠️  Excluded {unscored_count} unscored or invalid "
+                    "items; see ai_analysis_error for diagnostics.[/yellow]\n"
+                )
 
         deduped_items = threshold_items
         if topic_dedup and deduped_items:
@@ -678,6 +724,7 @@ class HorizonOrchestrator:
         return FilteringPipelineResult(
             items=balanced_digest.items,
             threshold_count=len(threshold_items),
+            unscored_count=unscored_count,
             topic_dedup_count=len(deduped_items),
             topic_dedup_removed=topic_dedup_removed,
             balanced_digest=balanced_digest,
@@ -845,7 +892,7 @@ class HorizonOrchestrator:
             f"   Re-analyzing {len(expanded)} Twitter items with reply context...\n"
         )
         ai_client = create_ai_client(self.config.ai)
-        analyzer = ContentAnalyzer(ai_client)
+        analyzer = ContentAnalyzer(ai_client, self.config.filtering)
         await analyzer.analyze_batch(expanded)
 
     async def _enrich_important_items(self, items: List[ContentItem]) -> None:
@@ -878,7 +925,7 @@ class HorizonOrchestrator:
         self.console.print("🤖 Analyzing content with AI...")
 
         ai_client = create_ai_client(self.config.ai)
-        analyzer = ContentAnalyzer(ai_client)
+        analyzer = ContentAnalyzer(ai_client, self.config.filtering)
 
         return await analyzer.analyze_batch(items)
 

--- a/src/scoring.py
+++ b/src/scoring.py
@@ -1,0 +1,135 @@
+"""Shared scoring and filtering semantics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isfinite
+from typing import Optional
+
+from .models import ContentItem, FilteringConfig
+
+
+@dataclass(frozen=True)
+class ScoreEvaluation:
+    """Diagnostic result of applying one filtering policy to one item."""
+
+    passed: Optional[bool]
+    aggregate_score: Optional[float]
+    matched_criteria: tuple[str, ...] = ()
+    failed_criteria: tuple[str, ...] = ()
+    error: Optional[str] = None
+
+
+def aggregate_custom_score(scores: dict[str, float], filter_mode: str) -> float:
+    """Return the scalar score retained for legacy sorting and presentation."""
+
+    if filter_mode == "any":
+        return max(scores.values())
+    if filter_mode == "all":
+        return min(scores.values())
+    raise ValueError(f"Unsupported filter mode: {filter_mode}")
+
+
+def evaluate_item_score(
+    item: ContentItem,
+    filtering: FilteringConfig,
+    *,
+    threshold_override: float | None = None,
+) -> ScoreEvaluation:
+    """Evaluate an item's scores without treating malformed data as a low score."""
+
+    if threshold_override is not None:
+        if (
+            isinstance(threshold_override, bool)
+            or not isinstance(threshold_override, (int, float))
+            or not isfinite(float(threshold_override))
+            or not 0 <= float(threshold_override) <= 10
+        ):
+            raise ValueError("Score threshold override must be a finite number from 0 to 10")
+        threshold_override = float(threshold_override)
+
+    criteria = filtering.score_criteria
+    if criteria is None:
+        score = item.ai_score
+        if score is None:
+            return ScoreEvaluation(
+                passed=None,
+                aggregate_score=None,
+                error=item.ai_analysis_error or "Missing legacy AI score",
+            )
+        if (
+            isinstance(score, bool)
+            or not isinstance(score, (int, float))
+            or not isfinite(float(score))
+            or not 0 <= float(score) <= 10
+        ):
+            return ScoreEvaluation(
+                passed=None,
+                aggregate_score=None,
+                error=f"Invalid legacy AI score for item {item.id}",
+            )
+
+        numeric_score = float(score)
+        threshold = (
+            filtering.ai_score_threshold
+            if threshold_override is None
+            else threshold_override
+        )
+        return ScoreEvaluation(
+            passed=numeric_score >= threshold,
+            aggregate_score=numeric_score,
+        )
+
+    expected_names = [criterion.name for criterion in criteria]
+    expected = set(expected_names)
+    actual = set(item.ai_scores)
+    missing = [name for name in expected_names if name not in actual]
+    unexpected = sorted(actual - expected)
+    if missing or unexpected:
+        details = []
+        if missing:
+            details.append(f"missing criteria: {', '.join(missing)}")
+        if unexpected:
+            details.append(f"unexpected criteria: {', '.join(unexpected)}")
+        return ScoreEvaluation(
+            passed=None,
+            aggregate_score=None,
+            error="Invalid custom score set (" + "; ".join(details) + ")",
+        )
+
+    scores: dict[str, float] = {}
+    for name in expected_names:
+        value = item.ai_scores[name]
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not isfinite(float(value))
+            or not 0 <= float(value) <= 10
+        ):
+            return ScoreEvaluation(
+                passed=None,
+                aggregate_score=None,
+                error=f"Invalid score for criterion '{name}'",
+            )
+        scores[name] = float(value)
+
+    matched = []
+    failed = []
+    for criterion in criteria:
+        threshold = (
+            criterion.threshold
+            if threshold_override is None
+            else threshold_override
+        )
+        if scores[criterion.name] >= threshold:
+            matched.append(criterion.name)
+        else:
+            failed.append(criterion.name)
+
+    passed = bool(matched) if filtering.filter_mode == "any" else not failed
+    return ScoreEvaluation(
+        passed=passed,
+        aggregate_score=aggregate_custom_score(scores, filtering.filter_mode),
+        matched_criteria=tuple(matched),
+        failed_criteria=tuple(failed),
+    )

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -98,6 +98,24 @@ def test_analyze_batch_concurrent_preserves_order(monkeypatch):
     assert [item.id for item in result] == [item.id for item in items]
 
 
+def test_analyze_batch_provider_failure_stays_unscored(monkeypatch):
+    analyzer = ContentAnalyzer(SimpleNamespace())
+    item = _make_item("rss:test:provider-failure")
+
+    async def fail_analysis(input_item):
+        raise RuntimeError("provider unavailable")
+
+    monkeypatch.setattr(analyzer, "_analyze_item", fail_analysis)
+
+    result = asyncio.run(analyzer.analyze_batch([item]))
+
+    assert result == [item]
+    assert item.ai_score is None
+    assert item.ai_scores == {}
+    assert item.ai_reason is None
+    assert item.ai_analysis_error == "AI analysis failed after retries (RuntimeError)"
+
+
 def test_analyze_item_accepts_valid_result():
     result = {
         "score": 8.5,
@@ -131,7 +149,7 @@ def test_analyze_item_accepts_valid_result():
         {"score": 5, "reason": "ok", "tags": []},
     ],
 )
-def test_analyze_item_malformed_json_result_uses_fallback(result):
+def test_analyze_item_malformed_json_result_stays_unscored(result):
     async def complete(**kwargs):
         return json.dumps(result)
 
@@ -139,7 +157,9 @@ def test_analyze_item_malformed_json_result_uses_fallback(result):
 
     asyncio.run(ContentAnalyzer(SimpleNamespace(complete=complete))._analyze_item(item))
 
-    assert item.ai_score == 0.0
-    assert item.ai_reason == "Analysis response parse failed"
+    assert item.ai_score is None
+    assert item.ai_scores == {}
+    assert item.ai_reason is None
     assert item.ai_summary == item.title
     assert item.ai_tags == []
+    assert item.ai_analysis_error

--- a/tests/test_configurable_scoring.py
+++ b/tests/test_configurable_scoring.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from src.ai.analyzer import ContentAnalyzer
+from src.ai.prompts import CONTENT_ANALYSIS_SYSTEM
+from src.models import (
+    ContentItem,
+    FilteringConfig,
+    ScoreCriterionConfig,
+    SourceType,
+)
+from src.orchestrator import HorizonOrchestrator
+from src.scoring import aggregate_custom_score
+from src.storage.manager import StorageManager
+
+
+def _item(item_id: str = "rss:test:1") -> ContentItem:
+    return ContentItem(
+        id=item_id,
+        source_type=SourceType.RSS,
+        title=f"Item {item_id}",
+        url="https://example.com/item",
+        published_at=datetime(2026, 7, 25, tzinfo=timezone.utc),
+    )
+
+
+def _criterion(
+    name: str,
+    threshold: float,
+    description: str | None = None,
+) -> ScoreCriterionConfig:
+    return ScoreCriterionConfig(
+        name=name,
+        threshold=threshold,
+        description=description or f"Relevance to {name}",
+    )
+
+
+class RecordingClient:
+    def __init__(self, response: object):
+        self.response = response
+        self.calls: list[dict[str, str]] = []
+        self.config = SimpleNamespace()
+
+    async def complete(self, **kwargs: str) -> str:
+        self.calls.append(kwargs)
+        return json.dumps(self.response)
+
+
+def _filter(
+    filtering: FilteringConfig,
+    items: list[ContentItem],
+):
+    orchestrator = HorizonOrchestrator.__new__(HorizonOrchestrator)
+    orchestrator.config = SimpleNamespace(filtering=filtering)
+    orchestrator.console = SimpleNamespace(print=lambda *args, **kwargs: None)
+    return asyncio.run(
+        orchestrator.filter_items(
+            items,
+            topic_dedup=False,
+            apply_balance=False,
+            log=False,
+        )
+    )
+
+
+def test_legacy_config_keeps_existing_prompt_parser_and_threshold_behavior() -> None:
+    filtering = FilteringConfig(ai_score_threshold=7.0)
+    client = RecordingClient(
+        {
+            "score": 7,
+            "reason": "Legacy relevant",
+            "summary": "Legacy summary",
+            "tags": ["legacy"],
+        }
+    )
+    item = _item()
+
+    asyncio.run(ContentAnalyzer(client, filtering)._analyze_item(item))
+    result = _filter(filtering, [item])
+
+    assert filtering.score_criteria is None
+    assert client.calls[0]["system"] == CONTENT_ANALYSIS_SYSTEM
+    assert '"score": <number>' in client.calls[0]["user"]
+    assert item.ai_score == 7.0
+    assert item.ai_scores == {}
+    assert result.items == [item]
+    assert result.unscored_count == 0
+
+
+def test_single_custom_criterion_drives_prompt_parse_and_equal_threshold() -> None:
+    filtering = FilteringConfig(
+        score_criteria=[
+            _criterion(
+                "finance",
+                6.0,
+                "Relevance to markets and investment decisions",
+            )
+        ]
+    )
+    client = RecordingClient(
+        {
+            "scores": {"finance": 6},
+            "reason": "Directly relevant",
+            "summary": "Market update",
+            "tags": ["finance"],
+        }
+    )
+    item = _item()
+
+    asyncio.run(ContentAnalyzer(client, filtering)._analyze_item(item))
+    result = _filter(filtering, [item])
+
+    system_prompt = client.calls[0]["system"]
+    user_prompt = client.calls[0]["user"]
+    assert '"name": "finance"' in system_prompt
+    assert '"filter_threshold": 6.0' in system_prompt
+    assert "markets and investment decisions" in system_prompt
+    assert '"finance": "<number 0-10>"' in user_prompt
+    assert item.ai_scores == {"finance": 6.0}
+    assert item.ai_score == 6.0
+    assert result.items == [item]
+
+
+def test_multiple_criteria_any_keeps_item_when_one_dimension_matches() -> None:
+    filtering = FilteringConfig(
+        filter_mode="any",
+        score_criteria=[
+            _criterion("tech", 7.0),
+            _criterion("finance", 6.0),
+        ],
+    )
+    item = _item()
+    item.ai_scores = {"tech": 5.0, "finance": 6.0}
+
+    result = _filter(filtering, [item])
+
+    assert result.items == [item]
+    assert item.ai_score == 6.0
+
+
+def test_multiple_criteria_all_requires_every_dimension() -> None:
+    filtering = FilteringConfig(
+        filter_mode="all",
+        score_criteria=[
+            _criterion("tech", 7.0),
+            _criterion("finance", 6.0),
+        ],
+    )
+    passing = _item("rss:test:passing")
+    passing.ai_scores = {"tech": 7.0, "finance": 6.0}
+    failing = _item("rss:test:failing")
+    failing.ai_scores = {"tech": 8.0, "finance": 5.9}
+
+    result = _filter(filtering, [passing, failing])
+
+    assert result.items == [passing]
+    assert passing.ai_score == 6.0
+    assert failing.ai_score == 5.9
+
+
+def test_filter_keeps_persisted_score_errors_diagnostic() -> None:
+    legacy = _item("rss:test:legacy-missing")
+    legacy_result = _filter(FilteringConfig(), [legacy])
+
+    assert legacy_result.unscored_count == 1
+    assert legacy.ai_analysis_error == "Missing legacy AI score"
+
+    invalid_legacy = _item("rss:test:legacy-invalid")
+    invalid_legacy.ai_score = float("nan")
+    invalid_legacy_result = _filter(FilteringConfig(), [invalid_legacy])
+
+    assert invalid_legacy_result.unscored_count == 1
+    assert "Invalid legacy AI score" in (invalid_legacy.ai_analysis_error or "")
+
+    custom_filtering = FilteringConfig(
+        score_criteria=[_criterion("tech", 7.0)]
+    )
+    unexpected = _item("rss:test:unexpected")
+    unexpected.ai_scores = {"tech": 8.0, "other": 9.0}
+    malformed = _item("rss:test:malformed")
+    malformed.ai_scores = {"tech": "8"}  # type: ignore[dict-item]
+
+    custom_result = _filter(custom_filtering, [unexpected, malformed])
+
+    assert custom_result.items == []
+    assert custom_result.unscored_count == 2
+    assert "unexpected criteria: other" in (unexpected.ai_analysis_error or "")
+    assert "Invalid score for criterion 'tech'" in (malformed.ai_analysis_error or "")
+
+
+def test_uniform_threshold_override_is_validated_and_applied() -> None:
+    filtering = FilteringConfig(
+        score_criteria=[_criterion("tech", 9.0)]
+    )
+    item = _item()
+    item.ai_scores = {"tech": 7.0}
+    orchestrator = HorizonOrchestrator.__new__(HorizonOrchestrator)
+    orchestrator.config = SimpleNamespace(filtering=filtering)
+    orchestrator.console = SimpleNamespace(print=lambda *args, **kwargs: None)
+
+    result = asyncio.run(
+        orchestrator.filter_items(
+            [item],
+            threshold=7.0,
+            topic_dedup=False,
+            apply_balance=False,
+            log=False,
+        )
+    )
+    assert result.items == [item]
+
+    with pytest.raises(ValueError, match="finite number from 0 to 10"):
+        asyncio.run(
+            orchestrator.filter_items(
+                [item],
+                threshold=11.0,
+                topic_dedup=False,
+                apply_balance=False,
+                log=False,
+            )
+        )
+
+
+def test_aggregate_rejects_unknown_mode_defensively() -> None:
+    with pytest.raises(ValueError, match="Unsupported filter mode"):
+        aggregate_custom_score({"tech": 7.0}, "unknown")
+
+
+@pytest.mark.parametrize(
+    ("scores", "error_fragment"),
+    [
+        ({"tech": 8.0}, "missing criteria: finance"),
+        ({"tech": 8.0, "finance": 7.0, "other": 9.0}, "unexpected criteria: other"),
+        ({"tech": "8", "finance": 7.0}, "finite number"),
+        ({"tech": 8.0, "finance": 11}, "finite number"),
+    ],
+)
+def test_custom_model_missing_or_malformed_scores_are_diagnostic(
+    scores: dict[str, object],
+    error_fragment: str,
+) -> None:
+    filtering = FilteringConfig(
+        score_criteria=[
+            _criterion("tech", 7.0),
+            _criterion("finance", 6.0),
+        ]
+    )
+    client = RecordingClient(
+        {
+            "scores": scores,
+            "reason": "Model output",
+            "summary": "Summary",
+            "tags": ["test"],
+        }
+    )
+    item = _item()
+
+    asyncio.run(ContentAnalyzer(client, filtering)._analyze_item(item))
+    result = _filter(filtering, [item])
+
+    assert item.ai_score is None
+    assert item.ai_scores == {}
+    assert item.ai_analysis_error
+    assert error_fragment in item.ai_analysis_error
+    assert result.items == []
+    assert result.unscored_count == 1
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"score_criteria": []},
+        {
+            "score_criteria": [
+                {
+                    "name": "Tech",
+                    "description": "First",
+                    "threshold": 7,
+                },
+                {
+                    "name": "tech",
+                    "description": "Duplicate by case",
+                    "threshold": 6,
+                },
+            ]
+        },
+        {
+            "score_criteria": [
+                {
+                    "name": "finance",
+                    "description": "Finance",
+                    "threshold": -0.1,
+                }
+            ]
+        },
+        {
+            "score_criteria": [
+                {
+                    "name": "finance",
+                    "description": "Finance",
+                    "threshold": 10.1,
+                }
+            ]
+        },
+        {
+            "score_criteria": [
+                {
+                    "name": "finance",
+                    "description": "Finance",
+                    "threshold": "6",
+                }
+            ]
+        },
+        {"ai_score_threshold": float("nan")},
+        {"filter_mode": "some"},
+    ],
+)
+def test_invalid_custom_scoring_config_is_rejected(kwargs: dict[str, object]) -> None:
+    with pytest.raises(ValidationError):
+        FilteringConfig(**kwargs)
+
+
+def test_config_load_prompt_parse_and_final_filter_are_semantically_consistent(
+    tmp_path,
+) -> None:
+    config_payload = {
+        "version": "1.0",
+        "ai": {
+            "provider": "openai",
+            "model": "test-model",
+            "api_key_env": "TEST_API_KEY",
+        },
+        "sources": {},
+        "filtering": {
+            "ai_score_threshold": 9.5,
+            "filter_mode": "any",
+            "score_criteria": [
+                {
+                    "name": "tech",
+                    "description": "Technical depth",
+                    "threshold": 8.0,
+                },
+                {
+                    "name": "finance",
+                    "description": "Financial relevance",
+                    "threshold": 6.0,
+                },
+            ],
+        },
+    }
+    (tmp_path / "config.json").write_text(
+        json.dumps(config_payload),
+        encoding="utf-8",
+    )
+    config = StorageManager(data_dir=str(tmp_path)).load_config()
+    client = RecordingClient(
+        {
+            "scores": {"tech": 4.0, "finance": 6.0},
+            "reason": "Matches finance only",
+            "summary": "Finance story",
+            "tags": ["finance"],
+        }
+    )
+    item = _item()
+
+    asyncio.run(ContentAnalyzer(client, config.filtering)._analyze_item(item))
+    result = _filter(config.filtering, [item])
+
+    assert '"tech": "<number 0-10>"' in client.calls[0]["user"]
+    assert '"finance": "<number 0-10>"' in client.calls[0]["user"]
+    assert item.ai_scores == {"tech": 4.0, "finance": 6.0}
+    assert result.items == [item]
+    assert config.filtering.ai_score_threshold == 9.5

--- a/tests/test_mcp_service_smoke.py
+++ b/tests/test_mcp_service_smoke.py
@@ -51,6 +51,8 @@ def test_validate_config_smoke(tmp_path: Path) -> None:
     assert result["config_path"] == str(config_path.resolve())
     assert result["enabled_sources"]
     assert result["missing_env"] == []
+    assert result["filtering"]["filter_mode"] == "any"
+    assert result["filtering"]["score_criteria"] is None
 
 
 def test_get_effective_config_can_filter_sources(tmp_path: Path) -> None:
@@ -206,6 +208,83 @@ def test_fetch_items_includes_fetch_report_in_response_and_metadata(
     assert result["fetch_report"]["sources"][1]["source"] == "GitHub"
     assert result["meta"]["fetch_status"] == "partial_failure"
     assert service.run_store.load_meta(result["run_id"])["fetch_report"] == result["fetch_report"]
+
+
+def test_score_items_uses_custom_scoring_semantics(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    service = HorizonPipelineService(runs_root=tmp_path / "mcp-runs")
+    service.run_store.create_run("run-custom-score")
+    filtering = FilteringConfig(
+        filter_mode="any",
+        score_criteria=[
+            {
+                "name": "tech",
+                "description": "Technical relevance",
+                "threshold": 8.0,
+            },
+            {
+                "name": "finance",
+                "description": "Financial relevance",
+                "threshold": 6.0,
+            },
+        ],
+    )
+    item = make_item("item-custom")
+
+    class FakeAnalyzer:
+        def __init__(self, ai_client, received_filtering):  # type: ignore[no-untyped-def]
+            assert received_filtering is filtering
+
+        async def analyze_batch(self, items):  # type: ignore[no-untyped-def]
+            items[0].ai_scores = {"tech": 4.0, "finance": 6.0}
+            items[0].ai_score = 6.0
+            return items
+
+    runtime = SimpleNamespace(
+        create_ai_client=lambda config: object(),
+        ContentAnalyzer=FakeAnalyzer,
+    )
+    config = SimpleNamespace(ai=object(), filtering=filtering)
+    ctx = SimpleNamespace(
+        runtime=runtime,
+        config_path=tmp_path / "config.json",
+        config=config,
+    )
+    monkeypatch.setattr(
+        service,
+        "_load_stage_items",
+        lambda **kwargs: ([item], ctx),
+    )
+    monkeypatch.setattr(
+        "src.mcp.service.make_storage",
+        lambda runtime, config_path: object(),
+    )
+
+    def make_filtering_orchestrator():  # type: ignore[no-untyped-def]
+        orchestrator = HorizonOrchestrator.__new__(HorizonOrchestrator)
+        orchestrator.config = config
+        orchestrator.console = SimpleNamespace(print=lambda *args, **kwargs: None)
+        return orchestrator
+
+    monkeypatch.setattr(
+        "src.mcp.service.make_orchestrator",
+        lambda runtime, loaded_config, storage: make_filtering_orchestrator(),
+    )
+
+    result = asyncio.run(
+        service.score_items(
+            run_id="run-custom-score",
+            source_stage="raw",
+        )
+    )
+
+    assert result["above_threshold"] == 1
+    assert result["unscored"] == 0
+    assert result["filter_mode"] == "any"
+    stored = service.run_store.load_items("run-custom-score", "scored")
+    assert stored[0]["ai_scores"] == {"tech": 4.0, "finance": 6.0}
 
 
 def test_filter_items_uses_public_filtering_pipeline_api(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- add user-defined scoring criteria with stable names, descriptions, and per-criterion thresholds
- support inclusive `any` and `all` filtering semantics through one shared evaluator
- generate the analysis prompt and expected score schema dynamically from configuration
- keep the legacy single-score prompt and `ai_score_threshold` behavior when no criteria are configured
- preserve malformed or incomplete model output as an explicit unscored diagnostic instead of coercing it to a low score
- document the configuration and add focused end-to-end coverage

## Configuration and compatibility

- `filtering.score_criteria` omitted or `null`: use the existing single-score behavior
- explicitly empty criteria, duplicate names, non-numeric/non-finite/out-of-range thresholds, and unknown modes: reject during configuration validation
- model responses with missing, unexpected, malformed, or out-of-range score fields: exclude as unscored and retain `ai_analysis_error`
- threshold comparisons are inclusive (`score >= threshold`)
- custom scores retain a compatibility scalar for sorting: maximum for `any`, minimum for `all`

## Validation

- focused scoring, analyzer, and MCP suite: 43 passed
- extended related suite: 80 passed
- full suite with a test-process-only public DNS mapping for three documentation domains: 408 passed
- `python -m compileall -q src tests`
- example and GitHub configuration model validation
- `pip check`
- editable package build/install
- `git diff --check`

The raw full-suite run on this Windows host initially had 21 SSRF-guard failures because the local Fake-IP DNS resolver maps documentation domains to `198.18.0.0/15`. The production SSRF protections were not weakened.

## Not covered

- real AI provider calls
- scheduled GitHub Actions runs
- email, Feishu/webhook, and GitHub Pages delivery
- Docker/Linux and Python 3.11/3.12 runtime verification

Closes #103
