### PR TITLE
feat(ai): add reliable local Codex daily runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ But Horizon is not just another summarizer. AI is great at reducing noise, but n
 ## Features
 
 - **📡 Watch Your Own Sources** — Track Hacker News, RSS, Reddit, Telegram, Twitter/X, GitHub releases or user activity, and OpenBB financial news watchlists in one pipeline
-- **🤖 Turn Noise Into a Reading List** — Score each item from 0-10 with Claude, GPT, Gemini, DeepSeek, Doubao, MiniMax, Ollama, or any OpenAI-compatible API
+- **🤖 Turn Noise Into a Reading List** — Score each item from 0-10 with Codex CLI, Claude, GPT, Gemini, DeepSeek, Doubao, MiniMax, Ollama, or any OpenAI-compatible API
 - **🔗 Merge Repeated Stories** — Deduplicate the same story across platforms before it reaches your briefing
 - **🔍 Understand the Background** — Add web-researched context for unfamiliar concepts, companies, projects, and technical terms
 - **💬 Read the Conversation** — Collect and summarize community comments from Hacker News, Reddit, and other supported sources

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,7 @@ Common API key variable names:
 
 | Provider | `api_key_env` value |
 | --- | --- |
+| Codex CLI | `""` (no API key) |
 | Anthropic | `ANTHROPIC_API_KEY` |
 | OpenAI | `OPENAI_API_KEY` |
 | Azure OpenAI | `AZURE_OPENAI_API_KEY` |
@@ -36,6 +37,38 @@ Common API key variable names:
 | Aliyun DashScope | `DASHSCOPE_API_KEY` |
 | Doubao | `DOUBAO_API_KEY` |
 | DeepSeek | `DEEPSEEK_API_KEY` |
+
+**Codex CLI**:
+
+The Codex provider uses an existing local Codex login instead of an API key.
+It is intended for personal automation on a computer where the Codex CLI is
+installed and authenticated:
+
+```bash
+codex login status
+```
+
+```json
+{
+  "ai": {
+    "provider": "codex",
+    "model": "default",
+    "api_key_env": "",
+    "throttle_sec": 0
+  }
+}
+```
+
+Set `model` to `default` to use the model selected by Codex, or provide an
+explicit Codex model name. Each request runs through an ephemeral `codex exec`
+process in an empty temporary directory with user configuration ignored and
+the sandbox set to read-only. Horizon does not create or read an API key for
+this provider.
+
+The following optional environment variables control the local process:
+
+- `HORIZON_CODEX_BIN`: Override the `codex` executable.
+- `HORIZON_CODEX_TIMEOUT_SEC`: Completion timeout in seconds. Default is `300`.
 
 **Anthropic Claude**:
 
@@ -220,6 +253,89 @@ By default, AI scoring and enrichment run one item at a time. If your API endpoi
 ```
 
 For OpenAI-compatible gateways, Horizon sends `temperature` by default. If a newer reasoning-style model rejects that parameter with an error such as `temperature is deprecated for this model`, Horizon retries once without it and remembers that capability for later requests.
+
+### Reliable local Codex daily runs
+
+`horizon-codex-daily` is a guarded local runner for computers that are not
+always on. It remains specific to `ai.provider: "codex"` so it can verify the
+local login before starting Horizon.
+
+Run it directly:
+
+```bash
+uv run horizon-codex-daily \
+  --config data/config.json \
+  --timezone Asia/Shanghai \
+  --daily-at 08:00
+```
+
+The runner can be invoked repeatedly by a scheduler:
+
+- Before `--daily-at`, it prints `SKIP`.
+- After that time, the first invocation runs Horizon.
+- Later invocations on the same local calendar day print `SKIP` after a
+  successful run.
+- If the computer was off, the next invocation after the configured time
+  expands the fetch window to cover time since the last successful run, plus a
+  two-hour overlap. Catch-up is capped at seven days.
+- A failed invocation records the error but does not record a success, so the
+  next scheduled invocation retries.
+
+Options:
+
+| Option | Behavior |
+| --- | --- |
+| `--config PATH` | Horizon configuration; default `data/config.json` |
+| `--timezone ZONE` | IANA timezone; default is the computer's local timezone |
+| `--daily-at HH:MM` | Earliest local start time; default `00:00` |
+| `--force` | Ignore the time gate and today's successful state |
+| `--status` | Print saved state without running Horizon |
+
+State is stored next to the selected configuration:
+
+- `codex-daily-state.json`
+- `codex-daily.lock`
+- `run-reports/`
+
+The command uses stable status prefixes: `DONE` and `SKIP` exit with status
+zero; `FAILED` exits with status one and includes the failure report path.
+
+For cron, invoke the runner every hour and use absolute paths:
+
+```cron
+0 * * * * cd /absolute/path/to/Horizon && /absolute/path/to/uv run horizon-codex-daily --timezone Asia/Shanghai --daily-at 08:00 >> /absolute/path/to/Horizon/data/codex-daily.log 2>&1
+```
+
+On macOS, save a LaunchAgent such as
+`~/Library/LaunchAgents/top.horizon.codex-daily.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>top.horizon.codex-daily</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/env</string>
+    <string>bash</string>
+    <string>-lc</string>
+    <string>cd /absolute/path/to/Horizon &amp;&amp; /absolute/path/to/uv run horizon-codex-daily --daily-at 08:00</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>3600</integer>
+</dict>
+</plist>
+```
+
+Systemd timers, Windows Task Scheduler, and local automation tools can call the
+same command on an hourly interval. This command is not a background daemon:
+it cannot run while the computer is off, but it safely catches up when a later
+scheduled invocation occurs.
 
 ## Information Sources
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ trafilatura = [
 
 [project.scripts]
 horizon = "src.main:main"
+horizon-codex-daily = "src.codex_daily:main"
 horizon-mcp = "src.mcp.server:main"
 horizon-wizard = "src.setup.wizard:main"
 horizon-webhook = "src.services.webhook_cli:main"

--- a/src/ai/client.py
+++ b/src/ai/client.py
@@ -1,7 +1,11 @@
 """AI client abstraction supporting multiple providers."""
 
+import asyncio
+import math
 import os
 import re
+import shutil
+import tempfile
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 from openai import AsyncAzureOpenAI, AsyncOpenAI
@@ -109,6 +113,109 @@ class AIClient(ABC):
             str: Generated completion text
         """
         pass
+
+
+class CodexCLIClient(AIClient):
+    """AI client backed by a locally authenticated Codex CLI session.
+
+    The client is intended for trusted local automation. It uses ``codex
+    exec`` rather than an API key and runs each completion in an empty,
+    temporary working directory with a read-only sandbox.
+    """
+
+    _DEFAULT_TIMEOUT_SEC = 300.0
+
+    def __init__(self, config: AIConfig):
+        self.config = config
+        self.model = config.model.strip()
+        binary = os.getenv("HORIZON_CODEX_BIN") or shutil.which("codex")
+        if not binary:
+            raise ValueError(
+                "Codex CLI was not found. Install Codex and ensure `codex` "
+                "is available on PATH."
+            )
+        self.binary = binary
+
+        timeout_raw = os.getenv(
+            "HORIZON_CODEX_TIMEOUT_SEC",
+            str(self._DEFAULT_TIMEOUT_SEC),
+        )
+        try:
+            timeout = float(timeout_raw)
+        except ValueError as exc:
+            raise ValueError(
+                "HORIZON_CODEX_TIMEOUT_SEC must be a positive number"
+            ) from exc
+        if not math.isfinite(timeout) or timeout <= 0:
+            raise ValueError(
+                "HORIZON_CODEX_TIMEOUT_SEC must be a positive number"
+            )
+        self.timeout_sec = timeout
+
+    def _build_command(self) -> List[str]:
+        command = [
+            self.binary,
+            "exec",
+            "--ephemeral",
+            "--ignore-user-config",
+            "--sandbox",
+            "read-only",
+            "--skip-git-repo-check",
+            "-",
+        ]
+        if self.model and self.model != "default":
+            command[2:2] = ["--model", self.model]
+        return command
+
+    async def complete(
+        self,
+        system: str,
+        user: str,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+    ) -> str:
+        """Generate one structured completion through ``codex exec``."""
+        del temperature, max_tokens
+        prompt = (
+            "Follow the system instruction and answer the user request.\n"
+            "Do not run commands, browse, edit files, or call tools.\n"
+            "Return only the requested JSON object.\n\n"
+            f"<system>\n{system}\n</system>\n\n"
+            f"<user>\n{user}\n</user>\n"
+        )
+
+        with tempfile.TemporaryDirectory(prefix="horizon-codex-") as workdir:
+            process = await asyncio.create_subprocess_exec(
+                *self._build_command(),
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=workdir,
+            )
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    process.communicate(prompt.encode("utf-8")),
+                    timeout=self.timeout_sec,
+                )
+            except TimeoutError as exc:
+                process.kill()
+                await process.wait()
+                raise TimeoutError(
+                    f"Codex CLI completion timed out after {self.timeout_sec:g}s"
+                ) from exc
+
+        if process.returncode != 0:
+            detail = stderr.decode("utf-8", errors="replace").strip()
+            if len(detail) > 2000:
+                detail = detail[-2000:]
+            raise RuntimeError(
+                f"Codex CLI exited with status {process.returncode}: {detail}"
+            )
+
+        result = stdout.decode("utf-8", errors="replace").strip()
+        if not result:
+            raise RuntimeError("Codex CLI returned an empty response")
+        return result
 
 
 class AnthropicClient(AIClient):
@@ -538,7 +645,9 @@ def _uses_anthropic_compatible_api(config: AIConfig) -> bool:
 
 def _create_single_client(config: AIConfig) -> AIClient:
     """Create a single AI client instance."""
-    if (
+    if config.provider == AIProvider.CODEX:
+        return CodexCLIClient(config)
+    elif (
         config.provider == AIProvider.ANTHROPIC
         or _uses_anthropic_compatible_api(config)
     ):

--- a/src/codex_daily.py
+++ b/src/codex_daily.py
@@ -1,0 +1,442 @@
+"""Reliable daily runner for Horizon's local Codex provider."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import errno
+import json
+import math
+import os
+import re
+import shutil
+import subprocess
+from datetime import datetime, time, tzinfo
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from ._file_utils import _atomic_write_text
+from .ai.client import CodexCLIClient
+from .models import AIProvider
+from .orchestrator import HorizonOrchestrator
+from .storage.manager import StorageManager
+
+MAX_CATCHUP_HOURS = 24 * 7
+CATCHUP_BUFFER_HOURS = 2
+_DAILY_AT_PATTERN = re.compile(r"^(?:[01]\d|2[0-3]):[0-5]\d$")
+
+
+class LockUnavailable(RuntimeError):
+    """Raised when another daily runner owns the instance lock."""
+
+
+class SingleInstanceLock:
+    """A small cross-platform, non-blocking advisory file lock."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self._file = None
+
+    def __enter__(self) -> "SingleInstanceLock":
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._file = self.path.open("a+", encoding="utf-8")
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                self._file.seek(0, os.SEEK_END)
+                if self._file.tell() == 0:
+                    self._file.write("\0")
+                    self._file.flush()
+                self._file.seek(0)
+                msvcrt.locking(self._file.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(
+                    self._file.fileno(),
+                    fcntl.LOCK_EX | fcntl.LOCK_NB,
+                )
+        except OSError as exc:
+            self._file.close()
+            self._file = None
+            if isinstance(exc, BlockingIOError) or exc.errno in {
+                errno.EACCES,
+                errno.EAGAIN,
+            }:
+                raise LockUnavailable from exc
+            raise
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        if self._file is None:
+            return
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                self._file.seek(0)
+                msvcrt.locking(self._file.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(self._file.fileno(), fcntl.LOCK_UN)
+        finally:
+            self._file.close()
+            self._file = None
+
+
+def _runner_paths(config_path: Path) -> dict[str, Path]:
+    data_dir = config_path.expanduser().resolve().parent
+    return {
+        "state": data_dir / "codex-daily-state.json",
+        "lock": data_dir / "codex-daily.lock",
+        "reports": data_dir / "run-reports",
+        "summaries": data_dir / "summaries",
+    }
+
+
+def _now(run_timezone: tzinfo) -> datetime:
+    return datetime.now(run_timezone)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = json.dumps(value, ensure_ascii=False, indent=2)
+    _atomic_write_text(path, f"{content}\n")
+
+
+def resolve_timezone(name: str | None) -> tzinfo:
+    """Resolve an IANA timezone, or use the host's current local timezone."""
+    if name is None:
+        local_timezone = datetime.now().astimezone().tzinfo
+        if local_timezone is None:
+            raise ValueError("Could not determine the system timezone")
+        return local_timezone
+    try:
+        return ZoneInfo(name)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError(f"Unknown IANA timezone: {name}") from exc
+
+
+def parse_daily_at(value: str) -> time:
+    """Parse a strict 24-hour ``HH:MM`` value."""
+    if not _DAILY_AT_PATTERN.fullmatch(value):
+        raise ValueError("--daily-at must use 24-hour HH:MM format")
+    return time.fromisoformat(value)
+
+
+def _parse_timestamp(value: Any, default_timezone: tzinfo) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        moment = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if moment.tzinfo is None:
+        return moment.replace(tzinfo=default_timezone)
+    return moment
+
+
+def is_due(now: datetime, daily_at: time) -> bool:
+    """Return whether today's configured start time has arrived."""
+    return now.timetz().replace(tzinfo=None) >= daily_at
+
+
+def should_skip_today(
+    state: dict[str, Any],
+    now: datetime,
+    run_timezone: tzinfo,
+) -> bool:
+    """Return whether a successful run already exists for the local date."""
+    last_success = _parse_timestamp(state.get("last_success_at"), run_timezone)
+    if last_success is None:
+        return False
+    return (
+        last_success.astimezone(run_timezone).date()
+        == now.astimezone(run_timezone).date()
+    )
+
+
+def calculate_fetch_hours(
+    configured_hours: int,
+    now: datetime,
+    last_success: datetime | None,
+) -> int:
+    """Cover downtime since the last success, with overlap and a seven-day cap."""
+    if last_success is None:
+        return min(configured_hours, MAX_CATCHUP_HOURS)
+    elapsed = max((now - last_success).total_seconds(), 0)
+    catchup = math.ceil(elapsed / 3600) + CATCHUP_BUFFER_HOURS
+    return min(max(configured_hours, catchup), MAX_CATCHUP_HOURS)
+
+
+def _codex_is_logged_in(stdout: str, stderr: str) -> bool:
+    return "logged in" in f"{stdout}\n{stderr}".lower()
+
+
+def _load_and_validate_codex_config(config_path: Path):
+    storage = StorageManager(
+        data_dir=str(config_path.parent),
+        config_path=config_path,
+    )
+    config = storage.load_config()
+    if config.ai.provider != AIProvider.CODEX:
+        raise RuntimeError(
+            f"Expected ai.provider=codex, got {config.ai.provider.value}"
+        )
+    if config.ai.provider_chain:
+        raise RuntimeError("horizon-codex-daily does not support provider_chain")
+    if config.ai.api_key_env:
+        raise RuntimeError("The Codex provider must not require an API key")
+
+    binary = os.getenv("HORIZON_CODEX_BIN") or shutil.which("codex")
+    if not binary:
+        raise RuntimeError("Codex CLI is not available on PATH")
+    login = subprocess.run(
+        [binary, "login", "status"],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+    if login.returncode != 0 or not _codex_is_logged_in(
+        login.stdout,
+        login.stderr,
+    ):
+        detail = (login.stderr or login.stdout).strip()
+        raise RuntimeError(f"Codex is not logged in: {detail}")
+
+    CodexCLIClient(config.ai)
+    return config
+
+
+async def _run_pipeline(config_path: Path, fetch_hours: int) -> dict[str, Any]:
+    storage = StorageManager(
+        data_dir=str(config_path.parent),
+        config_path=config_path,
+    )
+    config = storage.load_config()
+    orchestrator = HorizonOrchestrator(config, storage)
+    await orchestrator.run(force_hours=fetch_hours)
+    if orchestrator.last_fetch_report is None:
+        return {}
+    return orchestrator.last_fetch_report.to_dict()
+
+
+def _summary_snapshot(directory: Path) -> dict[Path, tuple[int, int]]:
+    if not directory.exists():
+        return {}
+    return {
+        path.resolve(): (path.stat().st_mtime_ns, path.stat().st_size)
+        for path in directory.glob("horizon-*.md")
+        if path.is_file()
+    }
+
+
+def _changed_summaries(
+    before: dict[Path, tuple[int, int]],
+    after: dict[Path, tuple[int, int]],
+) -> list[str]:
+    return sorted(
+        str(path)
+        for path, signature in after.items()
+        if before.get(path) != signature
+    )
+
+
+def run_once(
+    *,
+    config_path: Path,
+    run_timezone: tzinfo,
+    daily_at: time,
+    force: bool = False,
+    now: datetime | None = None,
+) -> int:
+    """Execute one guarded Codex daily run."""
+    paths = _runner_paths(config_path)
+    current = now or _now(run_timezone)
+    if current.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+    current = current.astimezone(run_timezone)
+
+    try:
+        lock = SingleInstanceLock(paths["lock"])
+        lock.__enter__()
+    except LockUnavailable:
+        print("SKIP: another Horizon Codex daily run is active")
+        return 0
+
+    try:
+        state = _load_json(paths["state"])
+        if not force and not is_due(current, daily_at):
+            print(
+                f"SKIP: daily start time {daily_at.strftime('%H:%M')} "
+                "has not arrived"
+            )
+            return 0
+        if not force and should_skip_today(state, current, run_timezone):
+            print(
+                "SKIP: Horizon Codex already completed on "
+                f"{current.date().isoformat()}"
+            )
+            return 0
+
+        source_report: dict[str, Any] = {}
+        try:
+            config = _load_and_validate_codex_config(config_path)
+            last_success = _parse_timestamp(
+                state.get("last_success_at"),
+                run_timezone,
+            )
+            fetch_hours = calculate_fetch_hours(
+                config.filtering.time_window_hours,
+                current,
+                last_success,
+            )
+            print(
+                f"RUN: Horizon Codex {current.date().isoformat()} "
+                f"(fetch window: {fetch_hours}h)"
+            )
+
+            summaries_before = _summary_snapshot(paths["summaries"])
+            source_report = asyncio.run(
+                _run_pipeline(config_path, fetch_hours)
+            )
+            if source_report.get("status") in {"failure", "partial_failure"}:
+                raise RuntimeError(
+                    "source fetch status was "
+                    f"{source_report['status']}"
+                )
+            summaries_after = _summary_snapshot(paths["summaries"])
+
+            completed_at = _now(run_timezone)
+            local_date = completed_at.date().isoformat()
+            report_path = paths["reports"] / f"{local_date}.json"
+            report = {
+                "status": "success",
+                "started_at": current.isoformat(),
+                "completed_at": completed_at.isoformat(),
+                "timezone": str(run_timezone),
+                "daily_at": daily_at.strftime("%H:%M"),
+                "fetch_hours": fetch_hours,
+                "source_report": source_report,
+                "summaries": _changed_summaries(
+                    summaries_before,
+                    summaries_after,
+                ),
+            }
+            _write_json(report_path, report)
+            state.update(
+                {
+                    "last_attempt_at": completed_at.isoformat(),
+                    "last_attempt_status": "success",
+                    "last_success_at": completed_at.isoformat(),
+                    "last_fetch_hours": fetch_hours,
+                    "last_report": str(report_path),
+                    "last_summaries": report["summaries"],
+                }
+            )
+            state.pop("last_error", None)
+            _write_json(paths["state"], state)
+            print(f"DONE: report: {report_path}")
+            return 0
+        except Exception as exc:
+            failed_at = _now(run_timezone)
+            stamp = failed_at.strftime("%Y%m%dT%H%M%S%f%z")
+            report_path = paths["reports"] / f"{stamp}-failure.json"
+            report = {
+                "status": "failure",
+                "started_at": current.isoformat(),
+                "completed_at": failed_at.isoformat(),
+                "timezone": str(run_timezone),
+                "daily_at": daily_at.strftime("%H:%M"),
+                "error": f"{type(exc).__name__}: {exc}",
+                "source_report": source_report,
+            }
+            _write_json(report_path, report)
+            state.update(
+                {
+                    "last_attempt_at": failed_at.isoformat(),
+                    "last_attempt_status": "failure",
+                    "last_error": report["error"],
+                    "last_report": str(report_path),
+                }
+            )
+            _write_json(paths["state"], state)
+            print(f"FAILED: {report['error']}; report: {report_path}")
+            return 1
+    finally:
+        lock.__exit__(None, None, None)
+
+
+def _print_status(config_path: Path) -> int:
+    state = _load_json(_runner_paths(config_path)["state"])
+    if not state:
+        print("Horizon Codex has not completed a local daily run yet.")
+        return 0
+    print(json.dumps(state, ensure_ascii=False, indent=2))
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("data/config.json"),
+        help="Horizon configuration path (default: data/config.json)",
+    )
+    parser.add_argument(
+        "--timezone",
+        help="IANA timezone (default: the system local timezone)",
+    )
+    parser.add_argument(
+        "--daily-at",
+        default="00:00",
+        help="Earliest local run time in 24-hour HH:MM format (default: 00:00)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Run even before daily-at or after today's success",
+    )
+    parser.add_argument(
+        "--status",
+        action="store_true",
+        help="Show the last run status without running",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.status:
+        return _print_status(args.config)
+    try:
+        run_timezone = resolve_timezone(args.timezone)
+        daily_at = parse_daily_at(args.daily_at)
+    except ValueError as exc:
+        parser.error(str(exc))
+    return run_once(
+        config_path=args.config.expanduser().resolve(),
+        run_timezone=run_timezone,
+        daily_at=daily_at,
+        force=args.force,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/models.py
+++ b/src/models.py
@@ -67,6 +67,7 @@ class ContentItem(BaseModel):
 class AIProvider(str, Enum):
     """Supported AI providers."""
 
+    CODEX = "codex"
     ANTHROPIC = "anthropic"
     OPENAI = "openai"
     AZURE = "azure"
@@ -80,6 +81,11 @@ class AIProvider(str, Enum):
 
 # Provider-specific defaults used by setup and provider-chain expansion.
 AI_PROVIDER_DEFAULTS = {
+    AIProvider.CODEX: {
+        "model": "default",
+        "api_key_env": "",
+        "base_url": None,
+    },
     AIProvider.ANTHROPIC: {
         "model": "claude-3-5-sonnet-20241022",
         "api_key_env": "ANTHROPIC_API_KEY",

--- a/src/setup/wizard.py
+++ b/src/setup/wizard.py
@@ -104,7 +104,7 @@ def configure_ai() -> Optional[AIConfig]:
 
 
 def _ai_recommendations_available(ai_config: AIConfig) -> bool:
-    if ai_config.provider == AIProvider.OLLAMA:
+    if ai_config.provider in {AIProvider.CODEX, AIProvider.OLLAMA}:
         return True
     return bool(ai_config.api_key_env and os.getenv(ai_config.api_key_env))
 

--- a/src/storage/manager.py
+++ b/src/storage/manager.py
@@ -63,9 +63,17 @@ class ConfigError(ValueError):
 class StorageManager:
     """Manages file-based storage for configuration and state."""
 
-    def __init__(self, data_dir: str = "data"):
+    def __init__(
+        self,
+        data_dir: str = "data",
+        config_path: str | Path | None = None,
+    ):
         self.data_dir = Path(data_dir)
-        self.config_path = self.data_dir / "config.json"
+        self.config_path = (
+            Path(config_path)
+            if config_path is not None
+            else self.data_dir / "config.json"
+        )
         self.summaries_dir = self.data_dir / "summaries"
 
         self.data_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_codex_client.py
+++ b/tests/test_codex_client.py
@@ -1,0 +1,146 @@
+"""Tests for the local Codex CLI AI client."""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from src.ai.client import CodexCLIClient, create_ai_client
+from src.models import AIConfig, AIProvider
+
+
+def _config(model: str = "default") -> AIConfig:
+    return AIConfig(
+        provider=AIProvider.CODEX,
+        model=model,
+        api_key_env="",
+    )
+
+
+class _Process:
+    def __init__(
+        self,
+        stdout: bytes = b'{"score": 8}',
+        stderr: bytes = b"",
+        returncode: int = 0,
+    ):
+        self.returncode = returncode
+        self.communicate = AsyncMock(return_value=(stdout, stderr))
+        self.kill = Mock()
+        self.wait = AsyncMock()
+
+
+def test_factory_creates_codex_client(monkeypatch):
+    monkeypatch.setattr("src.ai.client.shutil.which", lambda _: "/usr/bin/codex")
+
+    client = create_ai_client(_config())
+
+    assert isinstance(client, CodexCLIClient)
+    assert client.binary == "/usr/bin/codex"
+
+
+def test_missing_binary_has_actionable_error(monkeypatch):
+    monkeypatch.delenv("HORIZON_CODEX_BIN", raising=False)
+    monkeypatch.setattr("src.ai.client.shutil.which", lambda _: None)
+
+    with pytest.raises(ValueError, match="Codex CLI was not found"):
+        CodexCLIClient(_config())
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "not-a-number", "nan", "inf"])
+def test_timeout_must_be_positive_and_finite(monkeypatch, value):
+    monkeypatch.setattr("src.ai.client.shutil.which", lambda _: "/usr/bin/codex")
+    monkeypatch.setenv("HORIZON_CODEX_TIMEOUT_SEC", value)
+
+    with pytest.raises(ValueError, match="must be a positive number"):
+        CodexCLIClient(_config())
+
+
+def test_default_model_is_omitted_and_sandbox_is_read_only(monkeypatch):
+    monkeypatch.setattr("src.ai.client.shutil.which", lambda _: "/usr/bin/codex")
+    client = CodexCLIClient(_config())
+
+    command = client._build_command()
+
+    assert "--model" not in command
+    assert command[-1] == "-"
+    assert command[command.index("--sandbox") + 1] == "read-only"
+    assert "--ephemeral" in command
+    assert "--ignore-user-config" in command
+
+
+def test_explicit_model_is_forwarded(monkeypatch):
+    monkeypatch.setattr("src.ai.client.shutil.which", lambda _: "/usr/bin/codex")
+    client = CodexCLIClient(_config("gpt-5.6-terra"))
+
+    command = client._build_command()
+
+    model_index = command.index("--model")
+    assert command[model_index + 1] == "gpt-5.6-terra"
+
+
+def test_complete_uses_stdin_and_an_empty_temporary_workdir(monkeypatch):
+    monkeypatch.setattr("src.ai.client.shutil.which", lambda _: "/usr/bin/codex")
+    process = _Process()
+    create = AsyncMock(return_value=process)
+    monkeypatch.setattr("src.ai.client.asyncio.create_subprocess_exec", create)
+    client = CodexCLIClient(_config())
+
+    result = asyncio.run(client.complete(system="system text", user="user text"))
+
+    assert result == '{"score": 8}'
+    stdin = process.communicate.await_args.args[0].decode()
+    assert "<system>\nsystem text\n</system>" in stdin
+    assert "<user>\nuser text\n</user>" in stdin
+    workdir = Path(create.await_args.kwargs["cwd"])
+    assert workdir.name.startswith("horizon-codex-")
+    assert not workdir.exists()
+
+
+def test_complete_raises_on_nonzero_exit_and_truncates_stderr(monkeypatch):
+    monkeypatch.setattr("src.ai.client.shutil.which", lambda _: "/usr/bin/codex")
+    stderr = b"x" * 3000 + b"login required"
+    process = _Process(stderr=stderr, returncode=1)
+    monkeypatch.setattr(
+        "src.ai.client.asyncio.create_subprocess_exec",
+        AsyncMock(return_value=process),
+    )
+    client = CodexCLIClient(_config())
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(client.complete(system="s", user="u"))
+
+    assert "login required" in str(exc_info.value)
+    assert len(str(exc_info.value)) < 2100
+
+
+def test_complete_rejects_empty_response(monkeypatch):
+    monkeypatch.setattr("src.ai.client.shutil.which", lambda _: "/usr/bin/codex")
+    process = _Process(stdout=b" \n")
+    monkeypatch.setattr(
+        "src.ai.client.asyncio.create_subprocess_exec",
+        AsyncMock(return_value=process),
+    )
+    client = CodexCLIClient(_config())
+
+    with pytest.raises(RuntimeError, match="empty response"):
+        asyncio.run(client.complete(system="s", user="u"))
+
+
+def test_timeout_kills_and_waits_for_process(monkeypatch):
+    monkeypatch.setattr("src.ai.client.shutil.which", lambda _: "/usr/bin/codex")
+    monkeypatch.setenv("HORIZON_CODEX_TIMEOUT_SEC", "1")
+    process = _Process()
+    process.communicate = AsyncMock(side_effect=TimeoutError)
+    monkeypatch.setattr(
+        "src.ai.client.asyncio.create_subprocess_exec",
+        AsyncMock(return_value=process),
+    )
+    client = CodexCLIClient(_config())
+
+    with pytest.raises(TimeoutError, match="timed out after 1s"):
+        asyncio.run(client.complete(system="s", user="u"))
+
+    process.kill.assert_called_once_with()
+    process.wait.assert_awaited_once_with()

--- a/tests/test_codex_daily.py
+++ b/tests/test_codex_daily.py
@@ -1,0 +1,391 @@
+"""Tests for catch-up, idempotency, and retry in the Codex daily runner."""
+
+import json
+from datetime import datetime, time, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from src.codex_daily import (
+    MAX_CATCHUP_HOURS,
+    LockUnavailable,
+    SingleInstanceLock,
+    _codex_is_logged_in,
+    _load_and_validate_codex_config,
+    _runner_paths,
+    calculate_fetch_hours,
+    is_due,
+    main,
+    parse_daily_at,
+    resolve_timezone,
+    run_once,
+    should_skip_today,
+)
+
+
+def _write_config(
+    path: Path,
+    *,
+    provider: str = "codex",
+    api_key_env: str = "",
+    provider_chain: str | None = None,
+) -> None:
+    ai = {
+        "provider": provider,
+        "model": "default",
+        "api_key_env": api_key_env,
+    }
+    if provider_chain is not None:
+        ai["provider_chain"] = provider_chain
+    path.write_text(
+        json.dumps(
+            {
+                "ai": ai,
+                "sources": {},
+                "filtering": {"time_window_hours": 24},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _config_stub(hours: int = 24):
+    return SimpleNamespace(
+        filtering=SimpleNamespace(time_window_hours=hours)
+    )
+
+
+@pytest.mark.parametrize("value", ["00:00", "08:30", "23:59"])
+def test_parse_daily_at_accepts_strict_24_hour_time(value):
+    assert parse_daily_at(value).strftime("%H:%M") == value
+
+
+@pytest.mark.parametrize("value", ["8:00", "24:00", "12:60", "noon"])
+def test_parse_daily_at_rejects_invalid_values(value):
+    with pytest.raises(ValueError, match="HH:MM"):
+        parse_daily_at(value)
+
+
+def test_explicit_iana_timezones_are_supported():
+    assert str(resolve_timezone("UTC")) == "UTC"
+    assert str(resolve_timezone("America/New_York")) == "America/New_York"
+
+
+def test_unknown_timezone_is_rejected():
+    with pytest.raises(ValueError, match="Unknown IANA timezone"):
+        resolve_timezone("Mars/Olympus")
+
+
+def test_daily_run_is_not_due_before_start_time():
+    now = datetime(2026, 7, 29, 7, 59, tzinfo=timezone.utc)
+
+    assert not is_due(now, time(8, 0))
+    assert is_due(now.replace(hour=8), time(8, 0))
+
+
+def test_success_is_compared_in_the_selected_timezone():
+    los_angeles = resolve_timezone("America/Los_Angeles")
+    now = datetime(2026, 7, 28, 18, 0, tzinfo=los_angeles)
+    state = {"last_success_at": "2026-07-29T00:30:00+00:00"}
+
+    assert should_skip_today(state, now, los_angeles)
+    assert not should_skip_today(
+        {"last_success_at": "2026-07-28T00:30:00+00:00"},
+        now,
+        los_angeles,
+    )
+
+
+def test_fetch_window_covers_downtime_with_overlap():
+    now = datetime(2026, 7, 29, 10, 0, tzinfo=timezone.utc)
+    last_success = now - timedelta(hours=49, minutes=10)
+
+    assert calculate_fetch_hours(24, now, last_success) == 52
+
+
+def test_fetch_window_uses_configured_default_and_caps_catchup():
+    now = datetime(2026, 7, 29, 10, 0, tzinfo=timezone.utc)
+
+    assert calculate_fetch_hours(24, now, now - timedelta(hours=20)) == 24
+    assert (
+        calculate_fetch_hours(24, now, now - timedelta(days=30))
+        == MAX_CATCHUP_HOURS
+    )
+    assert calculate_fetch_hours(500, now, None) == MAX_CATCHUP_HOURS
+
+
+def test_single_instance_lock_rejects_a_second_owner(tmp_path):
+    lock_path = tmp_path / "daily.lock"
+
+    with SingleInstanceLock(lock_path):
+        with pytest.raises(LockUnavailable):
+            with SingleInstanceLock(lock_path):
+                pass
+
+    with SingleInstanceLock(lock_path):
+        pass
+
+
+def test_login_status_accepts_output_from_either_stream():
+    assert _codex_is_logged_in("Logged in using ChatGPT", "")
+    assert _codex_is_logged_in("", "Logged in using ChatGPT")
+
+
+def test_codex_preflight_accepts_logged_in_keyless_config(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    _write_config(config_path)
+    monkeypatch.setattr("src.codex_daily.shutil.which", lambda _: "/usr/bin/codex")
+    monkeypatch.setattr("src.ai.client.shutil.which", lambda _: "/usr/bin/codex")
+    run = SimpleNamespace(
+        returncode=0,
+        stdout="Logged in using ChatGPT",
+        stderr="",
+    )
+    monkeypatch.setattr("src.codex_daily.subprocess.run", lambda *a, **k: run)
+
+    config = _load_and_validate_codex_config(config_path)
+
+    assert config.ai.provider.value == "codex"
+    assert config.ai.api_key_env == ""
+
+
+@pytest.mark.parametrize(
+    ("provider", "api_key_env", "provider_chain", "message"),
+    [
+        ("openai", "OPENAI_API_KEY", None, "Expected ai.provider=codex"),
+        ("codex", "SOME_KEY", None, "must not require an API key"),
+        ("codex", "", "codex,ollama", "does not support provider_chain"),
+    ],
+)
+def test_codex_preflight_rejects_nonlocal_config(
+    tmp_path,
+    provider,
+    api_key_env,
+    provider_chain,
+    message,
+):
+    config_path = tmp_path / "config.json"
+    _write_config(
+        config_path,
+        provider=provider,
+        api_key_env=api_key_env,
+        provider_chain=provider_chain,
+    )
+
+    with pytest.raises(RuntimeError, match=message):
+        _load_and_validate_codex_config(config_path)
+
+
+def test_codex_preflight_rejects_logged_out_session(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    _write_config(config_path)
+    monkeypatch.setattr("src.codex_daily.shutil.which", lambda _: "/usr/bin/codex")
+    run = SimpleNamespace(returncode=1, stdout="", stderr="Not logged in")
+    monkeypatch.setattr("src.codex_daily.subprocess.run", lambda *a, **k: run)
+
+    with pytest.raises(RuntimeError, match="Codex is not logged in"):
+        _load_and_validate_codex_config(config_path)
+
+
+def test_runner_skips_before_daily_time_without_starting_pipeline(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    config_path = tmp_path / "config.json"
+    validate = pytest.fail
+    monkeypatch.setattr(
+        "src.codex_daily._load_and_validate_codex_config",
+        validate,
+    )
+    now = datetime(2026, 7, 29, 7, 59, tzinfo=timezone.utc)
+
+    result = run_once(
+        config_path=config_path,
+        run_timezone=timezone.utc,
+        daily_at=time(8, 0),
+        now=now,
+    )
+
+    assert result == 0
+    assert capsys.readouterr().out.startswith("SKIP:")
+
+
+def test_runner_success_is_idempotent_and_records_changed_summaries(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    config_path = tmp_path / "config.json"
+    now = datetime(2026, 7, 29, 10, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("src.codex_daily._now", lambda tz: now)
+    validate_calls = []
+    monkeypatch.setattr(
+        "src.codex_daily._load_and_validate_codex_config",
+        lambda path: validate_calls.append(path) or _config_stub(),
+    )
+
+    async def successful_pipeline(path, hours):
+        summaries = path.parent / "summaries"
+        summaries.mkdir()
+        (summaries / "horizon-2026-07-29-en.md").write_text(
+            "# Summary",
+            encoding="utf-8",
+        )
+        return {"status": "success", "attempted": 1, "failed": 0}
+
+    monkeypatch.setattr(
+        "src.codex_daily._run_pipeline",
+        successful_pipeline,
+    )
+
+    first = run_once(
+        config_path=config_path,
+        run_timezone=timezone.utc,
+        daily_at=time(8, 0),
+        now=now,
+    )
+    second = run_once(
+        config_path=config_path,
+        run_timezone=timezone.utc,
+        daily_at=time(8, 0),
+        now=now,
+    )
+
+    state = json.loads(
+        _runner_paths(config_path)["state"].read_text(encoding="utf-8")
+    )
+    output = capsys.readouterr().out
+    assert first == 0
+    assert second == 0
+    assert len(validate_calls) == 1
+    assert "DONE: report:" in output
+    assert "SKIP: Horizon Codex already completed" in output
+    assert state["last_attempt_status"] == "success"
+    assert state["last_summaries"] == [
+        str(
+            (
+                tmp_path
+                / "summaries"
+                / "horizon-2026-07-29-en.md"
+            ).resolve()
+        )
+    ]
+
+
+def test_force_runs_before_daily_time(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    now = datetime(2026, 7, 29, 7, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("src.codex_daily._now", lambda tz: now)
+    monkeypatch.setattr(
+        "src.codex_daily._load_and_validate_codex_config",
+        lambda path: _config_stub(),
+    )
+
+    async def successful_pipeline(path, hours):
+        return {"status": "success"}
+
+    monkeypatch.setattr(
+        "src.codex_daily._run_pipeline",
+        successful_pipeline,
+    )
+
+    assert (
+        run_once(
+            config_path=config_path,
+            run_timezone=timezone.utc,
+            daily_at=time(8, 0),
+            force=True,
+            now=now,
+        )
+        == 0
+    )
+
+
+def test_failure_preserves_success_state_and_next_invocation_retries(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    config_path = tmp_path / "config.json"
+    now = datetime(2026, 7, 29, 10, 0, tzinfo=timezone.utc)
+    old_success = "2026-07-27T10:00:00+00:00"
+    paths = _runner_paths(config_path)
+    paths["state"].write_text(
+        json.dumps({"last_success_at": old_success}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("src.codex_daily._now", lambda tz: now)
+    monkeypatch.setattr(
+        "src.codex_daily._load_and_validate_codex_config",
+        lambda path: _config_stub(),
+    )
+    attempts = 0
+
+    async def flaky_pipeline(path, hours):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("temporary failure")
+        return {"status": "success"}
+
+    monkeypatch.setattr("src.codex_daily._run_pipeline", flaky_pipeline)
+
+    failed = run_once(
+        config_path=config_path,
+        run_timezone=timezone.utc,
+        daily_at=time(8, 0),
+        now=now,
+    )
+    failed_state = json.loads(paths["state"].read_text(encoding="utf-8"))
+    retried = run_once(
+        config_path=config_path,
+        run_timezone=timezone.utc,
+        daily_at=time(8, 0),
+        now=now,
+    )
+    final_state = json.loads(paths["state"].read_text(encoding="utf-8"))
+
+    assert failed == 1
+    assert retried == 0
+    assert attempts == 2
+    assert failed_state["last_success_at"] == old_success
+    assert failed_state["last_attempt_status"] == "failure"
+    assert final_state["last_attempt_status"] == "success"
+    assert capsys.readouterr().out.count("FAILED:") == 1
+
+
+def test_partial_source_failure_is_retried(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    now = datetime(2026, 7, 29, 10, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("src.codex_daily._now", lambda tz: now)
+    monkeypatch.setattr(
+        "src.codex_daily._load_and_validate_codex_config",
+        lambda path: _config_stub(),
+    )
+
+    async def partial_pipeline(path, hours):
+        return {"status": "partial_failure", "failed": 1}
+
+    monkeypatch.setattr("src.codex_daily._run_pipeline", partial_pipeline)
+
+    assert (
+        run_once(
+            config_path=config_path,
+            run_timezone=timezone.utc,
+            daily_at=time(8, 0),
+            now=now,
+        )
+        == 1
+    )
+
+
+def test_main_reports_invalid_timezone_and_daily_time():
+    with pytest.raises(SystemExit) as timezone_error:
+        main(["--timezone", "Mars/Olympus"])
+    with pytest.raises(SystemExit) as time_error:
+        main(["--daily-at", "8:00"])
+
+    assert timezone_error.value.code == 2
+    assert time_error.value.code == 2

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -41,6 +41,16 @@ def test_ai_recommendations_available_for_ollama_without_api_key():
     assert wizard._ai_recommendations_available(config) is True
 
 
+def test_ai_recommendations_available_for_codex_without_api_key():
+    config = AIConfig(
+        provider=AIProvider.CODEX,
+        model="default",
+        api_key_env="",
+    )
+
+    assert wizard._ai_recommendations_available(config) is True
+
+
 def test_ai_recommendations_require_api_key_for_cloud_provider(monkeypatch):
     config = AIConfig(
         provider=AIProvider.OPENAI,


### PR DESCRIPTION
## What changed

- add a `codex` AI provider backed by the locally authenticated Codex CLI
- run each completion through ephemeral `codex exec` in an empty temporary
  directory with user configuration ignored and a read-only sandbox
- add `horizon-codex-daily`, a guarded local runner with:
  - configurable IANA timezone and `--daily-at HH:MM`
  - once-per-local-day idempotency
  - a cross-platform single-instance lock
  - catch-up since the last successful run, with overlap and a seven-day cap
  - atomic state, success reports, timestamped failure reports, and retry on
    the next scheduler invocation
- allow `StorageManager` to load an explicit configuration path
- document Codex configuration plus cron and launchd examples

## Why

Horizon already supports always-on GitHub Actions and API-backed providers, but
local Codex users may have neither an API key nor a computer that is always on.
This provides one complete local path: use the existing Codex login for model
calls, invoke the runner periodically, and safely catch up after downtime.

The daily runner intentionally remains specific to `ai.provider: "codex"` so
it can verify the local executable, login state, and keyless configuration
before a long Horizon run.

## Behavior

```bash
uv run horizon-codex-daily \
  --config data/config.json \
  --timezone Asia/Shanghai \
  --daily-at 08:00
```

- `DONE` and `SKIP` exit with status 0.
- `FAILED` exits with status 1 and prints the failure report path.
- Failed attempts do not update `last_success_at`, so the next invocation
  retries.
- The system local timezone and `00:00` are the defaults; no regional timezone
  is hard-coded.

## Validation

- `uv run --extra dev pytest` — 427 passed
- `python -m compileall -q src tests`
- `git diff --check`
- real local Codex smoke test returned `{"ok":true}`
