### PR TITLE
feat(cli): consistent -d / -c / -l params across all CLIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,16 +208,8 @@ uv pip install --only-binary=:all: openbb openbb-benzinga
 git clone https://github.com/Thysrael/Horizon.git
 cd Horizon
 
-# Configure environment
-cp .env.example .env
-cp data/config.example.json data/config.json
-# Edit .env and data/config.json with your API keys and preferences
-
 # Optional: build with comma-separated extras before the first run
 docker compose build --build-arg EXTRAS=trafilatura horizon
-
-# Run with Docker Compose (see step 3 for available options)
-docker compose run --rm horizon [OPTIONS]
 ```
 
 Multiple extras may be supplied as `EXTRAS=trafilatura,openbb`. The `twitter` extra also requires a Playwright browser and system packages, which the current Dockerfile does not install.
@@ -230,13 +222,7 @@ Multiple extras may be supplied as `EXTRAS=trafilatura,openbb`. The `twitter` ex
 uv run horizon-wizard
 ```
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `--data-dir PATH`, `-d` | `data` | Path to the data directory |
-| `--config PATH`, `-c` | `<data-dir>/config.json` | Path to config file |
-| `--log-level LEVEL`, `-l` | `WARNING` | Logging level (DEBUG/INFO/WARNING/ERROR/CRITICAL) |
-
-The wizard asks about your interests (e.g. "LLM inference", "嵌入式", "web security") and auto-generates `data/config.json`.
+The wizard asks about your interests (e.g. "LLM inference", "嵌入式", "web security") and auto-generates `data/config.json`. See [Interactive Wizard](docs/configuration.md#interactive-wizard) for CLI options.
 
 **Option B: Manual configuration**
 
@@ -344,8 +330,6 @@ For the full reference, see the [Configuration Guide](docs/configuration.md).
 uv run horizon [OPTIONS]
 ```
 
-`--data-dir` changes the state directory, including summaries, subscribers, and the default config location. `--config` changes only the config file; combine both flags when both locations should change. The setup wizard writes `data/config.json`, so custom paths should be initialized manually from `data/config.example.json`.
-
 **B. Docker**
 
 ```bash
@@ -355,11 +339,11 @@ docker compose run --rm horizon [OPTIONS]
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--hours N` | 24 | Fetch from last N hours |
-| `--data-dir PATH`, `-d` | `data` | Path to the data directory |
-| `--config PATH`, `-c` | `<data-dir>/config.json` | Path to config file |
-| `--log-level LEVEL`, `-l` | `WARNING` | Logging level (DEBUG/INFO/WARNING/ERROR/CRITICAL) |
+| `-d`, `--data-dir PATH` | `data` | Path to the data directory |
+| `-c`, `--config PATH` | `<data-dir>/config.json` | Path to config file |
+| `-l`, `--log-level LEVEL` | `WARNING` | Logging level (DEBUG/INFO/WARNING/ERROR/CRITICAL) |
 
-The generated report will be saved to `data/summaries/` (or `<data-dir>/summaries/` if `--data-dir` is set).
+`--data-dir` changes the state directory, including summaries, subscribers, and the default config location; `--config` changes only the config file. The generated report is saved to `data/summaries/` (or `<data-dir>/summaries/` if `--data-dir` is set). See [Configuration Paths](docs/configuration.md#configuration-paths) for combining both flags and initializing a custom config location.
 
 ### 4. Automate (Optional)
 

--- a/README.md
+++ b/README.md
@@ -216,11 +216,8 @@ cp data/config.example.json data/config.json
 # Optional: build with comma-separated extras before the first run
 docker compose build --build-arg EXTRAS=trafilatura horizon
 
-# Run with Docker Compose
-docker compose run --rm horizon
-
-# Run with a custom time window
-docker compose run --rm horizon --hours 48
+# Run with Docker Compose (see step 3 for available options)
+docker compose run --rm horizon [OPTIONS]
 ```
 
 Multiple extras may be supplied as `EXTRAS=trafilatura,openbb`. The `twitter` extra also requires a Playwright browser and system packages, which the current Dockerfile does not install.
@@ -232,6 +229,10 @@ Multiple extras may be supplied as `EXTRAS=trafilatura,openbb`. The `twitter` ex
 ```bash
 uv run horizon-wizard
 ```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--log-level LEVEL`, `-l` | `WARNING` | Logging level (DEBUG/INFO/WARNING/ERROR/CRITICAL) |
 
 The wizard asks about your interests (e.g. "LLM inference", "嵌入式", "web security") and auto-generates `data/config.json`.
 
@@ -335,24 +336,26 @@ For the full reference, see the [Configuration Guide](docs/configuration.md).
 
 ### 3. Run
 
-#### Local Installation
+**A. Local installation**
 
 ```bash
-uv run horizon                          # Run with default 24h window
-uv run horizon --hours 48               # Fetch from last 48 hours
-uv run horizon -d /path/to/data         # Use a custom data directory
-uv run horizon -c /path/to/config.json  # Use a custom config file
+uv run horizon [OPTIONS]
 ```
 
 `--data-dir` changes the state directory, including summaries, subscribers, and the default config location. `--config` changes only the config file; combine both flags when both locations should change. The setup wizard writes `data/config.json`, so custom paths should be initialized manually from `data/config.example.json`.
 
-#### With Docker
+**B. Docker**
 
 ```bash
-docker compose run --rm horizon                          # Run with default 24h window
-docker compose run --rm horizon --hours 48               # Fetch from last 48 hours
-docker compose run --rm horizon -c /app/data/alt.json   # Use a custom config file
+docker compose run --rm horizon [OPTIONS]
 ```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--hours N` | 24 | Fetch from last N hours |
+| `--data-dir PATH`, `-d` | `data` | Path to the data directory |
+| `--config PATH`, `-c` | `<data-dir>/config.json` | Path to config file |
+| `--log-level LEVEL`, `-l` | `WARNING` | Logging level (DEBUG/INFO/WARNING/ERROR/CRITICAL) |
 
 The generated report will be saved to `data/summaries/` (or `<data-dir>/summaries/` if `--data-dir` is set).
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ uv run horizon-wizard
 
 | Option | Default | Description |
 |--------|---------|-------------|
+| `--data-dir PATH`, `-d` | `data` | Path to the data directory |
+| `--config PATH`, `-c` | `<data-dir>/config.json` | Path to config file |
 | `--log-level LEVEL`, `-l` | `WARNING` | Logging level (DEBUG/INFO/WARNING/ERROR/CRITICAL) |
 
 The wizard asks about your interests (e.g. "LLM inference", "嵌入式", "web security") and auto-generates `data/config.json`.

--- a/README_ja.md
+++ b/README_ja.md
@@ -209,16 +209,8 @@ uv pip install --only-binary=:all: openbb openbb-benzinga
 git clone https://github.com/Thysrael/Horizon.git
 cd Horizon
 
-# 環境を設定
-cp .env.example .env
-cp data/config.example.json data/config.json
-# .env と data/config.json をAPIキーや好みに合わせて編集
-
 # オプション: 初回実行前にカンマ区切りのextrasを含めてビルド
 docker compose build --build-arg EXTRAS=trafilatura horizon
-
-# Docker Composeで実行（利用可能なオプションはステップ3を参照）
-docker compose run --rm horizon [OPTIONS]
 ```
 
 複数のextraは`EXTRAS=trafilatura,openbb`のように指定できます。`twitter` extraにはPlaywrightブラウザとシステムパッケージも必要ですが、現在のDockerfileはそれらをインストールしません。
@@ -231,13 +223,7 @@ docker compose run --rm horizon [OPTIONS]
 uv run horizon-wizard
 ```
 
-| オプション | デフォルト | 説明 |
-|--------|---------|-------------|
-| `--data-dir PATH`, `-d` | `data` | データディレクトリのパス |
-| `--config PATH`, `-c` | `<data-dir>/config.json` | 設定ファイルのパス |
-| `--log-level LEVEL`, `-l` | `WARNING` | ログレベル（DEBUG/INFO/WARNING/ERROR/CRITICAL）|
-
-ウィザードはあなたの興味（例: 「LLM inference」「嵌入式」「web security」）について質問し、`data/config.json`を自動生成します。
+ウィザードはあなたの興味（例: 「LLM inference」「嵌入式」「web security」）について質問し、`data/config.json`を自動生成します。CLIオプションは[対話式ウィザード](docs/configuration.md#interactive-wizard)を参照してください。
 
 **オプションB: 手動設定**
 
@@ -339,8 +325,6 @@ Geminiの場合は`GOOGLE_API_KEY`を使用します。
 uv run horizon [OPTIONS]
 ```
 
-`--data-dir`は、サマリー、購読者ファイル、デフォルト設定の場所を含む状態ディレクトリを変更します。`--config`は設定ファイルだけを変更するため、両方の場所を変更する場合は2つのオプションを併用してください。セットアップウィザードは`data/config.json`へ書き込むため、カスタムパスは`data/config.example.json`から手動で初期化します。
-
 **B. Docker**
 
 ```bash
@@ -350,11 +334,11 @@ docker compose run --rm horizon [OPTIONS]
 | オプション | デフォルト | 説明 |
 |--------|---------|-------------|
 | `--hours N` | 24 | 過去N時間から取得 |
-| `--data-dir PATH`, `-d` | `data` | データディレクトリのパス |
-| `--config PATH`, `-c` | `<data-dir>/config.json` | 設定ファイルのパス |
-| `--log-level LEVEL`, `-l` | `WARNING` | ログレベル（DEBUG/INFO/WARNING/ERROR/CRITICAL）|
+| `-d`, `--data-dir PATH` | `data` | データディレクトリのパス |
+| `-c`, `--config PATH` | `<data-dir>/config.json` | 設定ファイルのパス |
+| `-l`, `--log-level LEVEL` | `WARNING` | ログレベル（DEBUG/INFO/WARNING/ERROR/CRITICAL）|
 
-生成されたレポートは`data/summaries/`に保存されます（`--data-dir`を指定した場合は`<data-dir>/summaries/`）。
+`--data-dir`は、サマリー、購読者ファイル、デフォルト設定の場所を含む状態ディレクトリを変更します。`--config`は設定ファイルだけを変更します。生成されたレポートは`data/summaries/`に保存されます（`--data-dir`を指定した場合は`<data-dir>/summaries/`）。両方の場所を変更する場合やカスタム設定の初期化については、[設定パス](docs/configuration.md#configuration-paths)を参照してください。
 
 ### 4. 自動化（オプション）
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -217,11 +217,8 @@ cp data/config.example.json data/config.json
 # オプション: 初回実行前にカンマ区切りのextrasを含めてビルド
 docker compose build --build-arg EXTRAS=trafilatura horizon
 
-# Docker Composeで実行
-docker compose run --rm horizon
-
-# カスタムの時間枠で実行
-docker compose run --rm horizon --hours 48
+# Docker Composeで実行（利用可能なオプションはステップ3を参照）
+docker compose run --rm horizon [OPTIONS]
 ```
 
 複数のextraは`EXTRAS=trafilatura,openbb`のように指定できます。`twitter` extraにはPlaywrightブラウザとシステムパッケージも必要ですが、現在のDockerfileはそれらをインストールしません。
@@ -233,6 +230,10 @@ docker compose run --rm horizon --hours 48
 ```bash
 uv run horizon-wizard
 ```
+
+| オプション | デフォルト | 説明 |
+|--------|---------|-------------|
+| `--log-level LEVEL`, `-l` | `WARNING` | ログレベル（DEBUG/INFO/WARNING/ERROR/CRITICAL）|
 
 ウィザードはあなたの興味（例: 「LLM inference」「嵌入式」「web security」）について質問し、`data/config.json`を自動生成します。
 
@@ -330,24 +331,26 @@ Geminiの場合は`GOOGLE_API_KEY`を使用します。
 
 ### 3. 実行
 
-#### ローカルインストール
+**A. ローカルインストール**
 
 ```bash
-uv run horizon                          # デフォルトの24時間枠で実行
-uv run horizon --hours 48               # 過去48時間から取得
-uv run horizon -d /path/to/data         # カスタムデータディレクトリを使用
-uv run horizon -c /path/to/config.json  # カスタム設定ファイルを使用
+uv run horizon [OPTIONS]
 ```
 
 `--data-dir`は、サマリー、購読者ファイル、デフォルト設定の場所を含む状態ディレクトリを変更します。`--config`は設定ファイルだけを変更するため、両方の場所を変更する場合は2つのオプションを併用してください。セットアップウィザードは`data/config.json`へ書き込むため、カスタムパスは`data/config.example.json`から手動で初期化します。
 
-#### Dockerで
+**B. Docker**
 
 ```bash
-docker compose run --rm horizon                          # デフォルトの24時間枠で実行
-docker compose run --rm horizon --hours 48               # 過去48時間から取得
-docker compose run --rm horizon -c /app/data/alt.json   # カスタム設定ファイルを使用
+docker compose run --rm horizon [OPTIONS]
 ```
+
+| オプション | デフォルト | 説明 |
+|--------|---------|-------------|
+| `--hours N` | 24 | 過去N時間から取得 |
+| `--data-dir PATH`, `-d` | `data` | データディレクトリのパス |
+| `--config PATH`, `-c` | `<data-dir>/config.json` | 設定ファイルのパス |
+| `--log-level LEVEL`, `-l` | `WARNING` | ログレベル（DEBUG/INFO/WARNING/ERROR/CRITICAL）|
 
 生成されたレポートは`data/summaries/`に保存されます（`--data-dir`を指定した場合は`<data-dir>/summaries/`）。
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -233,6 +233,8 @@ uv run horizon-wizard
 
 | オプション | デフォルト | 説明 |
 |--------|---------|-------------|
+| `--data-dir PATH`, `-d` | `data` | データディレクトリのパス |
+| `--config PATH`, `-c` | `<data-dir>/config.json` | 設定ファイルのパス |
 | `--log-level LEVEL`, `-l` | `WARNING` | ログレベル（DEBUG/INFO/WARNING/ERROR/CRITICAL）|
 
 ウィザードはあなたの興味（例: 「LLM inference」「嵌入式」「web security」）について質問し、`data/config.json`を自動生成します。

--- a/README_zh.md
+++ b/README_zh.md
@@ -225,11 +225,8 @@ cp data/config.example.json data/config.json
 # 可选：首次运行前构建逗号分隔的 extras
 docker compose build --build-arg EXTRAS=trafilatura horizon
 
-# 使用 Docker Compose 运行
-docker compose run --rm horizon
-
-# 自定义时间窗口
-docker compose run --rm horizon --hours 48
+# 使用 Docker Compose 运行（可用选项见第 3 步）
+docker compose run --rm horizon [OPTIONS]
 ```
 
 多个 extra 可写为 `EXTRAS=trafilatura,openbb`。`twitter` extra 还需要 Playwright 浏览器及系统依赖，当前 Dockerfile 不会安装这些组件。
@@ -241,6 +238,10 @@ docker compose run --rm horizon --hours 48
 ```bash
 uv run horizon-wizard
 ```
+
+| 选项 | 默认值 | 说明 |
+|--------|---------|-------------|
+| `--log-level LEVEL`, `-l` | `WARNING` | 日志级别（DEBUG/INFO/WARNING/ERROR/CRITICAL）|
 
 向导会询问你的兴趣（如"LLM 推理"、"嵌入式"、"web 安全"），自动推荐并生成 `data/config.json`，还可选让 AI 补充推荐小众源。若你想分享信息源，请前往 [horizon1123.top](https://horizon1123.top/)。
 
@@ -321,24 +322,26 @@ cp data/config.example.json data/config.json  # 自定义信息源
 
 ### 3. 运行
 
-#### 本地安装
+**A. 本地安装**
 
 ```bash
-uv run horizon                          # 使用默认 24 小时窗口
-uv run horizon --hours 48               # 抓取最近 48 小时的内容
-uv run horizon -d /path/to/data         # 使用自定义数据目录
-uv run horizon -c /path/to/config.json  # 使用自定义配置文件
+uv run horizon [OPTIONS]
 ```
 
 `--data-dir` 会更改状态目录，包括日报、订阅者文件和默认配置位置；`--config` 只更改配置文件。两处位置都要修改时需同时使用两个参数。配置向导固定写入 `data/config.json`，使用自定义路径时请从 `data/config.example.json` 手动初始化。
 
-#### 使用 Docker
+**B. Docker**
 
 ```bash
-docker compose run --rm horizon                          # 使用默认 24 小时窗口
-docker compose run --rm horizon --hours 48               # 抓取最近 48 小时的内容
-docker compose run --rm horizon -c /app/data/alt.json   # 使用自定义配置文件
+docker compose run --rm horizon [OPTIONS]
 ```
+
+| 选项 | 默认值 | 说明 |
+|--------|---------|-------------|
+| `--hours N` | 24 | 抓取最近 N 小时的内容 |
+| `--data-dir PATH`, `-d` | `data` | 数据目录路径 |
+| `--config PATH`, `-c` | `<data-dir>/config.json` | 配置文件路径 |
+| `--log-level LEVEL`, `-l` | `WARNING` | 日志级别（DEBUG/INFO/WARNING/ERROR/CRITICAL）|
 
 生成的日报将保存在 `data/summaries/` 目录中（如设置了 `--data-dir`，则保存在 `<data-dir>/summaries/`）。
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -217,16 +217,8 @@ uv pip install --only-binary=:all: openbb openbb-benzinga
 git clone https://github.com/Thysrael/Horizon.git
 cd horizon
 
-# 配置环境
-cp .env.example .env
-cp data/config.example.json data/config.json
-# 编辑 .env 和 data/config.json，填入你的 API 密钥和偏好设置
-
 # 可选：首次运行前构建逗号分隔的 extras
 docker compose build --build-arg EXTRAS=trafilatura horizon
-
-# 使用 Docker Compose 运行（可用选项见第 3 步）
-docker compose run --rm horizon [OPTIONS]
 ```
 
 多个 extra 可写为 `EXTRAS=trafilatura,openbb`。`twitter` extra 还需要 Playwright 浏览器及系统依赖，当前 Dockerfile 不会安装这些组件。
@@ -239,13 +231,7 @@ docker compose run --rm horizon [OPTIONS]
 uv run horizon-wizard
 ```
 
-| 选项 | 默认值 | 说明 |
-|--------|---------|-------------|
-| `--data-dir PATH`, `-d` | `data` | 数据目录路径 |
-| `--config PATH`, `-c` | `<data-dir>/config.json` | 配置文件路径 |
-| `--log-level LEVEL`, `-l` | `WARNING` | 日志级别（DEBUG/INFO/WARNING/ERROR/CRITICAL）|
-
-向导会询问你的兴趣（如"LLM 推理"、"嵌入式"、"web 安全"），自动推荐并生成 `data/config.json`，还可选让 AI 补充推荐小众源。若你想分享信息源，请前往 [horizon1123.top](https://horizon1123.top/)。
+向导会询问你的兴趣（如"LLM 推理"、"嵌入式"、"web 安全"），自动推荐并生成 `data/config.json`，还可选让 AI 补充推荐小众源。若你想分享信息源，请前往 [horizon1123.top](https://horizon1123.top/)。CLI 选项见[交互式向导](docs/configuration.md#interactive-wizard)。
 
 **方式 B：手动配置**
 
@@ -330,8 +316,6 @@ cp data/config.example.json data/config.json  # 自定义信息源
 uv run horizon [OPTIONS]
 ```
 
-`--data-dir` 会更改状态目录，包括日报、订阅者文件和默认配置位置；`--config` 只更改配置文件。两处位置都要修改时需同时使用两个参数。配置向导固定写入 `data/config.json`，使用自定义路径时请从 `data/config.example.json` 手动初始化。
-
 **B. Docker**
 
 ```bash
@@ -341,11 +325,11 @@ docker compose run --rm horizon [OPTIONS]
 | 选项 | 默认值 | 说明 |
 |--------|---------|-------------|
 | `--hours N` | 24 | 抓取最近 N 小时的内容 |
-| `--data-dir PATH`, `-d` | `data` | 数据目录路径 |
-| `--config PATH`, `-c` | `<data-dir>/config.json` | 配置文件路径 |
-| `--log-level LEVEL`, `-l` | `WARNING` | 日志级别（DEBUG/INFO/WARNING/ERROR/CRITICAL）|
+| `-d`, `--data-dir PATH` | `data` | 数据目录路径 |
+| `-c`, `--config PATH` | `<data-dir>/config.json` | 配置文件路径 |
+| `-l`, `--log-level LEVEL` | `WARNING` | 日志级别（DEBUG/INFO/WARNING/ERROR/CRITICAL）|
 
-生成的日报将保存在 `data/summaries/` 目录中（如设置了 `--data-dir`，则保存在 `<data-dir>/summaries/`）。
+`--data-dir` 会更改状态目录，包括日报、订阅者文件和默认配置位置；`--config` 只更改配置文件。生成的日报将保存在 `data/summaries/` 目录中（如设置了 `--data-dir`，则保存在 `<data-dir>/summaries/`）。两处位置都要修改，或需要初始化自定义配置位置时，请查看[配置路径](docs/configuration.md#configuration-paths)。
 
 ### 4. 自动化（可选）
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -241,6 +241,8 @@ uv run horizon-wizard
 
 | 选项 | 默认值 | 说明 |
 |--------|---------|-------------|
+| `--data-dir PATH`, `-d` | `data` | 数据目录路径 |
+| `--config PATH`, `-c` | `<data-dir>/config.json` | 配置文件路径 |
 | `--log-level LEVEL`, `-l` | `WARNING` | 日志级别（DEBUG/INFO/WARNING/ERROR/CRITICAL）|
 
 向导会询问你的兴趣（如"LLM 推理"、"嵌入式"、"web 安全"），自动推荐并生成 `data/config.json`，还可选让 AI 补充推荐小众源。若你想分享信息源，请前往 [horizon1123.top](https://horizon1123.top/)。

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ Horizon is configured through a `.env` file for secrets, a JSON file for runtime
 
 ## Configuration Paths
 
-The CLI resolves configuration and state paths as follows:
+`horizon`, `horizon-wizard`, and `horizon-webhook` all resolve configuration and state paths the same way:
 
 | Option | Effect |
 | --- | --- |
@@ -22,12 +22,28 @@ uv run horizon --config /etc/horizon/config.json
 uv run horizon --data-dir /srv/horizon --config /etc/horizon/config.json
 ```
 
-When both options are present, configuration is loaded from `--config`, while summaries and subscribers remain under `--data-dir`. The setup wizard writes the default `data/config.json`; initialize a custom location manually:
+When both options are present, configuration is loaded from `--config`, while summaries and subscribers remain under `--data-dir`. Because this logic is identical across all three CLIs, passing the same `-d`/`-c` flags to each one keeps them pointed at the same files — for example, generating a config with `horizon-wizard --data-dir /srv/horizon`, then running `horizon --data-dir /srv/horizon` and testing with `horizon-webhook --data-dir /srv/horizon`.
+
+Without either flag, all three default to `data/config.json`. To bootstrap a custom location without the wizard, initialize it manually:
 
 ```bash
 mkdir -p /etc/horizon
 cp data/config.example.json /etc/horizon/config.json
 ```
+
+## Interactive Wizard
+
+`horizon-wizard` asks about your interests and generates `data/config.json` from matched presets and, optionally, AI recommendations:
+
+```bash
+uv run horizon-wizard
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `-d`, `--data-dir PATH` | `data` | Path to the data directory |
+| `-c`, `--config PATH` | `<data-dir>/config.json` | Path to config file |
+| `-l`, `--log-level LEVEL` | `WARNING` | Logging level (DEBUG/INFO/WARNING/ERROR/CRITICAL) |
 
 ## Terminal Icons
 
@@ -731,23 +747,6 @@ Webhook notification is optional and disabled unless `webhook.enabled` is `true`
 
 When `request_body` is a JSON object or array, Horizon renders placeholders and serializes it as JSON. When it is a string, Horizon renders it directly and detects JSON if the rendered string is valid JSON.
 
-### Testing
-
-Use `horizon-webhook` to preview or send a test notification without running the full pipeline:
-
-```bash
-uv run horizon-webhook --dry-run
-```
-
-| Option | Default | Description |
-|--------|---------|-------------|
-| `--lang LANG` | first configured language | Language to test |
-| `--dry-run` | off | Preview rendered content without sending |
-| `--delivery {summary,summary_and_items}` | value from config | Override delivery mode for this test |
-| `--data-dir PATH`, `-d` | `data` | Path to the data directory |
-| `--config PATH`, `-c` | `<data-dir>/config.json` | Path to config file |
-| `--log-level LEVEL`, `-l` | `WARNING` | Logging level (DEBUG/INFO/WARNING/ERROR/CRITICAL) |
-
 ### Delivery Modes And Layouts
 
 `delivery` controls how many webhook messages Horizon sends:
@@ -891,6 +890,24 @@ With this layout, Horizon sends one interactive card containing the overview and
 }
 ```
 
+### Testing
+
+Use `horizon-webhook` to preview or send a test notification without running the full pipeline:
+
+```bash
+uv run horizon-webhook --dry-run
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--lang LANG` | first configured language | Language to test |
+| `--dry-run` | off | Preview rendered content without sending |
+| `--delivery {summary,summary_and_items}` | value from config | Override delivery mode for this test |
+| `-d`, `--data-dir PATH` | `data` | Path to the data directory |
+| `-c`, `--config PATH` | `<data-dir>/config.json` | Path to config file |
+| `-l`, `--log-level LEVEL` | `WARNING` | Logging level (DEBUG/INFO/WARNING/ERROR/CRITICAL) |
+
+
 ## Static Site
 
 Horizon writes generated summaries to `data/summaries/` (or `<data-dir>/summaries/` when `--data-dir` is set) and copies publishable Markdown into `docs/` for the GitHub Pages site. The repository includes a ready-to-use workflow at `.github/workflows/daily-summary.yml`.
@@ -904,10 +921,6 @@ Horizon includes an MCP server for AI assistants and MCP-compatible clients.
 ```bash
 uv run horizon-mcp
 ```
-
-| Option | Default | Description |
-|--------|---------|-------------|
-| `--log-level LEVEL`, `-l` | `WARNING` | Logging level (DEBUG/INFO/WARNING/ERROR/CRITICAL) |
 
 Available tools include `hz_validate_config`, `hz_fetch_items`, `hz_score_items`, `hz_filter_items`, `hz_enrich_items`, `hz_generate_summary`, and `hz_run_pipeline`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -731,6 +731,23 @@ Webhook notification is optional and disabled unless `webhook.enabled` is `true`
 
 When `request_body` is a JSON object or array, Horizon renders placeholders and serializes it as JSON. When it is a string, Horizon renders it directly and detects JSON if the rendered string is valid JSON.
 
+### Testing
+
+Use `horizon-webhook` to preview or send a test notification without running the full pipeline:
+
+```bash
+uv run horizon-webhook --dry-run
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--lang LANG` | first configured language | Language to test |
+| `--dry-run` | off | Preview rendered content without sending |
+| `--delivery {summary,summary_and_items}` | value from config | Override delivery mode for this test |
+| `--data-dir PATH`, `-d` | `data` | Path to the data directory |
+| `--config PATH`, `-c` | `<data-dir>/config.json` | Path to config file |
+| `--log-level LEVEL`, `-l` | `WARNING` | Logging level (DEBUG/INFO/WARNING/ERROR/CRITICAL) |
+
 ### Delivery Modes And Layouts
 
 `delivery` controls how many webhook messages Horizon sends:
@@ -887,6 +904,10 @@ Horizon includes an MCP server for AI assistants and MCP-compatible clients.
 ```bash
 uv run horizon-mcp
 ```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--log-level LEVEL`, `-l` | `WARNING` | Logging level (DEBUG/INFO/WARNING/ERROR/CRITICAL) |
 
 Available tools include `hz_validate_config`, `hz_fetch_items`, `hz_score_items`, `hz_filter_items`, `hz_enrich_items`, `hz_generate_summary`, and `hz_run_pipeline`.
 

--- a/src/_cli.py
+++ b/src/_cli.py
@@ -12,3 +12,18 @@ def add_log_level_argument(parser: argparse.ArgumentParser) -> None:
         metavar="LEVEL",
         help="Logging level (default: WARNING)",
     )
+
+
+def add_data_dir_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "-d", "--data-dir",
+        default="data",
+        metavar="PATH",
+        help="Path to the data directory (default: 'data')",
+    )
+    parser.add_argument(
+        "-c", "--config",
+        default=None,
+        metavar="PATH",
+        help="Path to config file (default: <data-dir>/config.json)",
+    )

--- a/src/_cli.py
+++ b/src/_cli.py
@@ -1,0 +1,14 @@
+"""Shared CLI argument helpers for Horizon entrypoints."""
+
+import argparse
+
+
+def add_log_level_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "-l", "--log-level",
+        default="WARNING",
+        type=str.upper,
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        metavar="LEVEL",
+        help="Logging level (default: WARNING)",
+    )

--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -6,7 +6,7 @@ from rich.console import Console
 from rich.logging import RichHandler
 
 
-def configure_logging(console: Console, level: int = logging.WARNING) -> None:
+def configure_logging(console: Console, level: int | str = logging.WARNING) -> None:
     """Route application logging through the entry point's Rich console."""
     logging.basicConfig(
         level=level,

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 from rich.console import Console
 
+from ._cli import add_log_level_argument
 from .console_icons import get_icons
 from .logging_config import configure_logging
 from .storage.manager import ConfigError, StorageManager
@@ -46,7 +47,10 @@ def main():
                         help="Path to the data directory (default: 'data')")
     parser.add_argument("-c", "--config", default=None, metavar="PATH",
                         help="Path to config file (default: <data-dir>/config.json)")
+    add_log_level_argument(parser)
     args = parser.parse_args()
+
+    configure_logging(console, level=args.log_level)
 
     try:
         # Load environment variables from .env file

--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 from rich.console import Console
 
-from ._cli import add_log_level_argument
+from ._cli import add_data_dir_arguments, add_log_level_argument
 from .console_icons import get_icons
 from .logging_config import configure_logging
 from .storage.manager import ConfigError, StorageManager
@@ -43,10 +43,7 @@ def main():
 
     parser = argparse.ArgumentParser(description="Horizon - AI-Driven Information Aggregation System")
     parser.add_argument("--hours", type=int, help="Force fetch from last N hours")
-    parser.add_argument("-d", "--data-dir", default="data", metavar="PATH",
-                        help="Path to the data directory (default: 'data')")
-    parser.add_argument("-c", "--config", default=None, metavar="PATH",
-                        help="Path to config file (default: <data-dir>/config.json)")
+    add_data_dir_arguments(parser)
     add_log_level_argument(parser)
     args = parser.parse_args()
 

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -40,7 +40,7 @@ uv run horizon-mcp
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--log-level LEVEL`, `-l` | `WARNING` | Logging level (DEBUG/INFO/WARNING/ERROR/CRITICAL) |
+| `-l`, `--log-level LEVEL` | `WARNING` | Logging level (DEBUG/INFO/WARNING/ERROR/CRITICAL) |
 
 The server runs over stdio and is intended to be launched by an MCP client. Stdout is reserved for the MCP protocol; progress, logs, warnings, and errors are written to stderr through one shared Rich console.
 

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -38,6 +38,10 @@ uv sync
 uv run horizon-mcp
 ```
 
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--log-level LEVEL`, `-l` | `WARNING` | Logging level (DEBUG/INFO/WARNING/ERROR/CRITICAL) |
+
 The server runs over stdio and is intended to be launched by an MCP client. Stdout is reserved for the MCP protocol; progress, logs, warnings, and errors are written to stderr through one shared Rich console.
 
 ## Run Artifacts

--- a/src/mcp/server.py
+++ b/src/mcp/server.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import logging
+import argparse
 from datetime import datetime, timezone
 from time import perf_counter
 from typing import Any, Awaitable, Callable
@@ -10,6 +10,7 @@ from typing import Any, Awaitable, Callable
 from mcp.server.fastmcp import FastMCP
 from rich.console import Console
 
+from .._cli import add_log_level_argument
 from ..logging_config import configure_logging
 from .errors import HorizonMcpError
 from .service import HorizonPipelineService
@@ -500,8 +501,12 @@ def r_effective_config() -> dict[str, Any]:
 
 def main() -> None:
     """Run MCP server over stdio."""
+    parser = argparse.ArgumentParser(description="Horizon MCP server")
+    add_log_level_argument(parser)
+    args = parser.parse_args()
 
-    configure_logging(console, level=logging.INFO)
+    configure_logging(console, level=args.log_level)
+
     mcp.run()
 
 

--- a/src/services/webhook_cli.py
+++ b/src/services/webhook_cli.py
@@ -5,13 +5,12 @@ import asyncio
 import json
 import sys
 from datetime import datetime, timezone
-from pathlib import Path
 
 from dotenv import load_dotenv
 from rich.console import Console
 from rich.panel import Panel
 
-from .._cli import add_log_level_argument
+from .._cli import add_data_dir_arguments, add_log_level_argument
 from ..logging_config import configure_logging
 
 from ..ai.summarizer import DailySummarizer
@@ -228,6 +227,7 @@ def main() -> None:
         choices=["summary", "summary_and_items"],
         help="Override the delivery mode from config for this test.",
     )
+    add_data_dir_arguments(parser)
     add_log_level_argument(parser)
     args = parser.parse_args()
 
@@ -236,7 +236,7 @@ def main() -> None:
     try:
         load_dotenv()
 
-        storage = StorageManager(data_dir=str(Path("data")))
+        storage = StorageManager(data_dir=args.data_dir, config_path=args.config)
         try:
             config = storage.load_config()
         except FileNotFoundError:

--- a/src/services/webhook_cli.py
+++ b/src/services/webhook_cli.py
@@ -11,6 +11,9 @@ from dotenv import load_dotenv
 from rich.console import Console
 from rich.panel import Panel
 
+from .._cli import add_log_level_argument
+from ..logging_config import configure_logging
+
 from ..ai.summarizer import DailySummarizer
 from ..console_icons import IconStyle, get_icons
 from ..models import (
@@ -225,7 +228,10 @@ def main() -> None:
         choices=["summary", "summary_and_items"],
         help="Override the delivery mode from config for this test.",
     )
+    add_log_level_argument(parser)
     args = parser.parse_args()
+
+    configure_logging(console, level=args.log_level)
 
     try:
         load_dotenv()

--- a/src/setup/wizard.py
+++ b/src/setup/wizard.py
@@ -13,7 +13,7 @@ from rich.prompt import Prompt, Confirm
 from rich.table import Table
 from rich.panel import Panel
 
-from .._cli import add_log_level_argument
+from .._cli import add_data_dir_arguments, add_log_level_argument
 from ..logging_config import configure_logging
 
 from ..models import (
@@ -390,6 +390,7 @@ def _gh_key(src: GitHubSourceConfig) -> str:
 def main():
     """Main entry point for the setup wizard."""
     parser = argparse.ArgumentParser(description="Horizon setup wizard")
+    add_data_dir_arguments(parser)
     add_log_level_argument(parser)
     args = parser.parse_args()
 
@@ -397,7 +398,7 @@ def main():
 
     print_banner()
 
-    storage = StorageManager(data_dir="data")
+    storage = StorageManager(data_dir=args.data_dir, config_path=args.config)
 
     # Step 1: AI configuration
     ai_config = configure_ai()
@@ -411,7 +412,8 @@ def main():
     # Step 3: Preset library matching
     console.print("\n[dim]Fetching preset source library...[/dim]")
     try:
-        presets = load_presets(prefer_api=True)
+        presets_path = str(Path(args.data_dir) / "presets.json")
+        presets = load_presets(presets_path=presets_path, prefer_api=True)
         offline = os.environ.get("HORIZON_OFFLINE", "").lower() in ("1", "true", "yes")
         if offline:
             console.print("[dim]Using local presets (offline mode)[/dim]")

--- a/src/setup/wizard.py
+++ b/src/setup/wizard.py
@@ -1,5 +1,6 @@
 """Interactive setup wizard for Horizon configuration."""
 
+import argparse
 import json
 import os
 import sys
@@ -11,6 +12,9 @@ from rich.console import Console
 from rich.prompt import Prompt, Confirm
 from rich.table import Table
 from rich.panel import Panel
+
+from .._cli import add_log_level_argument
+from ..logging_config import configure_logging
 
 from ..models import (
     AIConfig,
@@ -385,6 +389,12 @@ def _gh_key(src: GitHubSourceConfig) -> str:
 
 def main():
     """Main entry point for the setup wizard."""
+    parser = argparse.ArgumentParser(description="Horizon setup wizard")
+    add_log_level_argument(parser)
+    args = parser.parse_args()
+
+    configure_logging(console, level=args.log_level)
+
     print_banner()
 
     storage = StorageManager(data_dir="data")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,69 @@
+import argparse
+
+import pytest
+
+from src._cli import add_data_dir_arguments, add_log_level_argument
+
+
+def _parser(*builders) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    for builder in builders:
+        builder(parser)
+    return parser
+
+
+def test_log_level_defaults_to_warning():
+    args = _parser(add_log_level_argument).parse_args([])
+
+    assert args.log_level == "WARNING"
+
+
+@pytest.mark.parametrize("flag", ["-l", "--log-level"])
+def test_log_level_accepts_short_and_long_flags(flag):
+    args = _parser(add_log_level_argument).parse_args([flag, "info"])
+
+    assert args.log_level == "INFO"
+
+
+def test_log_level_is_case_insensitive():
+    args = _parser(add_log_level_argument).parse_args(["--log-level", "dEbUg"])
+
+    assert args.log_level == "DEBUG"
+
+
+def test_log_level_rejects_unknown_value():
+    with pytest.raises(SystemExit):
+        _parser(add_log_level_argument).parse_args(["--log-level", "NOPE"])
+
+
+def test_data_dir_arguments_default_to_data_and_none_config():
+    args = _parser(add_data_dir_arguments).parse_args([])
+
+    assert args.data_dir == "data"
+    assert args.config is None
+
+
+@pytest.mark.parametrize(
+    ("flags", "expected_data_dir", "expected_config"),
+    [
+        (["-d", "/tmp/custom"], "/tmp/custom", None),
+        (["--data-dir", "/tmp/custom"], "/tmp/custom", None),
+        (["-c", "/tmp/custom.json"], "data", "/tmp/custom.json"),
+        (["--config", "/tmp/custom.json"], "data", "/tmp/custom.json"),
+    ],
+)
+def test_data_dir_arguments_accept_short_and_long_flags(flags, expected_data_dir, expected_config):
+    args = _parser(add_data_dir_arguments).parse_args(flags)
+
+    assert args.data_dir == expected_data_dir
+    assert args.config == expected_config
+
+
+def test_both_helpers_can_be_combined_on_one_parser():
+    args = _parser(add_data_dir_arguments, add_log_level_argument).parse_args(
+        ["-d", "/tmp/custom", "-c", "/tmp/custom.json", "-l", "error"]
+    )
+
+    assert args.data_dir == "/tmp/custom"
+    assert args.config == "/tmp/custom.json"
+    assert args.log_level == "ERROR"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,7 +18,7 @@ def test_missing_custom_config_reports_requested_path(monkeypatch, tmp_path):
 
     output = []
     monkeypatch.setattr(main_module, "StorageManager", MissingConfigStorage)
-    monkeypatch.setattr(main_module, "configure_logging", lambda console: None)
+    monkeypatch.setattr(main_module, "configure_logging", lambda console, level=None: None)
     monkeypatch.setattr(
         main_module,
         "console",
@@ -35,3 +35,76 @@ def test_missing_custom_config_reports_requested_path(monkeypatch, tmp_path):
     assert exc_info.value.code == 1
     assert str(config_path) in rendered
     assert "horizon-wizard" not in rendered
+
+
+def test_data_dir_and_config_flags_are_forwarded_to_storage_manager(monkeypatch, tmp_path):
+    data_dir = tmp_path / "state"
+    config_path = tmp_path / "custom" / "horizon.json"
+    storage_calls = []
+
+    class RecordingStorage:
+        def __init__(self, data_dir, config_path):
+            storage_calls.append({"data_dir": data_dir, "config_path": config_path})
+
+        def load_config(self):
+            raise FileNotFoundError
+
+    monkeypatch.setattr(main_module, "StorageManager", RecordingStorage)
+    monkeypatch.setattr(main_module, "configure_logging", lambda console, level=None: None)
+    monkeypatch.setattr(main_module.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["horizon", "--data-dir", str(data_dir), "--config", str(config_path)],
+    )
+
+    with pytest.raises(SystemExit):
+        main_module.main()
+
+    assert storage_calls == [{"data_dir": str(data_dir), "config_path": str(config_path)}]
+
+
+def test_data_dir_and_config_default_to_data_directory(monkeypatch):
+    storage_calls = []
+
+    class RecordingStorage:
+        def __init__(self, data_dir, config_path):
+            storage_calls.append({"data_dir": data_dir, "config_path": config_path})
+
+        def load_config(self):
+            raise FileNotFoundError
+
+    monkeypatch.setattr(main_module, "StorageManager", RecordingStorage)
+    monkeypatch.setattr(main_module, "configure_logging", lambda console, level=None: None)
+    monkeypatch.setattr(main_module.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr("sys.argv", ["horizon"])
+
+    with pytest.raises(SystemExit):
+        main_module.main()
+
+    assert storage_calls == [{"data_dir": "data", "config_path": None}]
+
+
+def test_log_level_flag_is_forwarded_to_configure_logging(monkeypatch, tmp_path):
+    logging_calls = []
+
+    class RecordingStorage:
+        def __init__(self, data_dir, config_path):
+            pass
+
+        def load_config(self):
+            raise FileNotFoundError
+
+    monkeypatch.setattr(main_module, "StorageManager", RecordingStorage)
+    monkeypatch.setattr(
+        main_module,
+        "configure_logging",
+        lambda console, level=None: logging_calls.append(level),
+    )
+    monkeypatch.setattr(main_module.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr("sys.argv", ["horizon", "--log-level", "debug"])
+
+    with pytest.raises(SystemExit):
+        main_module.main()
+
+    # The first call is the pre-argparse default; the second reflects the CLI flag.
+    assert logging_calls[-1] == "DEBUG"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,45 @@
+from src.mcp import server
+
+
+def test_log_level_flag_is_forwarded_to_configure_logging(monkeypatch):
+    logging_calls = []
+
+    monkeypatch.setattr(
+        server,
+        "configure_logging",
+        lambda console, level=None: logging_calls.append(level),
+    )
+    monkeypatch.setattr(server.mcp, "run", lambda: None)
+    monkeypatch.setattr("sys.argv", ["horizon-mcp", "--log-level", "debug"])
+
+    server.main()
+
+    assert logging_calls == ["DEBUG"]
+
+
+def test_log_level_defaults_to_warning(monkeypatch):
+    logging_calls = []
+
+    monkeypatch.setattr(
+        server,
+        "configure_logging",
+        lambda console, level=None: logging_calls.append(level),
+    )
+    monkeypatch.setattr(server.mcp, "run", lambda: None)
+    monkeypatch.setattr("sys.argv", ["horizon-mcp"])
+
+    server.main()
+
+    assert logging_calls == ["WARNING"]
+
+
+def test_main_starts_the_mcp_server(monkeypatch):
+    run_calls = []
+
+    monkeypatch.setattr(server, "configure_logging", lambda console, level=None: None)
+    monkeypatch.setattr(server.mcp, "run", lambda: run_calls.append(True))
+    monkeypatch.setattr("sys.argv", ["horizon-mcp"])
+
+    server.main()
+
+    assert run_calls == [True]

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -1,7 +1,31 @@
 from __future__ import annotations
 
+import pytest
+
 from src.models import AIConfig, AIProvider, Config
 from src.setup import wizard
+
+
+class _StopWizard(Exception):
+    """Raised by a stubbed load_presets() to short-circuit main() for tests."""
+
+
+def _prepare_main(monkeypatch, load_presets_calls):
+    """Wire main() up to run until the preset-loading step, then stop."""
+
+    def fake_load_presets(**kwargs):
+        load_presets_calls.append(kwargs)
+        raise _StopWizard()
+
+    monkeypatch.setattr(wizard, "configure_logging", lambda console, level=None: None)
+    monkeypatch.setattr(wizard.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        wizard,
+        "configure_ai",
+        lambda: AIConfig(provider=AIProvider.OLLAMA, model="llama3.1", api_key_env=""),
+    )
+    monkeypatch.setattr(wizard, "get_interests", lambda: "test interests")
+    monkeypatch.setattr(wizard, "load_presets", fake_load_presets)
 
 
 def test_configure_ai_allows_ollama_without_api_key(monkeypatch):
@@ -160,3 +184,71 @@ def test_merge_configs_preserves_all_existing_configuration_and_deduplicates_lis
     assert merged.sources.reddit.users[0].fetch_limit == 3
     assert merged.sources.telegram.channels[0].enabled is False
     assert merged.sources.telegram.channels[0].fetch_limit == 7
+
+
+def test_data_dir_and_config_flags_are_forwarded_to_storage_and_presets(monkeypatch, tmp_path):
+    data_dir = tmp_path / "state"
+    config_path = tmp_path / "custom" / "horizon.json"
+    storage_calls = []
+    load_presets_calls = []
+
+    class RecordingStorage:
+        def __init__(self, data_dir, config_path):
+            storage_calls.append({"data_dir": data_dir, "config_path": config_path})
+
+    _prepare_main(monkeypatch, load_presets_calls)
+    monkeypatch.setattr(wizard, "StorageManager", RecordingStorage)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["horizon-wizard", "--data-dir", str(data_dir), "--config", str(config_path)],
+    )
+
+    with pytest.raises(_StopWizard):
+        wizard.main()
+
+    assert storage_calls == [{"data_dir": str(data_dir), "config_path": str(config_path)}]
+    assert load_presets_calls == [
+        {"presets_path": str(data_dir / "presets.json"), "prefer_api": True}
+    ]
+
+
+def test_data_dir_and_config_default_to_data_directory(monkeypatch):
+    storage_calls = []
+    load_presets_calls = []
+
+    class RecordingStorage:
+        def __init__(self, data_dir, config_path):
+            storage_calls.append({"data_dir": data_dir, "config_path": config_path})
+
+    _prepare_main(monkeypatch, load_presets_calls)
+    monkeypatch.setattr(wizard, "StorageManager", RecordingStorage)
+    monkeypatch.setattr("sys.argv", ["horizon-wizard"])
+
+    with pytest.raises(_StopWizard):
+        wizard.main()
+
+    assert storage_calls == [{"data_dir": "data", "config_path": None}]
+    assert load_presets_calls == [{"presets_path": "data/presets.json", "prefer_api": True}]
+
+
+def test_log_level_flag_is_forwarded_to_configure_logging(monkeypatch):
+    logging_calls = []
+    load_presets_calls = []
+
+    class RecordingStorage:
+        def __init__(self, data_dir, config_path):
+            pass
+
+    _prepare_main(monkeypatch, load_presets_calls)
+    monkeypatch.setattr(wizard, "StorageManager", RecordingStorage)
+    monkeypatch.setattr(
+        wizard,
+        "configure_logging",
+        lambda console, level=None: logging_calls.append(level),
+    )
+    monkeypatch.setattr("sys.argv", ["horizon-wizard", "--log-level", "debug"])
+
+    with pytest.raises(_StopWizard):
+        wizard.main()
+
+    assert logging_calls == ["DEBUG"]

--- a/tests/test_webhook_cli.py
+++ b/tests/test_webhook_cli.py
@@ -1,0 +1,175 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.services import webhook_cli
+
+
+def _fake_config(webhook=None, languages=("en",), icon_style="emoji"):
+    return SimpleNamespace(
+        webhook=webhook,
+        ai=SimpleNamespace(languages=list(languages)),
+        display=SimpleNamespace(icon_style=icon_style),
+    )
+
+
+def _silence(monkeypatch):
+    monkeypatch.setattr(webhook_cli, "configure_logging", lambda console, level=None: None)
+    monkeypatch.setattr(webhook_cli.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr(webhook_cli, "load_dotenv", lambda: None)
+
+
+def test_data_dir_and_config_flags_are_forwarded_to_storage_manager(monkeypatch, tmp_path):
+    data_dir = tmp_path / "state"
+    config_path = tmp_path / "custom" / "horizon.json"
+    storage_calls = []
+
+    class RecordingStorage:
+        def __init__(self, data_dir, config_path):
+            storage_calls.append({"data_dir": data_dir, "config_path": config_path})
+
+        def load_config(self):
+            return _fake_config()
+
+    _silence(monkeypatch)
+    monkeypatch.setattr(webhook_cli, "StorageManager", RecordingStorage)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["horizon-webhook", "--data-dir", str(data_dir), "--config", str(config_path)],
+    )
+
+    with pytest.raises(SystemExit):
+        webhook_cli.main()
+
+    assert storage_calls == [{"data_dir": str(data_dir), "config_path": str(config_path)}]
+
+
+def test_data_dir_and_config_default_to_data_directory(monkeypatch):
+    storage_calls = []
+
+    class RecordingStorage:
+        def __init__(self, data_dir, config_path):
+            storage_calls.append({"data_dir": data_dir, "config_path": config_path})
+
+        def load_config(self):
+            return _fake_config()
+
+    _silence(monkeypatch)
+    monkeypatch.setattr(webhook_cli, "StorageManager", RecordingStorage)
+    monkeypatch.setattr("sys.argv", ["horizon-webhook"])
+
+    with pytest.raises(SystemExit):
+        webhook_cli.main()
+
+    assert storage_calls == [{"data_dir": "data", "config_path": None}]
+
+
+def test_log_level_flag_is_forwarded_to_configure_logging(monkeypatch):
+    logging_calls = []
+
+    class FixedStorage:
+        def __init__(self, data_dir, config_path):
+            pass
+
+        def load_config(self):
+            return _fake_config()
+
+    monkeypatch.setattr(webhook_cli.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr(webhook_cli, "load_dotenv", lambda: None)
+    monkeypatch.setattr(webhook_cli, "StorageManager", FixedStorage)
+    monkeypatch.setattr(
+        webhook_cli,
+        "configure_logging",
+        lambda console, level=None: logging_calls.append(level),
+    )
+    monkeypatch.setattr("sys.argv", ["horizon-webhook", "--log-level", "debug"])
+
+    with pytest.raises(SystemExit):
+        webhook_cli.main()
+
+    assert logging_calls == ["DEBUG"]
+
+
+def test_exits_when_webhook_not_enabled(monkeypatch):
+    class FixedStorage:
+        def __init__(self, data_dir, config_path):
+            pass
+
+        def load_config(self):
+            return _fake_config(webhook=None)
+
+    _silence(monkeypatch)
+    monkeypatch.setattr(webhook_cli, "StorageManager", FixedStorage)
+    monkeypatch.setattr("sys.argv", ["horizon-webhook"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        webhook_cli.main()
+
+    assert exc_info.value.code == 1
+
+
+def test_lang_dry_run_and_delivery_flags_are_forwarded_to_run_test(monkeypatch):
+    run_calls = []
+
+    async def fake_run_test(webhook_config, lang, dry_run, delivery_override=None, icon_style="emoji"):
+        run_calls.append(
+            {
+                "webhook_config": webhook_config,
+                "lang": lang,
+                "dry_run": dry_run,
+                "delivery_override": delivery_override,
+                "icon_style": icon_style,
+            }
+        )
+
+    webhook_config = SimpleNamespace(enabled=True)
+
+    class FixedStorage:
+        def __init__(self, data_dir, config_path):
+            pass
+
+        def load_config(self):
+            return _fake_config(webhook=webhook_config, languages=["en", "zh"])
+
+    _silence(monkeypatch)
+    monkeypatch.setattr(webhook_cli, "StorageManager", FixedStorage)
+    monkeypatch.setattr(webhook_cli, "_run_test", fake_run_test)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["horizon-webhook", "--lang", "zh", "--dry-run", "--delivery", "summary_and_items"],
+    )
+
+    webhook_cli.main()
+
+    assert run_calls == [
+        {
+            "webhook_config": webhook_config,
+            "lang": "zh",
+            "dry_run": True,
+            "delivery_override": "summary_and_items",
+            "icon_style": "emoji",
+        }
+    ]
+
+
+def test_lang_defaults_to_first_configured_language(monkeypatch):
+    run_calls = []
+
+    async def fake_run_test(webhook_config, lang, dry_run, delivery_override=None, icon_style="emoji"):
+        run_calls.append(lang)
+
+    class FixedStorage:
+        def __init__(self, data_dir, config_path):
+            pass
+
+        def load_config(self):
+            return _fake_config(webhook=SimpleNamespace(enabled=True), languages=["zh", "en"])
+
+    _silence(monkeypatch)
+    monkeypatch.setattr(webhook_cli, "StorageManager", FixedStorage)
+    monkeypatch.setattr(webhook_cli, "_run_test", fake_run_test)
+    monkeypatch.setattr("sys.argv", ["horizon-webhook"])
+
+    webhook_cli.main()
+
+    assert run_calls == ["zh"]


### PR DESCRIPTION
## Summary

Brings `-l/--log-level` and `-d/--data-dir`/`-c/--config` to every filesystem-backed CLI entrypoint (`horizon`, `horizon-webhook`, `horizon-wizard`, `horizon-mcp`), so they behave consistently and can be pointed at the same data/config location. Also trims the README Quick Start guide and cleans up the CLI docs so the option tables aren't duplicated or stale.

## Scope

- [x] This PR contains **one feature / one focused change**
- [x] This PR does **not** combine multiple unrelated features

## Changes

- `src/_cli.py`: adds shared `add_log_level_argument()` and `add_data_dir_arguments()` helpers used by every entrypoint, so the flag wiring lives in one place.
- `src/main.py`, `src/mcp/server.py`: switch to the shared `_cli` helpers; `main.py` also stops double-declaring `-d/--data-dir`/`-c/--config` inline.
- `src/services/webhook_cli.py`, `src/setup/wizard.py`: gain `-d/--data-dir` and `-c/--config` (previously hardcoded to `"data"`), wired into `StorageManager`; `wizard.py`'s offline `load_presets()` fallback now resolves against `--data-dir` too instead of a hardcoded `"data/presets.json"`.
- `src/logging_config.py`: `configure_logging()` now accepts a `level` (int or str) so it can be driven by the new CLI flag.
- `tests/test_cli.py` (new), `tests/test_webhook_cli.py` (new), `tests/test_mcp_server.py` (new), `tests/test_setup_wizard.py`, `tests/test_main.py`: cover the shared `_cli.py` helpers and the CLI flag plumbing on each entrypoint.
- `README.md`, `README_ja.md`, `README_zh.md`: Relevant sections updated; removed duplicated in the multiple places commands (Install section).
- `docs/configuration.md`: new Interactive Wizard and Webhook Notification Testing sections; updated Configuration Paths section.

## Notes for Reviewers

<details><summary>Tests</summary>
<p>

```
uv run --with pytest pytest tests/
................................................................................................... [ 20%]
................................................................................................... [ 40%]
................................................................................................... [ 60%]
................................................................................................... [ 80%]
.............................................................................................       [100%]
============================================ warnings summary =============================================
.venv/lib/python3.14/site-packages/google/genai/types.py:43: DeprecationWarning: '_UnionGenericAlias' is deprecated and slated for removal in Python 3.17
    VersionedUnionType = Union[builtin_types.UnionType, _UnionGenericAlias]

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
489 passed, 1 warning in 1.77s
```

</p>
</details> 

## Checklist

- [x] I explained the change clearly
- [x] I kept the PR focused and easy to review
- [x] I tested the change locally when applicable