### PR TITLE
fix(rss): handle timezone-less publication dates

### DIFF
--- a/src/scrapers/rss.py
+++ b/src/scrapers/rss.py
@@ -156,7 +156,10 @@ class RSSScraper(BaseScraper):
                         )
                     # Fallback to string parsing
                     date_str = entry[field]
-                    return parsedate_to_datetime(date_str)
+                    parsed_date = parsedate_to_datetime(date_str)
+                    if parsed_date.tzinfo is None:
+                        parsed_date = parsed_date.replace(tzinfo=timezone.utc)
+                    return parsed_date
                 except Exception:
                     continue
 

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -47,6 +47,19 @@ def test_rss_ids_are_deterministic() -> None:
     assert first_item.profile == "rss-profile"
 
 
+def test_timezone_less_pubdate_is_treated_as_utc() -> None:
+    client = _make_feed_client(_FEED.replace(" GMT", ""))
+    source = RSSSourceConfig(name="Test", url="https://example.com/feed.xml")
+    scraper = RSSScraper([source], client)
+
+    items = asyncio.run(scraper.fetch(_SINCE))
+
+    assert len(items) == 1
+    assert items[0].published_at == datetime(
+        2026, 4, 24, 12, 0, tzinfo=timezone.utc
+    )
+
+
 def _make_registry(name: str, extractor):
     registry = MagicMock()
     registry.get.side_effect = lambda n: extractor if n == name else None


### PR DESCRIPTION
## Summary

Timezone-less but otherwise parseable RSS publication dates currently produce naive `datetime` values. Comparing them with the scraper's UTC-aware `since` boundary raises a `TypeError`, and the feed-level error handler then returns no items.

This change treats those timezone-less dates as UTC before comparison, matching the existing behavior of the repository's Reddit RSS date parser. Dates that already include an offset are left unchanged.

## Scope

- [x] This PR contains **one feature / one fix / one focused change**
- [x] This PR does **not** combine multiple unrelated features

## Changes

- Normalize string-parsed RSS dates to UTC only when they do not declare a timezone.
- Add a public-path regression test that verifies the item is retained with an aware UTC publication timestamp.

## Notes for Reviewers

The regression command failed on the unchanged base because `RSSScraper.fetch()` logged `can't compare offset-naive and offset-aware datetimes` and returned an empty list. The same command passes after the fix.

Verification:

- `UV_OFFLINE=1 PYTHONDONTWRITEBYTECODE=1 uv run --no-sync pytest -p no:cacheprovider -q tests/test_rss.py::test_timezone_less_pubdate_is_treated_as_utc --log-cli-level=WARNING`
- `UV_OFFLINE=1 PYTHONDONTWRITEBYTECODE=1 uv run --no-sync pytest -p no:cacheprovider -q tests/test_rss.py`
- `UV_OFFLINE=1 PYTHONDONTWRITEBYTECODE=1 uv run --no-sync pytest -p no:cacheprovider -q`
- `UV_OFFLINE=1 uv build --offline`
- `git diff --cached --check 36dcca0f0d224d56802f2991298f0b852e788b36`

## Checklist

- [x] I explained the change clearly
- [x] I kept the PR focused and easy to review
- [x] I tested the change locally when applicable
